### PR TITLE
Restore lock indicator to top right

### DIFF
--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -584,11 +584,10 @@ void menuUtilityRenderHeader(void)
 			break;
 	}
 
-	/* NO ROOM TO DISPLAY THIS
 	if (keypadLocked)
 	{
-		strcat(buffer," L");
-	}*/
+		UC1701_printAt(83, Y_OFFSET, "L", UC1701_FONT_6x8);
+	}
 
 	UC1701_printCentered(Y_OFFSET,(char *)POWER_LEVELS[nonVolatileSettings.txPowerLevel],UC1701_FONT_6x8);
 


### PR DESCRIPTION
The `L` lock indicator was removed in 14304e2265dd09f2d1e03f7eb1c88cc7218635ef because there was no room on the left of the header, but there's some room on the right, and I think it looks fine over there. I've placed it so that it will display as `L100%` on a full battery, but `L 97%` in the real world. I'm not especially happy that it gets crammed to `LC1` in DMR mode, but that's really not so bad.

![locked](https://user-images.githubusercontent.com/260569/69840389-39fed480-1210-11ea-9341-abf7b855b4d8.png)
![locked-dmr](https://user-images.githubusercontent.com/260569/69840393-3cf9c500-1210-11ea-8c32-dafb44da3941.png)

I'm happy to incorporate any feedback (including putting some space before the `C1`), or to drop this entirely. It's true enough that you'll find out the keypad it locked when you try to unlock it, so there's not a strong need for this.