### PR TITLE
Cleanup and hamonize font types and identifiers, create UC1701_Font_t enum type instead of #defines.

### DIFF
--- a/firmware/include/hardware/UC1701.h
+++ b/firmware/include/hardware/UC1701.h
@@ -29,19 +29,22 @@
 #include <math.h>
 #include "fw_common.h"
 
-#define UC1701_FONT_6X8 				0
-#define UC1701_FONT_6X8_bold			1
-#define UC1701_FONT_8X8 				2
-#define UC1701_FONT_GD77_8x16 			3
-#define UC1701_FONT_16x32 				4
+typedef enum
+{
+	UC1701_FONT_6x8 = 0,
+	UC1701_FONT_6x8_BOLD,
+	UC1701_FONT_8x8,
+	UC1701_FONT_8x16,
+	UC1701_FONT_16x32
+} UC1701_Font_t;
 
 void UC1701_begin(bool isInverted);
 void UC1701_clearBuf();
 void UC1701_render();
 void UC1701RenderRows(int16_t startRow, int16_t endRow);
-void UC1701_printCentered(uint8_t y, char *text, int16_t fontSize);
-void UC1701_printAt(uint8_t x, uint8_t y, char *text, int16_t fontSize);
-int UC1701_printCore(int16_t x, int16_t y, char *szMsg, int16_t iSize, int16_t alignment, bool isInverted);
+void UC1701_printCentered(uint8_t y, char *text, UC1701_Font_t fontSize);
+void UC1701_printAt(uint8_t x, uint8_t y, char *text, UC1701_Font_t fontSize);
+int UC1701_printCore(int16_t x, int16_t y, char *szMsg, UC1701_Font_t fontSize, int16_t alignment, bool isInverted);
 
 int16_t UC1701_setPixel(int16_t x, int16_t y, bool color);
 

