### PR TITLE
Display rx and tx frequency in channel details screen. #47

### DIFF
--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -37,7 +37,7 @@ static int CTCSSRxIndex=0;
 static int CTCSSTxIndex=0;
 static struct_codeplugChannel_t tmpChannel;// update a temporary copy of the channel and only write back if green menu is pressed
 
-enum CHANNEL_DETAILS_DISPLAY_LIST { CH_DETAILS_MODE = 0, CH_DETAILS_DMR_CC, CH_DETAILS_DMR_TS,CH_DETAILS_RXCTCSS, CH_DETAILS_TXCTCSS , CH_DETAILS_BANDWIDTH,
+enum CHANNEL_DETAILS_DISPLAY_LIST { CH_DETAILS_MODE = 0, CH_DETAILS_DMR_CC, CH_DETAILS_DMR_TS,CH_DETAILS_RXCTCSS, CH_DETAILS_TXCTCSS , CH_DETAILS_RXFREQ, CH_DETAILS_TXFREQ, CH_DETAILS_BANDWIDTH,
 									CH_DETAILS_FREQ_STEP, CH_DETAILS_TOT,
 									NUM_CH_DETAILS_ITEMS};// The last item in the list is used so that we automatically get a total number of items in the list
 
@@ -75,6 +75,8 @@ static void updateScreen()
 	int mNum = 0;
 	char buf[17];
 	int tmpVal;
+	int val_before_dp;
+	int val_after_dp;
 
 	UC1701_clearBuf();
 	UC1701_printCentered(0, "Channel info", UC1701_FONT_GD77_8x16);
@@ -150,6 +152,16 @@ static void updateScreen()
 				{
 					strcpy(buf, "Rx CTCSS:N/A");
 				}
+				break;
+			case CH_DETAILS_RXFREQ:
+				val_before_dp = tmpChannel.rxFreq / 10000;
+				val_after_dp = tmpChannel.rxFreq - val_before_dp * 10000;
+				sprintf(buf, "RX: %d.%04d MHz", val_before_dp, val_after_dp);
+				break;
+			case CH_DETAILS_TXFREQ:
+				val_before_dp = tmpChannel.txFreq / 10000;
+				val_after_dp = tmpChannel.txFreq - val_before_dp * 10000;
+				sprintf(buf, "TX: %d.%04d MHz", val_before_dp, val_after_dp);
 				break;
 			case CH_DETAILS_BANDWIDTH:
 				// Bandwidth

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -332,17 +332,23 @@ static void handleEvent(int buttons, int keys, int events)
 	{
 		if (menuUtilityHandlePrivateCallActions(buttons,keys,events))
 		{
+			reset_freq_enter_digits();
 			return;
 		}
 		if (buttons & BUTTON_SK2 )
 		{
 			menuSystemPushNewMenu(MENU_CHANNEL_DETAILS);
+			reset_freq_enter_digits();
+			return;
 		}
 		else
 		{
-			menuSystemPushNewMenu(MENU_MAIN_MENU);
+			if (freq_enter_idx == 0)
+			{
+				menuSystemPushNewMenu(MENU_MAIN_MENU);
+				return;
+			}
 		}
-		return;
 	}
 	else if ((keys & KEY_HASH)!=0)
 	{
@@ -552,6 +558,21 @@ static void handleEvent(int buttons, int keys, int events)
 			reset_freq_enter_digits();
     	    set_melody(melody_NACK_beep);
     		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+		}
+		else if ((keys & KEY_GREEN) != 0)
+		{
+			int tmp_frequency=read_freq_enter_digits();
+			if (trxCheckFrequencyIsSupportedByTheRadioHardware(tmp_frequency))
+			{
+				update_frequency(tmp_frequency);
+				reset_freq_enter_digits();
+//	        	    set_melody(melody_ACK_beep);
+			}
+			else
+			{
+        	    set_melody(melody_ERROR_beep);
+			}
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 	}
 	if (freq_enter_idx<7)


### PR DESCRIPTION
Also allows in VFO mode to enter frequency and omit trailing zeros with key green, e.g. 145,5.