### PR TITLE
If key is pressed while backlight is off, turn backlight on and discard key

### DIFF
--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -160,12 +160,20 @@ void fw_main_task()
         		if (keys!=0)
         		{
             	    set_melody(melody_key_beep);
-        		}
+				}
+
+    			if (menuDisplayLightTimer == 0)
+    			{
+    				key_event = EVENT_KEY_NONE;
+    				displayLightTrigger();
+    			}
         	}
 
-        	if (button_event==EVENT_BUTTON_CHANGE)
-        	{
-        		/*
+
+
+			if (button_event == EVENT_BUTTON_CHANGE)
+			{
+				/*
         		if ((buttons & BUTTON_SK1)!=0)
         		{
             	    set_melody(melody_sk1_beep);

--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -162,7 +162,7 @@ void fw_main_task()
             	    set_melody(melody_key_beep);
 				}
 
-    			if (menuDisplayLightTimer == 0)
+    			if (menuDisplayLightTimer == 0 && nonVolatileSettings.backLightTimeout != 0)
     			{
     				key_event = EVENT_KEY_NONE;
     				displayLightTrigger();


### PR DESCRIPTION
Pressing e.g. KEY_RIGHT in dmr channel mode while backlight is off changes the talkgroup and turns backlight on.

I think it's better to only turn on backlight and discard the key event. 
The next keypress does the actual change.
And it is possible to turn on the backlight to look at the display by pressing any key.
