### PR TITLE
Access contacts in DMR mode for PC or TG entry

### DIFF
--- a/firmware/source/user_interface/menuNumericalEntry.c
+++ b/firmware/source/user_interface/menuNumericalEntry.c
@@ -19,12 +19,15 @@
 #include <user_interface/menuSystem.h>
 #include <user_interface/menuUtilityQSOData.h>
 #include "fw_settings.h"
+#include "fw_codeplug.h"
 
 static char digits[9];
+static int pcIdx;
+static struct_codeplugContact_t contact;
 static void updateScreen();
 static void handleEvent(int buttons, int keys, int events);
 
-static const char *menuName[]={"TG entry","PC entry","User DMR ID"};
+static const char *menuName[] = { "TG entry", "PC entry", "Contact", "User DMR ID" };
 
 // public interface
 int menuNumericalEntry(int buttons, int keys, int events, bool isFirstRun)
@@ -33,6 +36,7 @@ int menuNumericalEntry(int buttons, int keys, int events, bool isFirstRun)
 	{
 		gMenusCurrentItemIndex=0;
 		digits[0]=0x00;
+		pcIdx = 0;
 		updateScreen();
 	}
 	else
@@ -52,14 +56,50 @@ int menuNumericalEntry(int buttons, int keys, int events, bool isFirstRun)
 
 static void updateScreen()
 {
+	char buf[17];
+
 	UC1701_clearBuf();
 
 	UC1701_printCentered(8, (char *)menuName[gMenusCurrentItemIndex],UC1701_FONT_GD77_8x16);
 
-	UC1701_printCentered(32, (char *)digits,UC1701_FONT_GD77_8x16);
+	if (pcIdx == 0)
+	{
+		UC1701_printCentered(32, (char *)digits,UC1701_FONT_GD77_8x16);
+	}
+	else
+	{
+		codeplugUtilConvertBufToString(contact.name, buf, 16);
+		UC1701_printCentered(32, buf, UC1701_FONT_GD77_8x16);
+		UC1701_printCentered(52, (char *)digits,UC1701_FONT_6X8);
+	}
 	displayLightTrigger();
 
 	UC1701_render();
+}
+
+static int getNextContact(int curidx, int dir, struct_codeplugContact_t *contact)
+{
+	int idx = curidx;
+
+	do {
+		idx += dir;
+		if (idx >= 1024) {
+			if (curidx == 0) {
+				idx = 0;
+				break;
+			}
+			idx = 1;
+		} else if (idx ==0) {
+			if (curidx == 0) {
+				idx = 0;
+				break;
+			}
+			idx = 1024;
+		}
+		codeplugContactGetDataForIndex(idx, contact);
+	} while ((curidx != idx) && ((*contact).tgNumber == 0));
+
+	return idx;
 }
 
 static void handleEvent(int buttons, int keys, int events)
@@ -71,15 +111,14 @@ static void handleEvent(int buttons, int keys, int events)
 	}
 	else if ((keys & KEY_GREEN)!=0)
 	{
-		if (gMenusCurrentItemIndex!=2)
+		if (gMenusCurrentItemIndex!=3)
 		{
 			uint32_t saveTrxTalkGroupOrPcId = trxTalkGroupOrPcId;
 			trxTalkGroupOrPcId = atoi(digits);
 			nonVolatileSettings.overrideTG = trxTalkGroupOrPcId;
-			if (gMenusCurrentItemIndex == 1)
+			if (gMenusCurrentItemIndex == 1 || (pcIdx != 0 && contact.callType == 0x01))
 			{
 				// Private Call
-
 
 				if ((saveTrxTalkGroupOrPcId >> 24) != PC_CALL_FLAG)
 				{
@@ -102,26 +141,45 @@ static void handleEvent(int buttons, int keys, int events)
 	}
 	else if ((keys & KEY_HASH)!=0)
 	{
-		if ((buttons & BUTTON_SK2)!= 0  && gMenusCurrentItemIndex == 1)
+		pcIdx = 0;
+		if ((buttons & BUTTON_SK2)!= 0  && gMenusCurrentItemIndex == 2)
 		{
-			gMenusCurrentItemIndex = 2;
+			gMenusCurrentItemIndex = 3;
 		}
 		else
 		{
 			gMenusCurrentItemIndex++;
-			if (gMenusCurrentItemIndex > 1)
+			if (gMenusCurrentItemIndex > 2)
 			{
 				gMenusCurrentItemIndex = 0;
+			} else if (gMenusCurrentItemIndex == 2)
+			{
+				pcIdx = getNextContact(0, 1, &contact);
+				if (pcIdx != 0 ) {
+					itoa(contact.tgNumber, digits, 10);
+				}
 			}
 		}
 
 		updateScreen();
 	}
+	if (gMenusCurrentItemIndex == 2) {
+		int idx = pcIdx;
 
-	if (strlen(digits)<7)
-	{
-		char c[2]={0,0};
-		if ((keys & KEY_0)!=0)
+		if ((keys & KEY_RIGHT) != 0) {
+			idx = getNextContact(pcIdx, 1, &contact);
+		} else if ((keys & KEY_LEFT) != 0) {
+			idx = getNextContact(pcIdx, -1, &contact);
+		}
+		if (pcIdx != idx ) {
+			pcIdx = idx;
+			itoa(contact.tgNumber, digits, 10);
+			updateScreen();
+		}
+	}
+	else if (strlen(digits) < 7) {
+		char c[2] = {0, 0};
+		if ((keys & KEY_0) != 0)
 		{
 			c[0]='0';
 		}

--- a/firmware/source/user_interface/menuNumericalEntry.c
+++ b/firmware/source/user_interface/menuNumericalEntry.c
@@ -144,6 +144,7 @@ static void handleEvent(int buttons, int keys, int events)
 		pcIdx = 0;
 		if ((buttons & BUTTON_SK2)!= 0  && gMenusCurrentItemIndex == 2)
 		{
+			digits[0] = 0x00;
 			gMenusCurrentItemIndex = 3;
 		}
 		else

--- a/firmware/source/user_interface/menuNumericalEntry.c
+++ b/firmware/source/user_interface/menuNumericalEntry.c
@@ -97,7 +97,7 @@ static int getNextContact(int curidx, int dir, struct_codeplugContact_t *contact
 			idx = 1024;
 		}
 		codeplugContactGetDataForIndex(idx, contact);
-	} while ((curidx != idx) && ((*contact).tgNumber == 0));
+	} while ((curidx != idx) && ((*contact).name[0] == 0xff));
 
 	return idx;
 }


### PR DESCRIPTION
In DMR mode added entry 'Contact' to key HASH.
Select one contact stored in codeplug with LEFT or RIGHT and use it as PC or TG override.

The TG contacts are included as not all TG's need to be in the RX-list used for the active channel.
 
Perhaps we should add an alias for TG override. So the name of the contact instead of the ID is shown in uiVFOMode and uiChannelMode.