### PR TITLE
Fix crash when unlocking PTT lock

### DIFF
--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -200,28 +200,6 @@ void fw_main_task(void *data)
 				}
 			}
 
-			if (keypadLocked)
-			{
-				if (key_event == EVENT_KEY_CHANGE)
-				{
-					key_event = EVENT_KEY_NONE;
-					keys = 0;
-					if (menuSystemGetCurrentMenuNumber() != MENU_LOCK_SCREEN)
-					{
-						menuSystemPushNewMenu(MENU_LOCK_SCREEN);
-					}
-				}
-				if (button_event == EVENT_BUTTON_CHANGE
-						&& (buttons & BUTTON_ORANGE) != 0)
-				{
-					button_event = EVENT_BUTTON_NONE;
-					buttons = 0;
-					if (menuSystemGetCurrentMenuNumber() != MENU_LOCK_SCREEN)
-					{
-						menuSystemPushNewMenu(MENU_LOCK_SCREEN);
-					}
-				}
-			}
 			if (key_event == EVENT_KEY_CHANGE && (buttons & BUTTON_PTT) == 0 && keys != 0) {
 				if (keys & KEY_MOD_PRESS)
 				{

--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -180,7 +180,7 @@ void fw_main_task(void *data)
 			}
 
 			// Only PTT is locked, user ask to unlock
-			if (PTTLocked && ((buttons & BUTTON_SK2) && ((keys & KEY_STAR) != 0)))
+			if (PTTLocked && ((buttons & BUTTON_PTT) != 0))
 			{
 				if (menuSystemGetCurrentMenuNumber() != MENU_LOCK_SCREEN)
 				{


### PR DESCRIPTION
This is a partially fix, as I couldn't produce the crash as described.
But I got a crash when PTT was locked and then unlocked.

I changed the key handling in uiLockScreen.c. So maybe it fixed the other problems.