--- a/firmware/include/hardware/UC1701_charset.h
+++ b/firmware/include/hardware/UC1701_charset.h
@@ -348,7 +348,7 @@ const uint8_t font_8x8[] = {
 
 #if 1
 
-const uint8_t font_gd77_8x16[] = {
+const uint8_t font_8x16[] = {
    0x00, 0x00, // Ignored.
    32        , // first char ASCII code.
    126       , // last char ASCII code.

--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -46,7 +46,7 @@ void fw_init()
 static void show_lowbattery()
 {
 	UC1701_clearBuf();
-	UC1701_printCentered(32, "LOW BATTERY !!!", UC1701_FONT_GD77_8x16);
+	UC1701_printCentered(32, "LOW BATTERY !!!", UC1701_FONT_8x16);
 	UC1701_render();
 }
 

--- a/firmware/source/hardware/UC1701.c
+++ b/firmware/source/hardware/UC1701.c
@@ -153,7 +153,7 @@ static inline bool checkWritePos(uint8_t * writePos)
 }
 #endif
 
-int UC1701_printCore(int16_t x, int16_t y, char *szMsg, int16_t iSize, int16_t alignment, bool isInverted)
+int UC1701_printCore(int16_t x, int16_t y, char *szMsg, UC1701_Font_t fontSize, int16_t alignment, bool isInverted)
 {
 	int16_t i, sLen;
 	uint8_t *currentCharData;
@@ -168,19 +168,19 @@ int UC1701_printCore(int16_t x, int16_t y, char *szMsg, int16_t iSize, int16_t a
 
     sLen = strlen(szMsg);
 
-    switch(iSize)
+    switch(fontSize)
     {
-    	case UC1701_FONT_6X8:
+    	case UC1701_FONT_6x8:
     		currentFont = (uint8_t *) font_6x8;
     		break;
-    	case UC1701_FONT_6X8_bold:
+    	case UC1701_FONT_6x8_BOLD:
 			currentFont = (uint8_t *) font_6x8_bold;
     		break;
-    	case UC1701_FONT_8X8:
+    	case UC1701_FONT_8x8:
     		currentFont = (uint8_t *) font_8x8;
     		break;
-    	case UC1701_FONT_GD77_8x16:
-    		currentFont = (uint8_t *) font_gd77_8x16;
+    	case UC1701_FONT_8x16:
+    		currentFont = (uint8_t *) font_8x16;
 			break;
     	case UC1701_FONT_16x32:
     		currentFont = (uint8_t *) font_16x32;
@@ -364,12 +364,12 @@ void UC1701_clearBuf()
 	memset(screenBuf,0x00,1024);
 }
 
-void UC1701_printCentered(uint8_t y, char *text, int16_t fontSize)
+void UC1701_printCentered(uint8_t y, char *text, UC1701_Font_t fontSize)
 {
 	UC1701_printCore(0, y, text, fontSize, 1, false);
 }
 
-void UC1701_printAt(uint8_t x, uint8_t y, char *text, int16_t fontSize)
+void UC1701_printAt(uint8_t x, uint8_t y, char *text, UC1701_Font_t fontSize)
 {
 	UC1701_printCore(x, y, text, fontSize, 0, false);
 }

--- a/firmware/source/user_interface/menuFirmwareInfoScreen.c
+++ b/firmware/source/user_interface/menuFirmwareInfoScreen.c
@@ -40,9 +40,9 @@ int menuFirmwareInfoScreen(int buttons, int keys, int events, bool isFirstRun)
 static void updateScreen()
 {
 	UC1701_clearBuf();
-	UC1701_printCentered(12, "OpenGD77",UC1701_FONT_GD77_8x16);
-	UC1701_printCentered(32,(char *)FIRMWARE_VERSION_STRING,UC1701_FONT_GD77_8x16);
-	UC1701_printCentered(48,__DATE__,UC1701_FONT_GD77_8x16);
+	UC1701_printCentered(12, "OpenGD77",UC1701_FONT_8x16);
+	UC1701_printCentered(32,(char *)FIRMWARE_VERSION_STRING,UC1701_FONT_8x16);
+	UC1701_printCentered(48,__DATE__,UC1701_FONT_8x16);
 	UC1701_render();
 	displayLightTrigger();
 }

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -68,7 +68,7 @@ static void updateScreen()
 	{
 		if (dmrIDLookup(item->id,&foundRecord))
 		{
-			UC1701_printCentered(16+(numDisplayed*16), foundRecord.text,UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(16+(numDisplayed*16), foundRecord.text,UC1701_FONT_8x16);
 		}
 		else
 		{
@@ -81,7 +81,7 @@ static void updateScreen()
 			{
 				sprintf(buffer,"ID:%d",item->id);
 			}
-			UC1701_printCentered(16+(numDisplayed*16), buffer,UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(16+(numDisplayed*16), buffer,UC1701_FONT_8x16);
 		}
 
 		numDisplayed++;

--- a/firmware/source/user_interface/menuRSSIScreen.c
+++ b/firmware/source/user_interface/menuRSSIScreen.c
@@ -70,10 +70,10 @@ static void updateScreen()
 		menuDisplayTitle("RSSI");
 
 		sprintf(buffer,"%d", trxRxSignal);
-		UC1701_printCore(0, 3, buffer, UC1701_FONT_8X8, 2, false);
+		UC1701_printCore(0, 3, buffer, UC1701_FONT_8x8, 2, false);
 
 		sprintf(buffer,"%ddBm", dBm);
-		UC1701_printCentered(20, buffer,UC1701_FONT_GD77_8x16);
+		UC1701_printCentered(20, buffer,UC1701_FONT_8x16);
 
 		barGraphLength = ((dBm + 130) * 24)/10;
 		if (barGraphLength<0)
@@ -87,7 +87,7 @@ static void updateScreen()
 		}
 		UC1701_fillRect(4, 40,barGraphLength,8,false);
 
-		UC1701_printCore(5,50,"S1  S3  S5  S7  S9",UC1701_FONT_6X8,0,false);
+		UC1701_printCore(5,50,"S1  S3  S5  S7  S9",UC1701_FONT_6x8,0,false);
 		UC1701_render();
 		displayLightTrigger();
 		trxRxSignal=0;

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -232,7 +232,7 @@ int menuDisplayList(int buttons, int keys, int events, bool isFirstRun)
 void menuDisplayTitle(char *title)
 {
 	UC1701_drawFastHLine(0, 13, 128, true);
-	UC1701_printCore(0, 3, title, UC1701_FONT_8X8, 1, false);
+	UC1701_printCore(0, 3, title, UC1701_FONT_8x8, 1, false);
 }
 
 void menuDisplayEntry(int loopOffset, int focusedItem, char *entryText)
@@ -242,7 +242,7 @@ void menuDisplayEntry(int loopOffset, int focusedItem, char *entryText)
 	if (focused)
 		UC1701_fillRoundRect(0, (loopOffset + 2) * 16, 128, 16, 2, true);
 
-	UC1701_printCore(0, (loopOffset + 2) * 16, entryText, UC1701_FONT_GD77_8x16, 0, focused);
+	UC1701_printCore(0, (loopOffset + 2) * 16, entryText, UC1701_FONT_8x16, 0, focused);
 }
 
 int menuGetMenuOffset(int maxMenuEntries, int loopOffset)

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -183,18 +183,18 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 					{
 						sprintf(nameBuf,"CH %d",channelNumber);
 					}
-					UC1701_printCentered(50 , (char *)nameBuf,UC1701_FONT_6X8);
+					UC1701_printCentered(50 , (char *)nameBuf,UC1701_FONT_6x8);
 				}
 				else
 				{
 					snprintf(nameBuf, 16, "%s",currentZoneName);
 					nameBuf[16] = 0;
-					UC1701_printCentered(50, (char *)nameBuf,UC1701_FONT_6X8);
+					UC1701_printCentered(50, (char *)nameBuf,UC1701_FONT_6x8);
 				}
 			}
 
 			codeplugUtilConvertBufToString(channelScreenChannelData.name,nameBuf,16);
-			UC1701_printCentered(32 + verticalPositionOffset, (char *)nameBuf,UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(32 + verticalPositionOffset, (char *)nameBuf,UC1701_FONT_8x16);
 
 			if (trxGetMode() == RADIO_MODE_DIGITAL)
 			{
@@ -216,12 +216,12 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 				{
 					codeplugUtilConvertBufToString(contactData.name,nameBuf,16);
 				}
-				UC1701_printCentered(CONTACT_Y_POS + verticalPositionOffset, (char *)nameBuf,UC1701_FONT_GD77_8x16);
+				UC1701_printCentered(CONTACT_Y_POS + verticalPositionOffset, (char *)nameBuf,UC1701_FONT_8x16);
 			}
 			else if(displaySquelch && !trxIsTransmitting)
 			{
 				sprintf(buffer,"Squelch");
-				UC1701_printAt(0,16,buffer,UC1701_FONT_GD77_8x16);
+				UC1701_printAt(0,16,buffer,UC1701_FONT_8x16);
 				int bargraph= 1 + ((currentChannelData->sql-1)*5)/2 ;
 				UC1701_fillRect(62,21,bargraph,8,false);
 				displaySquelch=false;

--- a/firmware/source/user_interface/uiHotspot.c
+++ b/firmware/source/user_interface/uiHotspot.c
@@ -753,9 +753,9 @@ int menuHotspotMode(int buttons, int keys, int events, bool isFirstRun)
 		settingsUsbMode = USB_MODE_HOTSPOT;
 		MMDVMHostRxState = MMDVMHOST_RX_READY; // We have not sent anything to MMDVMHost, so it can't be busy yet.
 		UC1701_clearBuf();
-		UC1701_printCentered(0, "Hotspot",UC1701_FONT_GD77_8x16);
-		UC1701_printCentered(32, "Waiting for",UC1701_FONT_GD77_8x16);
-		UC1701_printCentered(48, "PiStar",UC1701_FONT_GD77_8x16);
+		UC1701_printCentered(0, "Hotspot",UC1701_FONT_8x16);
+		UC1701_printCentered(32, "Waiting for",UC1701_FONT_8x16);
+		UC1701_printCentered(48, "PiStar",UC1701_FONT_8x16);
 		UC1701_render();
 		displayLightTrigger();
 //		updateScreen(HOTSPOT_RX_IDLE);
@@ -784,7 +784,7 @@ static void updateScreen(int rxCommandState)
 	dmrIdDataStruct_t currentRec;
 
 	UC1701_clearBuf();
-	UC1701_printAt(0,0, "DMR Hotspot",UC1701_FONT_GD77_8x16);
+	UC1701_printAt(0,0, "DMR Hotspot",UC1701_FONT_8x16);
 	int  batteryPerentage = (int)(((averageBatteryVoltage - CUTOFF_VOLTAGE_UPPER_HYST) * 100) / (BATTERY_MAX_VOLTAGE - CUTOFF_VOLTAGE_UPPER_HYST));
 	if (batteryPerentage>100)
 	{
@@ -797,17 +797,17 @@ static void updateScreen(int rxCommandState)
 
 	sprintf(buffer,"%d%%",batteryPerentage);
 
-	UC1701_printCore(0,4,buffer,UC1701_FONT_6X8,2,false);// Display battery percentage at the right
+	UC1701_printCore(0,4,buffer,UC1701_FONT_6x8,2,false);// Display battery percentage at the right
 
 
 	if (trxIsTransmitting)
 	{
 		dmrIDLookup( (trxDMRID & 0xFFFFFF),&currentRec);
 		sprintf(buffer,"%s", currentRec.text);
-		UC1701_printCentered(16, buffer,UC1701_FONT_GD77_8x16);
+		UC1701_printCentered(16, buffer,UC1701_FONT_8x16);
 
 	//	sprintf(buffer,"ID %d",trxDMRID & 0xFFFFFF);
-	//	UC1701_printCentered(16, buffer,UC1701_FONT_GD77_8x16);
+	//	UC1701_printCentered(16, buffer,UC1701_FONT_8x16);
 		if ((trxTalkGroupOrPcId & 0xFF000000) == 0)
 		{
 			sprintf(buffer,"TG %d",trxTalkGroupOrPcId & 0xFFFFFF);
@@ -816,7 +816,7 @@ static void updateScreen(int rxCommandState)
 		{
 			sprintf(buffer,"PC %d",trxTalkGroupOrPcId &0xFFFFFF);
 		}
-		UC1701_printCentered(32, buffer,UC1701_FONT_GD77_8x16);
+		UC1701_printCentered(32, buffer,UC1701_FONT_8x16);
 
 		val_before_dp = freq_tx/100000;
 		val_after_dp = freq_tx - val_before_dp*100000;
@@ -832,7 +832,7 @@ static void updateScreen(int rxCommandState)
 
 			dmrIDLookup(srcId,&currentRec);
 			sprintf(buffer,"%s", currentRec.text);
-			UC1701_printCentered(16, buffer,UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(16, buffer,UC1701_FONT_8x16);
 
 			if (FLCO == 0)
 			{
@@ -842,20 +842,20 @@ static void updateScreen(int rxCommandState)
 			{
 				sprintf(buffer,"PC %d",dstId);
 			}
-			UC1701_printCentered(32, buffer,UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(32, buffer,UC1701_FONT_8x16);
 		}
 		else
 		{
 			sprintf(buffer,"CC:%d" ,  trxGetDMRColourCode());//, trxGetDMRTimeSlot()+1) ;
-			UC1701_printCore(0, 32, buffer, UC1701_FONT_GD77_8x16, 0, false);
+			UC1701_printCore(0, 32, buffer, UC1701_FONT_8x16, 0, false);
 
-			UC1701_printCore(0, 32, (char *)POWER_LEVELS[hotspotPowerLevel], UC1701_FONT_GD77_8x16, 2, false);
+			UC1701_printCore(0, 32, (char *)POWER_LEVELS[hotspotPowerLevel], UC1701_FONT_8x16, 2, false);
 		}
 		val_before_dp = freq_rx/100000;
 		val_after_dp = freq_rx - val_before_dp*100000;
 		sprintf(buffer,"R %d.%04d MHz",val_before_dp, val_after_dp);
 	}
-	UC1701_printCentered(48, buffer,UC1701_FONT_GD77_8x16);
+	UC1701_printCentered(48, buffer,UC1701_FONT_8x16);
 
 	UC1701_render();
 	displayLightTrigger();

--- a/firmware/source/user_interface/uiLockScreen.c
+++ b/firmware/source/user_interface/uiLockScreen.c
@@ -45,11 +45,11 @@ static void updateScreen()
 	UC1701_clearBuf();
 	UC1701_drawRoundRect(4, 4, 120, 56, 5, true);
 	if (keypadLocked) {
-		UC1701_printCentered(10, "Keypad locked",UC1701_FONT_GD77_8x16);
-		UC1701_printCentered(30, "Press Blue + *",UC1701_FONT_6X8);
-		UC1701_printCentered(38, "to unlock",UC1701_FONT_6X8);
+		UC1701_printCentered(10, "Keypad locked",UC1701_FONT_8x16);
+		UC1701_printCentered(30, "Press Blue + *",UC1701_FONT_6x8);
+		UC1701_printCentered(38, "to unlock",UC1701_FONT_6x8);
 	} else {
-		UC1701_printCentered(20, "Unlocked",UC1701_FONT_GD77_8x16);
+		UC1701_printCentered(20, "Unlocked",UC1701_FONT_8x16);
 	}
 	UC1701_render();
 	displayLightTrigger();

--- a/firmware/source/user_interface/uiPowerOff.c
+++ b/firmware/source/user_interface/uiPowerOff.c
@@ -38,8 +38,8 @@ int menuPowerOff(int buttons, int keys, int events, bool isFirstRun)
 static void updateScreen()
 {
 	UC1701_clearBuf();
-	UC1701_printCentered(12, "Power Off...",UC1701_FONT_GD77_8x16);
-	UC1701_printCentered(32, "73",UC1701_FONT_GD77_8x16);
+	UC1701_printCentered(12, "Power Off...",UC1701_FONT_8x16);
+	UC1701_printCentered(32, "73",UC1701_FONT_8x16);
 	UC1701_render();
 	displayLightTrigger();
 }

--- a/firmware/source/user_interface/uiSplashScreen.c
+++ b/firmware/source/user_interface/uiSplashScreen.c
@@ -42,9 +42,9 @@ static void updateScreen()
 
 	codeplugGetBootItemTexts(line1,line2);
 	UC1701_clearBuf();
-	UC1701_printCentered(10, "OpenGD77",UC1701_FONT_GD77_8x16);
-	UC1701_printCentered(28, line1,UC1701_FONT_GD77_8x16);
-	UC1701_printCentered(42, line2,UC1701_FONT_GD77_8x16);
+	UC1701_printCentered(10, "OpenGD77",UC1701_FONT_8x16);
+	UC1701_printCentered(28, line1,UC1701_FONT_8x16);
+	UC1701_printCentered(42, line2,UC1701_FONT_8x16);
 	UC1701_render();
 	displayLightTrigger();
 }

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -63,11 +63,11 @@ int menuTxScreen(int buttons, int keys, int events, bool isFirstRun)
 			UC1701_printCentered(4, "ERROR",UC1701_FONT_16x32);
 			if ((currentChannelData->flag4 & 0x04) !=0x00)
 			{
-				UC1701_printCentered(40, "Rx only",UC1701_FONT_GD77_8x16);
+				UC1701_printCentered(40, "Rx only",UC1701_FONT_8x16);
 			}
 			else
 			{
-				UC1701_printCentered(40, "OUT OF BAND",UC1701_FONT_GD77_8x16);
+				UC1701_printCentered(40, "OUT OF BAND",UC1701_FONT_8x16);
 			}
 			UC1701_render();
 			displayLightOverrideTimeout(-1);

--- a/firmware/source/user_interface/uiTxTgPcContactOwnId.c
+++ b/firmware/source/user_interface/uiTxTgPcContactOwnId.c
@@ -60,17 +60,17 @@ static void updateScreen()
 
 	UC1701_clearBuf();
 
-	UC1701_printCentered(8, (char *)menuName[gMenusCurrentItemIndex],UC1701_FONT_GD77_8x16);
+	UC1701_printCentered(8, (char *)menuName[gMenusCurrentItemIndex],UC1701_FONT_8x16);
 
 	if (pcIdx == 0)
 	{
-		UC1701_printCentered(32, (char *)digits,UC1701_FONT_GD77_8x16);
+		UC1701_printCentered(32, (char *)digits,UC1701_FONT_8x16);
 	}
 	else
 	{
 		codeplugUtilConvertBufToString(contact.name, buf, 16);
-		UC1701_printCentered(32, buf, UC1701_FONT_GD77_8x16);
-		UC1701_printCentered(52, (char *)digits,UC1701_FONT_6X8);
+		UC1701_printCentered(32, buf, UC1701_FONT_8x16);
+		UC1701_printCentered(52, (char *)digits,UC1701_FONT_6x8);
 	}
 	displayLightTrigger();
 

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -337,7 +337,7 @@ static void displayChannelNameOrRxFrequency(char *buffer)
 		int val_after_dp = currentChannelData->rxFreq - val_before_dp*100000;
 		sprintf(buffer,"%d.%05d MHz",val_before_dp, val_after_dp);
 	}
-	UC1701_printCentered(52,buffer,UC1701_FONT_6X8);
+	UC1701_printCentered(52,buffer,UC1701_FONT_6x8);
 }
 
 void menuUtilityRenderQSOData()
@@ -353,20 +353,20 @@ void menuUtilityRenderQSOData()
 		dmrIDLookup( (LinkHead->id & 0xFFFFFF),&currentRec);
 		snprintf(buffer, 20, "%s", currentRec.text);
 		buffer[20] = 0;
-		UC1701_printCentered(16, buffer,UC1701_FONT_GD77_8x16);
+		UC1701_printCentered(16, buffer,UC1701_FONT_8x16);
 
 		// Are we already in PC mode to this caller ?
 		if (trxTalkGroupOrPcId != (LinkHead->id | (PC_CALL_FLAG<<24)))
 		{
 			// No either we are not in PC mode or not on a Private Call to this station
-			UC1701_printCentered(32, "Accept call?",UC1701_FONT_GD77_8x16);
-			UC1701_printCentered(48, "YES          NO",UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(32, "Accept call?",UC1701_FONT_8x16);
+			UC1701_printCentered(48, "YES          NO",UC1701_FONT_8x16);
 			menuUtilityReceivedPcId = LinkHead->id | (PC_CALL_FLAG<<24);
 		    set_melody(melody_private_call);
 		}
 		else
 		{
-			UC1701_printCentered(32, "Private call",UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(32, "Private call",UC1701_FONT_8x16);
 		}
 	}
 	else
@@ -377,11 +377,11 @@ void menuUtilityRenderQSOData()
 		if (tg != trxTalkGroupOrPcId)
 		{
 			UC1701_fillRect(0,16,128,16,false);// fill background with black
-			UC1701_printCore(0, CONTACT_Y_POS, buffer,UC1701_FONT_GD77_8x16,1,true);// draw the text in inverse video
+			UC1701_printCore(0, CONTACT_Y_POS, buffer,UC1701_FONT_8x16,1,true);// draw the text in inverse video
 		}
 		else
 		{
-			UC1701_printCentered(CONTACT_Y_POS, buffer,UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(CONTACT_Y_POS, buffer,UC1701_FONT_8x16);
 		}
 
 		// first check if we have this ID in the DMR ID data
@@ -389,7 +389,7 @@ void menuUtilityRenderQSOData()
 		{
 			snprintf(buffer, 20, "%s", currentRec.text);
 			buffer[20] = 0;
-			UC1701_printCentered(32, buffer,UC1701_FONT_GD77_8x16);
+			UC1701_printCentered(32, buffer,UC1701_FONT_8x16);
 			displayChannelNameOrRxFrequency(buffer);
 		}
 		else
@@ -402,15 +402,15 @@ void menuUtilityRenderQSOData()
 					// More than 1 line wide of text, so we need to split onto 2 lines.
 					memcpy(buffer,LinkHead->talkerAlias,6);
 					buffer[6]=0x00;
-					UC1701_printCentered(32, buffer,UC1701_FONT_GD77_8x16);
+					UC1701_printCentered(32, buffer,UC1701_FONT_8x16);
 
 					memcpy(buffer,&LinkHead->talkerAlias[6],16);
 					buffer[16]=0x00;
-					UC1701_printAt(0,48,buffer,UC1701_FONT_GD77_8x16);
+					UC1701_printAt(0,48,buffer,UC1701_FONT_8x16);
 				}
 				else
 				{
-					UC1701_printCentered(32,LinkHead->talkerAlias,UC1701_FONT_GD77_8x16);
+					UC1701_printCentered(32,LinkHead->talkerAlias,UC1701_FONT_8x16);
 					displayChannelNameOrRxFrequency(buffer);
 				}
 			}
@@ -418,7 +418,7 @@ void menuUtilityRenderQSOData()
 			{
 				// No talker alias. So we can only show the ID.
 				sprintf(buffer,"ID: %d", LinkHead->id);
-				UC1701_printCentered(32, buffer,UC1701_FONT_GD77_8x16);
+				UC1701_printCentered(32, buffer,UC1701_FONT_8x16);
 				displayChannelNameOrRxFrequency(buffer);
 			}
 		}
@@ -483,9 +483,9 @@ void menuUtilityRenderHeader()
 		strcat(buffer," L");
 	}
 
-	UC1701_printAt(0,Y_OFFSET, buffer,UC1701_FONT_6X8);
+	UC1701_printAt(0,Y_OFFSET, buffer,UC1701_FONT_6x8);
 
-	UC1701_printCentered(Y_OFFSET,(char *)POWER_LEVELS[nonVolatileSettings.txPowerLevel],UC1701_FONT_6X8);
+	UC1701_printCentered(Y_OFFSET,(char *)POWER_LEVELS[nonVolatileSettings.txPowerLevel],UC1701_FONT_6x8);
 
 
 	int  batteryPerentage = (int)(((averageBatteryVoltage - CUTOFF_VOLTAGE_UPPER_HYST) * 100) / (BATTERY_MAX_VOLTAGE - CUTOFF_VOLTAGE_UPPER_HYST));
@@ -507,7 +507,7 @@ void menuUtilityRenderHeader()
 		sprintf(buffer,"C%d %d%%",trxGetDMRColourCode(),batteryPerentage);
 	}
 
-	UC1701_printCore(0,Y_OFFSET,buffer,UC1701_FONT_6X8,2,false);// Display battery percentage at the right
+	UC1701_printCore(0,Y_OFFSET,buffer,UC1701_FONT_6x8,2,false);// Display battery percentage at the right
 }
 
 void drawRSSIBarGraph()

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -189,17 +189,17 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 
 				if (trxIsTransmitting)
 				{
-					UC1701_printCentered(34,buffer,UC1701_FONT_GD77_8x16);
+					UC1701_printCentered(34,buffer,UC1701_FONT_8x16);
 				}
 				else
 				{
-					UC1701_printCentered(CONTACT_Y_POS,buffer,UC1701_FONT_GD77_8x16);
+					UC1701_printCentered(CONTACT_Y_POS,buffer,UC1701_FONT_8x16);
 				}
 			}
 			else if(displaySquelch)
 			{
 				sprintf(buffer,"Squelch");
-				UC1701_printAt(0,16,buffer,UC1701_FONT_GD77_8x16);
+				UC1701_printAt(0,16,buffer,UC1701_FONT_8x16);
 				int bargraph= 1 + ((currentChannelData->sql-1)*5)/2 ;
 				UC1701_fillRect(62,21,bargraph,8,false);
 				displaySquelch=false;
@@ -212,7 +212,7 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 					val_before_dp = currentChannelData->rxFreq/100000;
 					val_after_dp = currentChannelData->rxFreq - val_before_dp*100000;
 					sprintf(buffer,"%cR %d.%05d MHz", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_RX)?'>':' ',val_before_dp, val_after_dp);
-					UC1701_printCentered(32, buffer,UC1701_FONT_GD77_8x16);
+					UC1701_printCentered(32, buffer,UC1701_FONT_8x16);
 				}
 				else
 				{
@@ -223,18 +223,18 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 				val_before_dp = currentChannelData->txFreq/100000;
 				val_after_dp = currentChannelData->txFreq - val_before_dp*100000;
 				sprintf(buffer,"%cT %d.%05d MHz", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX || trxIsTransmitting)?'>':' ',val_before_dp, val_after_dp);
