### PR TITLE
Add drop-shadow box around TG/PC/Contact/DMR-ID menu title.

### DIFF
--- a/firmware/include/functions/fw_ticks.h
+++ b/firmware/include/functions/fw_ticks.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C)2019 Kai Ludwig, DG4KLU
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#ifndef _FW_TICKS_H_
+#define _FW_TICKS_H_
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+uint32_t fw_millis(void);
+
+
+#endif /* _FW_TICKS_H_ */
+

--- a/firmware/include/hardware/UC1701.h
+++ b/firmware/include/hardware/UC1701.h
@@ -55,7 +55,7 @@ void UC1701_drawFastHLine(int16_t x, int16_t y, int16_t w, bool color);
 void UC1701_drawCircle(int16_t x0, int16_t y0, int16_t r, bool color);
 void UC1701_fillCircle(int16_t x0, int16_t y0, int16_t r, bool color);
 
-void UC1701_drawellipse(int16_t x0, int16_t y0, int16_t x1, int16_t y1, bool color);
+void UC1701_drawEllipse(int16_t x0, int16_t y0, int16_t x1, int16_t y1, bool color);
 
 void UC1701_drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool color);
 void UC1701_fillTriangle ( int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool color);
@@ -64,9 +64,11 @@ void UC1701_fillArc(uint16_t x, uint16_t y, uint16_t radius, uint16_t thickness,
 
 void UC1701_drawRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, bool color);
 void UC1701_fillRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, bool color);
+void UC1701_drawRoundRectWithDropShadow(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, bool color);
 
 void UC1701_drawRect(int16_t x, int16_t y, int16_t w, int16_t h, bool color);
 void UC1701_fillRect(int16_t x, int16_t y, int16_t width, int16_t height, bool isInverted);
+void UC1701_drawRectWithDropShadow(int16_t x, int16_t y, int16_t w, int16_t h, bool color);
 
 void UC1701_drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h, bool color);
 void UC1701_drawXBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, bool color);

--- a/firmware/source/functions/fw_ticks.c
+++ b/firmware/source/functions/fw_ticks.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C)2019 Kai Ludwig, DG4KLU
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "fw_ticks.h"
+
+
+uint32_t fw_millis(void)
+{
+	return xTaskGetTickCount();
+}
+

--- a/firmware/source/hardware/UC1701.c
+++ b/firmware/source/hardware/UC1701.c
@@ -764,7 +764,7 @@ void UC1701_fillArc(uint16_t x, uint16_t y, uint16_t radius, uint16_t thickness,
  * ***** End of Arc related functions *****
  */
 
-void UC1701_drawellipse(int16_t x0, int16_t y0, int16_t x1, int16_t y1, bool color)
+void UC1701_drawEllipse(int16_t x0, int16_t y0, int16_t x1, int16_t y1, bool color)
 {
   int16_t a = abs(x1 - x0), b = abs(y1 - y0), b1 = b & 1; /* values of diameter */
   long dx = 4 * (1 - a) * b * b, dy = 4 * (b1 + 1) * a * a; /* error increment */
@@ -923,6 +923,16 @@ void UC1701_fillRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r,
 }
 
 /*
+ *
+ */
+void UC1701_drawRoundRectWithDropShadow(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, bool color)
+{
+	UC1701_fillRoundRect(x + 2, y, w, h, r, color); // Shadow
+	UC1701_fillRoundRect(x, y - 2, w, h, r, !color); // Empty box
+	UC1701_drawRoundRect(x, y - 2, w, h, r, color); // Outline
+}
+
+/*
  * Draw a rectangle
  */
 void UC1701_drawRect(int16_t x, int16_t y, int16_t w, int16_t h, bool color)
@@ -998,6 +1008,16 @@ void UC1701_fillRect(int16_t x, int16_t y, int16_t width, int16_t height, bool i
 			}
 		}
 	}
+}
+
+/*
+ *
+ */
+void UC1701_drawRectWithDropShadow(int16_t x, int16_t y, int16_t w, int16_t h, bool color)
+{
+	UC1701_fillRect(x + 2, y, w, h, !color); // Shadow
+	UC1701_fillRect(x, y - 2, w, h, color); // Empty box
+	UC1701_drawRect(x, y - 2, w, h, color); // Outline
 }
 
 /*


### PR DESCRIPTION
Add blinking cursor when numerical value is expected (taking account of the CCS7 lenght).
Add fw_millis(void) function.

I think it's nicer.

![numEntry-cursor](https://user-images.githubusercontent.com/10473896/69148834-7b3b0a00-0ad5-11ea-9ec2-f6413c30ba4b.png)


