### PR TITLE
Add delete contact to 'Contact List', use DMR ID as name in 'New Contact'

### DIFF
--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -98,6 +98,7 @@ enum MENU_SCREENS { MENU_SPLASH_SCREEN=0,
 					MENU_CONTACT_LIST,
 					MENU_CONTACT_DETAILS,
 					MENU_SAVED_SCREEN,
+					MENU_DELETED_SCREEN,
 };
 
 extern int gMenusCurrentItemIndex;

--- a/firmware/source/user_interface/menuContactDetails.c
+++ b/firmware/source/user_interface/menuContactDetails.c
@@ -135,6 +135,7 @@ static void updateScreen(void)
 
 static void handleEvent(int buttons, int keys, int events)
 {
+	dmrIdDataStruct_t foundRecord;
 	char buf[17];
 	int sLen = strlen(digits);
 
@@ -214,11 +215,17 @@ static void handleEvent(int buttons, int keys, int events)
 				tmpContact.tgNumber = atoi(digits);
 				if (tmpContact.name[0] == 0x00) {
 					if (tmpContact.callType == CONTACT_CALLTYPE_PC) {
-						sprintf(buf,"PC %d",tmpContact.tgNumber);
+						if (dmrIDLookup(tmpContact.tgNumber,&foundRecord))
+						{
+							codeplugUtilConvertStringToBuf(foundRecord.text, tmpContact.name, 16);
+						} else {
+							sprintf(buf,"PC %d",tmpContact.tgNumber);
+							codeplugUtilConvertStringToBuf(buf, tmpContact.name, 16);
+						}
 					} else {
 						sprintf(buf,"TG %d",tmpContact.tgNumber);
+						codeplugUtilConvertStringToBuf(buf, tmpContact.name, 16);
 					}
-					codeplugUtilConvertStringToBuf(buf, tmpContact.name, 16);
 				}
 				codeplugContactSaveDataForIndex(contactListContactIndex, &tmpContact);
 				contactListContactIndex = 0;

--- a/firmware/source/user_interface/menuContactList.c
+++ b/firmware/source/user_interface/menuContactList.c
@@ -121,6 +121,18 @@ static void handleEvent(int buttons, int keys, int events)
 		}
 		else if (KEYCHECK_SHORTUP(keys, KEY_RED))
 		{
+			if ((buttons & BUTTON_SK2)!= 0) {
+				contactListContactIndex = codeplugContactGetDataForNumber(gMenusCurrentItemIndex+1, contactCallType, &contact);
+				if (contactListContactIndex > 0 && contact.callType == CONTACT_CALLTYPE_PC) {
+					memset(contact.name, 0xff, 16);
+					contact.tgNumber = 0;
+					contact.callType =0;
+					codeplugContactSaveDataForIndex(contactListContactIndex, &contact);
+					contactListContactIndex = 0;
+					menuSystemPushNewMenu(MENU_DELETED_SCREEN);
+					return;
+				}
+			}
 			contactListContactIndex = 0;
 			menuSystemPopPreviousMenu();
 			return;

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -48,7 +48,7 @@ int menuCPS(int buttons, int keys, int events, bool isFirstRun);
 int menuLockScreen(int buttons, int keys, int events, bool isFirstRun);
 int menuContactList(int buttons, int keys, int events, bool isFirstRun);
 int menuContactDetails(int buttons, int keys, int events, bool isFirstRun);
-int menuSavedScreen(int buttons, int keys, int events, bool isFirstRun);
+int menuInfoMsgScreen(int buttons, int keys, int events, bool isFirstRun);
 
 /*
  * ---------------------- IMPORTANT ----------------------------
@@ -84,6 +84,7 @@ const menuItemNew_t * menusData[] = { 	NULL,// splash
 										NULL,// Contact List
 										NULL,// Contact Details
 										NULL,// Saved
+										NULL,// Deleted
 								};
 
 const MenuFunctionPointer_t menuFunctions[] = { menuSplashScreen,
@@ -110,7 +111,8 @@ const MenuFunctionPointer_t menuFunctions[] = { menuSplashScreen,
                                                 menuLockScreen,
 												menuContactList,
 												menuContactDetails,
-												menuSavedScreen,
+												menuInfoMsgScreen,
+												menuInfoMsgScreen,
 };
 
 void menuSystemPushNewMenu(int menuNumber)

--- a/firmware/source/user_interface/uiInfoMsgScreen.c
+++ b/firmware/source/user_interface/uiInfoMsgScreen.c
@@ -23,7 +23,7 @@ static void handleEvent(int buttons, int keys, int events);
 
 static const int TIMEOUT_MS = 2000;
 
-int menuSavedScreen(int buttons, int keys, int events, bool isFirstRun)
+int menuInfoMsgScreen(int buttons, int keys, int events, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -41,7 +41,14 @@ static void updateScreen(void)
 {
 	UC1701_clearBuf();
 	UC1701_drawRoundRect(4, 4, 120, 56, 5, true);
-	UC1701_printCentered(18, "Saved",UC1701_FONT_16x32);
+	switch (menuSystemGetCurrentMenuNumber()) {
+	case MENU_SAVED_SCREEN:
+		UC1701_printCentered(18, "Saved",UC1701_FONT_16x32);
+		break;
+	case MENU_DELETED_SCREEN:
+		UC1701_printCentered(18, "Deleted",UC1701_FONT_16x32);
+		break;
+	}
 	UC1701_render();
 	displayLightTrigger();
 }


### PR DESCRIPTION
1. If a new private contact is created and the ID is found in the DMR ID database that info is used as the contact name instead of 'PC #######'. The text from the DMR ID is shorten to 16 letters.

2. Deleting a contact is added to the 'Contact List'
Deleting a private contact is done by pressing SK2+RED.
TG's can not be deleted right now. I will add this later for TG's not used in a RX Group.
