### PR TITLE
Prevent buffer overlow, and insure strings are NULL terminated before rendered on LCD screen.

### DIFF
--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -187,7 +187,8 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 				}
 				else
 				{
-					sprintf(nameBuf,"%s",currentZoneName);
+					snprintf(nameBuf, 16, "%s",currentZoneName);
+					nameBuf[16] = 0;
 					UC1701_printCentered(50, (char *)nameBuf,UC1701_FONT_6X8);
 				}
 			}
@@ -207,7 +208,8 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 					{
 						dmrIdDataStruct_t currentRec;
 						dmrIDLookup((trxTalkGroupOrPcId & 0x00FFFFFF),&currentRec);
-						sprintf(nameBuf,"%s",currentRec.text);
+						snprintf(nameBuf, 16, "%s",currentRec.text);
+						nameBuf[16] = 0;
 					}
 				}
 				else

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -351,7 +351,8 @@ void menuUtilityRenderQSOData()
 	{
 		// Its a Private call
 		dmrIDLookup( (LinkHead->id & 0xFFFFFF),&currentRec);
-		sprintf(buffer,"%s", currentRec.text);
+		snprintf(buffer, 20, "%s", currentRec.text);
+		buffer[20] = 0;
 		UC1701_printCentered(16, buffer,UC1701_FONT_GD77_8x16);
 
 		// Are we already in PC mode to this caller ?
@@ -386,7 +387,8 @@ void menuUtilityRenderQSOData()
 		// first check if we have this ID in the DMR ID data
 		if (dmrIDLookup( LinkHead->id,&currentRec))
 		{
-			sprintf(buffer,"%s", currentRec.text);
+			snprintf(buffer, 20, "%s", currentRec.text);
+			buffer[20] = 0;
 			UC1701_printCentered(32, buffer,UC1701_FONT_GD77_8x16);
 			displayChannelNameOrRxFrequency(buffer);
 		}

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -178,7 +178,8 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 					{
 						dmrIdDataStruct_t currentRec;
 						dmrIDLookup((trxTalkGroupOrPcId & 0x00FFFFFF),&currentRec);
-						sprintf(buffer,"%s",currentRec.text);
+						snprintf(buffer, 20, "%s",currentRec.text);
+						buffer[20] = 0;
 					}
 				}
 				else


### PR DESCRIPTION
Hi,

   This morning I was experiencing some garbage rendered, while listening TG91/3100, just bellow TG xxx, where contact/talker alias should be printed.
Checking the code I find few locations where "string" buffer could be overflowed or non NULL terminated.

Cheers. 