### PR TITLE
Add `N` after `FM` when using 12.5kHz FM

### DIFF
--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -447,6 +447,10 @@ void menuUtilityRenderHeader()
 	{
 		case RADIO_MODE_ANALOG:
 			strcpy(buffer, "FM");
+			if (!trxGetBandwidthIs25kHz())
+			{
+				strcat(buffer,"N");
+			}
 			if ((currentChannelData->txTone!=65535)||(currentChannelData->rxTone!=65535))
 			{
 				strcat(buffer," C");


### PR DESCRIPTION
Fixes #70

If the radio is in narrowband, both receive and transmit tones are set,
and power is set to less than 1W, the `CTR` will be right next to the power.

`FM N CTR250mW`