-				UC1701_printCentered(48, buffer,UC1701_FONT_GD77_8x16);
+				UC1701_printCentered(48, buffer,UC1701_FONT_8x16);
 			}
 			else
 			{
 				sprintf(buffer,"%c%c%c.%c%c%c%c%c MHz", freq_enter_digits[0], freq_enter_digits[1], freq_enter_digits[2], freq_enter_digits[3], freq_enter_digits[4], freq_enter_digits[5], freq_enter_digits[6], freq_enter_digits[7] );
 				if (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX)
 				{
-					UC1701_printCentered(48, buffer,UC1701_FONT_GD77_8x16);
+					UC1701_printCentered(48, buffer,UC1701_FONT_8x16);
 				}
 				else
 				{
-					UC1701_printCentered(32, buffer,UC1701_FONT_GD77_8x16);
+					UC1701_printCentered(32, buffer,UC1701_FONT_8x16);
 				}
 			}
 


### PR DESCRIPTION
Major change is the following (+ functions prototype):

#define UC1701_FONT_6X8 				0
#define UC1701_FONT_6X8_bold			1
#define UC1701_FONT_8X8 				2
#define UC1701_FONT_GD77_8x16 			3
#define UC1701_FONT_16x32 				4
typedef enum
{
	UC1701_FONT_6x8 = 0,
	UC1701_FONT_6x8_BOLD,
	UC1701_FONT_8x8,
	UC1701_FONT_8x16,
	UC1701_FONT_16x32
} UC1701_Font_t;

Also, it renames font font_gd77_8x16  to font_8x16[].

Cheers.