### PR TITLE
Manual TG or PC displays contact name if available.

### DIFF
--- a/firmware/include/functions/fw_codeplug.h
+++ b/firmware/include/functions/fw_codeplug.h
@@ -131,7 +131,7 @@ bool codeplugChannelSaveDataForIndex(int index, struct_codeplugChannel_t *channe
 
 int codeplugContactsGetCount(int callType);
 int codeplugContactGetDataForNumber(int number, int callType, struct_codeplugContact_t *contact);
-int codeplugContactIndexByTGorPC(int tgorpc, int callType);
+int codeplugContactIndexByTGorPC(int tgorpc, int callType, struct_codeplugContact_t *contact);
 int codeplugContactSaveDataForIndex(int index, struct_codeplugContact_t *contact);
 int codeplugContactGetFreeIndex(void);
 bool codeplugContactGetRXGroup(int index);

--- a/firmware/source/functions/fw_codeplug.c
+++ b/firmware/source/functions/fw_codeplug.c
@@ -436,14 +436,12 @@ int codeplugContactGetDataForNumber(int number, int callType, struct_codeplugCon
 	return pos;
 }
 
-int codeplugContactIndexByTGorPC(int tgorpc, int callType)
+int codeplugContactIndexByTGorPC(int tgorpc, int callType, struct_codeplugContact_t *contact)
 {
-	struct_codeplugContact_t contact;
-
 	for (int i = 1; i <= 1024; i++)
 	{
-		codeplugContactGetDataForIndex(i, &contact);
-		if (contact.name[0] != 0xff && contact.tgNumber == tgorpc && contact.callType == callType)
+		codeplugContactGetDataForIndex(i, contact);
+		if (contact->name[0] != 0xff && contact->tgNumber == tgorpc && contact->callType == callType)
 		{
 			return i;
 		}

--- a/firmware/source/user_interface/menuContactDetails.c
+++ b/firmware/source/user_interface/menuContactDetails.c
@@ -246,7 +246,8 @@ static void handleEvent(int buttons, int keys, int events)
 
 				if (tmpContact.tgNumber > 0 && tmpContact.tgNumber <= 9999999)
 				{
-					int index = codeplugContactIndexByTGorPC(tmpContact.tgNumber, tmpContact.callType);
+					struct_codeplugContact_t contact;
+					int index = codeplugContactIndexByTGorPC(tmpContact.tgNumber, tmpContact.callType, &contact);
 					if (index > 0 && index != tmpContact.NOT_IN_CODEPLUGDATA_indexNumber)
 					{
 						menuContactDetailsTimeout = 2000;

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -197,6 +197,8 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 	static const int bufferLen = 17;
 	char buffer[bufferLen];
 	int verticalPositionOffset = 0;
+	struct_codeplugContact_t contact;
+	int contactIndex;
 
 	UC1701_clearBuf();
 	menuUtilityRenderHeader();
@@ -255,15 +257,26 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 				{
 					if((trxTalkGroupOrPcId>>24) == TG_CALL_FLAG)
 					{
-						snprintf(nameBuf, bufferLen, "TG %d", (trxTalkGroupOrPcId & 0x00FFFFFF));
+						contactIndex = codeplugContactIndexByTGorPC((trxTalkGroupOrPcId & 0x00FFFFFF), CONTACT_CALLTYPE_TG, &contact);
+						if (contactIndex == 0) {
+							snprintf(nameBuf, bufferLen, "TG %d", (trxTalkGroupOrPcId & 0x00FFFFFF));
+						} else {
+							codeplugUtilConvertBufToString(contact.name, nameBuf, 16);
+						}
 					}
 					else
 					{
-						dmrIdDataStruct_t currentRec;
-						dmrIDLookup((trxTalkGroupOrPcId & 0x00FFFFFF), &currentRec);
-						strncpy(nameBuf, currentRec.text, bufferLen);
+						contactIndex = codeplugContactIndexByTGorPC((trxTalkGroupOrPcId & 0x00FFFFFF), CONTACT_CALLTYPE_PC, &contact);
+						if (contactIndex == 0) {
+							dmrIdDataStruct_t currentRec;
+							dmrIDLookup((trxTalkGroupOrPcId & 0x00FFFFFF), &currentRec);
+							strncpy(nameBuf, currentRec.text, bufferLen);
+						} else {
+							codeplugUtilConvertBufToString(contact.name, nameBuf, 16);
+						}
 					}
 					nameBuf[bufferLen - 1] = 0;
+					UC1701_drawRect(0, CONTACT_Y_POS + verticalPositionOffset, 128, 16, true);
 				}
 				else
 				{

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -152,6 +152,8 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 	int val_after_dp;
 	static const int bufferLen = 17;
 	char buffer[bufferLen];
+	struct_codeplugContact_t contact;
+	int contactIndex;
 
 	UC1701_clearBuf();
 
@@ -169,13 +171,28 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 				{
 					if((trxTalkGroupOrPcId >> 24) == TG_CALL_FLAG)
 					{
-						snprintf(buffer, bufferLen, "TG %d", (trxTalkGroupOrPcId & 0x00FFFFFF));
+						contactIndex = codeplugContactIndexByTGorPC((trxTalkGroupOrPcId & 0x00FFFFFF), CONTACT_CALLTYPE_TG, &contact);
+						if (contactIndex == 0) {
+							snprintf(buffer, bufferLen, "TG %d", (trxTalkGroupOrPcId & 0x00FFFFFF));
+						} else {
+							codeplugUtilConvertBufToString(contact.name, buffer, 16);
+						}
 					}
 					else
 					{
-						dmrIdDataStruct_t currentRec;
-						dmrIDLookup((trxTalkGroupOrPcId & 0x00FFFFFF),&currentRec);
-						strncpy(buffer, currentRec.text, bufferLen);
+						contactIndex = codeplugContactIndexByTGorPC((trxTalkGroupOrPcId & 0x00FFFFFF), CONTACT_CALLTYPE_PC, &contact);
+						if (contactIndex == 0) {
+							dmrIdDataStruct_t currentRec;
+							dmrIDLookup((trxTalkGroupOrPcId & 0x00FFFFFF),&currentRec);
+							strncpy(buffer, currentRec.text, bufferLen);
+						} else {
+							codeplugUtilConvertBufToString(contact.name, buffer, 16);
+						}
+					}
+					if (trxIsTransmitting) {
+						UC1701_drawRect(0, 34, 128, 16, true);
+					} else {
+						UC1701_drawRect(0, CONTACT_Y_POS, 128, 16, true);
 					}
 				}
 				else


### PR DESCRIPTION
If a TG or PC is entered manual and a contact with that ID exists, the contact name is displayed instead of the ID.

For private calls if no contact exists the dmr id data is used.

If a override TG or PC is set, a border is drawn around the ID or name. 
