### PR TITLE
Display "VFO:B" instead of "VFO B" in quick menu

### DIFF
--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -786,7 +786,7 @@ static void updateQuickMenuScreen(void)
 				sprintf(buf, "DMR Mon:%s",DMR_FILTER_LEVELS[tmpQuickMenuDmrFilterLevel]);
 				break;
 			case VFO_SCREEN_QUICK_MENU_VFO_A_B:
-				sprintf(buf, "VFO %s",((nonVolatileSettings.currentVFONumber==0)?"A":"B"));
+				sprintf(buf, "VFO:%s",((nonVolatileSettings.currentVFONumber==0)?"A":"B"));
 				break;
 
 			default:


### PR DESCRIPTION
The first time I tried to switch between VFO A and B I was confused
because I'm use to the ":" indicating that I modify the value with Left
or Right. This makes this menu item consistent with others controlled in
the same way.