### PR TITLE
Default squelch settings for 3 bands, and also changed the way band c…

### DIFF
--- a/firmware/include/functions/fw_calibration.h
+++ b/firmware/include/functions/fw_calibration.h
@@ -105,7 +105,7 @@ void read_val_padrv_ibit(int offset, uint8_t* value);
 
 void read_val_xmitter_dev_wideband(int offset, uint16_t* value);
 void read_val_xmitter_dev_narrowband(int offset, uint16_t* value);
-void read_val_dev_tone(int freq, int index, uint8_t *value);
+void read_val_dev_tone(int index, uint8_t *value);
 
 void read_val_dac_vgain_analog(int offset, uint8_t* value);
 void read_val_volume_analog(int offset, uint8_t* value);
@@ -119,6 +119,6 @@ void read_val_rssi3_th_narrowband(int offset, uint16_t* value);
 
 void read_val_squelch_th(int offset, int mod, uint16_t* value);
 bool calibrationGetPowerForFrequency(int freq, calibrationPowerValues_t *powerSettings);
-bool calibrationGetRSSIMeterParams(int freq, calibrationRSSIMeter_t *rssiMeterValues);
+bool calibrationGetRSSIMeterParams(calibrationRSSIMeter_t *rssiMeterValues);
 
 #endif

--- a/firmware/include/functions/fw_settings.h
+++ b/firmware/include/functions/fw_settings.h
@@ -22,6 +22,7 @@
 
 #include "fw_common.h"
 #include "fw_codeplug.h"
+#include "fw_trx.h"
 
 extern const int BAND_VHF_MIN;
 extern const int BAND_VHF_MAX;
@@ -62,6 +63,7 @@ typedef struct settingsStruct
 	uint8_t			languageIndex;
 	uint8_t			scanDelay;
 	bool			scanModePause;
+	uint8_t			squelchDefaults[RADIO_BANDS_TOTAL_NUM];// VHF,200Mhz and UHF
 } settingsStruct_t;
 
 typedef enum {DMR_FILTER_NONE = 0, DMR_FILTER_TS = 1, DMR_FILTER_TS_TG = 2} dmrFilter_t;

--- a/firmware/include/functions/fw_trx.h
+++ b/firmware/include/functions/fw_trx.h
@@ -30,6 +30,12 @@ typedef struct frequencyBand
 	int maxFreq;
 } frequencyBand_t;
 
+typedef struct trxFrequency
+{
+	int rxFreq;
+	int txFreq;
+} trxFrequency_t;
+
 extern const int RADIO_VHF_MIN;
 extern const int RADIO_VHF_MAX;
 extern const int RADIO_UHF_MIN;
@@ -39,6 +45,7 @@ enum RADIO_MODE { RADIO_MODE_NONE,RADIO_MODE_ANALOG,RADIO_MODE_DIGITAL};
 enum DMR_ADMIT_CRITERIA { ADMIT_CRITERIA_ALWAYS,ADMIT_CRITERIA_CHANNEL_FREE,ADMIT_CRITERIA_COLOR_CODE};
 enum DMR_MODE {DMR_MODE_AUTO,DMR_MODE_ACTIVE,DMR_MODE_PASSIVE,DMR_MODE_SFR};
 enum RADIO_FREQUENCY_BAND_NAMES { RADIO_BAND_VHF = 0,RADIO_BAND_220MHz = 1,RADIO_BAND_UHF=2,RADIO_BANDS_TOTAL_NUM=3};
+enum {TRX_RX_FREQ_BAND = 0,TRX_TX_FREQ_BAND = 1};
 
 extern const frequencyBand_t RADIO_FREQUENCY_BANDS[RADIO_BANDS_TOTAL_NUM];
 
@@ -53,6 +60,7 @@ extern volatile uint8_t trxRxSignal;
 extern volatile uint8_t trxRxNoise;
 extern volatile bool trxIsTransmittingTone;
 extern calibrationPowerValues_t trxPowerSettings;
+extern int trxCurrentBand[2];
 
 int trx_carrier_detected(void);
 void trx_check_analog_squelch(void);
@@ -74,13 +82,12 @@ int trxGetDMRColourCode(void);
 int trxGetDMRTimeSlot(void);
 void trxSetDMRTimeSlot(int timeslot);
 //bool trxCheckFrequencyIsVHF(int frequency);
-bool trxCheckFrequencyIsUHF(int frequency);
-bool trxCheckFrequency(int tmp_frequency);
+//bool trxCheckFrequencyIsUHF(int frequency);
 void trxSetTxCTCSS(int toneFreqX10);
 void trxSetRxCTCSS(int toneFreqX10);
 bool trxCheckCTCSSFlag(void);
 bool trxCheckFrequencyInAmateurBand(int tmp_frequency);
-bool trxCheckFrequencyIsSupportedByTheRadioHardware(int frequency);
+int trxGetBandFromFrequency(int frequency);
 void trxReadRSSIAndNoise(void);
 void trxSelectVoiceChannel(uint8_t channel);
 void trxSetTone1(int toneFreq);

--- a/firmware/source/functions/fw_calibration.c
+++ b/firmware/source/functions/fw_calibration.c
@@ -105,11 +105,11 @@ void read_val_xmitter_dev_narrowband(int offset, uint16_t* value)
 	*value=buffer[0] + ((buffer[1] & 0x03) << 8);
 }
 
-void read_val_dev_tone(int freq, int index, uint8_t *value)
+void read_val_dev_tone(int index, uint8_t *value)
 {
 	int address;
 
-	if (trxCheckFrequencyIsUHF(freq))
+	if (trxCurrentBand[TRX_TX_FREQ_BAND] == RADIO_BAND_UHF)
 	{
 		address = EXT_uhf_dev_tone+index;
 	}
@@ -204,7 +204,7 @@ bool calibrationGetPowerForFrequency(int freq, calibrationPowerValues_t *powerSe
 	uint8_t buffer[2];
 
 
-	if (trxCheckFrequencyIsUHF(freq))
+	if (trxCurrentBand[TRX_TX_FREQ_BAND] == RADIO_BAND_UHF)
 	{
 		address = POWER_CALIBRATION_ADDRESS_UHF_400MHZ + ((freq - RADIO_FREQUENCY_BANDS[RADIO_BAND_UHF].minFreq) / 500000) * 2;
 	}
@@ -220,11 +220,11 @@ bool calibrationGetPowerForFrequency(int freq, calibrationPowerValues_t *powerSe
 	return true;
 }
 
-bool calibrationGetRSSIMeterParams(int freq, calibrationRSSIMeter_t *rssiMeterValues)
+bool calibrationGetRSSIMeterParams(calibrationRSSIMeter_t *rssiMeterValues)
 {
 	int address;
 
-	if (trxCheckFrequencyIsUHF(freq))
+	if (trxCurrentBand[TRX_RX_FREQ_BAND] == RADIO_BAND_UHF)
 	{
 		address = 0x8F053;
 	}

--- a/firmware/source/functions/fw_settings.c
+++ b/firmware/source/functions/fw_settings.c
@@ -31,7 +31,7 @@ const int BAND_UHF_MIN 	= 43000000;
 const int BAND_UHF_MAX 	= 45000000;
 
 static const int STORAGE_BASE_ADDRESS 		= 0x6000;
-static const int STORAGE_MAGIC_NUMBER 		= 0x472B;
+static const int STORAGE_MAGIC_NUMBER 		= 0x472C;
 
 settingsStruct_t nonVolatileSettings;
 struct_codeplugChannel_t *currentChannelData;
@@ -157,6 +157,9 @@ void settingsRestoreDefaultSettings(void)
 	nonVolatileSettings.languageIndex=0;
 	nonVolatileSettings.scanDelay=5;// 5 seconds
 	nonVolatileSettings.scanModePause=false;
+	nonVolatileSettings.squelchDefaults[RADIO_BAND_VHF]		= 10;// 1 - 21 = 0 - 100% , same as from the CPS variable squelch
+	nonVolatileSettings.squelchDefaults[RADIO_BAND_220MHz]	= 10;// 1 - 21 = 0 - 100% , same as from the CPS variable squelch
+	nonVolatileSettings.squelchDefaults[RADIO_BAND_UHF]		= 10;// 1 - 21 = 0 - 100% , same as from the CPS variable squelch
 
 	currentChannelData = &settingsVFOChannel[nonVolatileSettings.currentVFONumber];// Set the current channel data to point to the VFO data since the default screen will be the VFO
 

--- a/firmware/source/functions/fw_trx.c
+++ b/firmware/source/functions/fw_trx.c
@@ -33,6 +33,8 @@ volatile bool trxIsTransmittingTone = false;
 static uint16_t txPower;
 static bool analogSignalReceived = false;
 
+int trxCurrentBand[2] = {RADIO_BAND_VHF,RADIO_BAND_VHF};// Rx and Tx band.
+
 const frequencyBand_t RADIO_FREQUENCY_BANDS[RADIO_BANDS_TOTAL_NUM] =  {
 													{
 														.minFreq=13400000,
@@ -47,6 +49,7 @@ const frequencyBand_t RADIO_FREQUENCY_BANDS[RADIO_BANDS_TOTAL_NUM] =  {
 														.maxFreq=52000000
 													}// UHF
 };
+static const int TRX_SQUELCH_MAX = 70;
 /*
  * superseded by the RADIO_FREQUENCY_BANDS data above
  *
@@ -152,29 +155,35 @@ void trxSetModeAndBandwidth(int mode, bool bandwidthIs25kHz)
 	}
 }
 
-bool trxCheckFrequencyIsSupportedByTheRadioHardware(int frequency)
+int trxGetBandFromFrequencyssss(int frequency)
 {
 	for(int i=0;i<RADIO_BANDS_TOTAL_NUM;i++)
 	{
 		if (frequency >= RADIO_FREQUENCY_BANDS[i].minFreq && frequency < RADIO_FREQUENCY_BANDS[i].maxFreq)
 		{
-			return true;
+			return i;
 		}
 	}
-	return false;
-	//return (((frequency >= RADIO_VHF_MIN) && (frequency < RADIO_VHF_MAX)) || ((frequency >= RADIO_UHF_MIN) && (frequency < RADIO_UHF_MAX)));
+	return -1;
 }
-/*
-bool trxCheckFrequencyIsVHF(int frequency)
-{
-	return ((frequency >= RADIO_VHF_MIN) && (frequency < RADIO_VHF_MAX));
-}
-*/
 
+int trxGetBandFromFrequency(int frequency)
+{
+	for(int i=0;i<RADIO_BANDS_TOTAL_NUM;i++)
+	{
+		if (frequency >= RADIO_FREQUENCY_BANDS[i].minFreq && frequency < RADIO_FREQUENCY_BANDS[i].maxFreq)
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
+/*
 bool trxCheckFrequencyIsUHF(int frequency)
 {
 	return ((frequency >= RADIO_FREQUENCY_BANDS[RADIO_BAND_UHF].minFreq) && (frequency < RADIO_FREQUENCY_BANDS[RADIO_BAND_UHF].maxFreq));
-}
+}*/
 
 bool trxCheckFrequencyInAmateurBand(int tmp_frequency)
 {
@@ -190,7 +199,7 @@ void trxReadRSSIAndNoise(void)
 
 int trx_carrier_detected(void)
 {
-	uint8_t squelch=45;
+	uint8_t squelch;
 
 	// The task Critical wrapper may not be necessary and is only added as a precaution
 	taskENTER_CRITICAL();
@@ -200,7 +209,11 @@ int trx_carrier_detected(void)
 	// check for variable squelch control
 	if (currentChannelData->sql!=0)
 	{
-		squelch =  70 - (((currentChannelData->sql-1)*11)>>2);
+		squelch =  TRX_SQUELCH_MAX - (((currentChannelData->sql-1)*11)>>2);
+	}
+	else
+	{
+		squelch =  TRX_SQUELCH_MAX - (((nonVolatileSettings.squelchDefaults[trxCurrentBand[TRX_RX_FREQ_BAND]])*11)>>2);
 	}
 
 	if (trxRxNoise < squelch)
@@ -219,14 +232,18 @@ void trx_check_analog_squelch(void)
 	trx_measure_count++;
 	if (trx_measure_count==50)
 	{
-		uint8_t squelch=45;
+		uint8_t squelch;//=45;
 
 		trxReadRSSIAndNoise();
 
 		// check for variable squelch control
 		if (currentChannelData->sql!=0)
 		{
-			squelch =  70 - (((currentChannelData->sql-1)*11)>>2);
+			squelch =  TRX_SQUELCH_MAX - (((currentChannelData->sql-1)*11)>>2);
+		}
+		else
+		{
+			squelch =  TRX_SQUELCH_MAX - (((nonVolatileSettings.squelchDefaults[trxCurrentBand[TRX_RX_FREQ_BAND]])*11)>>2);
 		}
 
 		if (trxRxNoise < squelch)
@@ -261,8 +278,13 @@ void trxSetFrequency(int fRx,int fTx, int dmrMode)
 	taskENTER_CRITICAL();
 	if (currentRxFrequency!=fRx || currentTxFrequency!=fTx)
 	{
+		trxCurrentBand[TRX_RX_FREQ_BAND] = trxGetBandFromFrequency(fRx);
+		trxCurrentBand[TRX_TX_FREQ_BAND] = trxGetBandFromFrequency(fTx);
+
 		calibrationGetPowerForFrequency(fTx, &trxPowerSettings);
 		trxSetPowerFromLevel(nonVolatileSettings.txPowerLevel);
+
+
 
 		currentRxFrequency=fRx;
 		currentTxFrequency=fTx;
@@ -335,7 +357,7 @@ void trxSetFrequency(int fRx,int fTx, int dmrMode)
 
 		if (!txPAEnabled)
 		{
-			if (trxCheckFrequencyIsUHF(currentRxFrequency))
+			if (trxCurrentBand[TRX_TX_FREQ_BAND] == RADIO_BAND_UHF)
 			{
 				GPIO_PinWrite(GPIO_VHF_RX_amp_power, Pin_VHF_RX_amp_power, 0);
 				GPIO_PinWrite(GPIO_UHF_RX_amp_power, Pin_UHF_RX_amp_power, 1);
@@ -410,7 +432,7 @@ void trx_activateRx(void)
 	txPAEnabled=false;
 
 
-    if (trxCheckFrequencyIsUHF(currentRxFrequency))
+    if (trxCurrentBand[TRX_RX_FREQ_BAND] == RADIO_BAND_UHF)
 	{
 		GPIO_PinWrite(GPIO_VHF_RX_amp_power, Pin_VHF_RX_amp_power, 0);// VHF pre-amp off
 		GPIO_PinWrite(GPIO_UHF_RX_amp_power, Pin_UHF_RX_amp_power, 1);// UHF pre-amp on
@@ -463,7 +485,7 @@ void trx_activateTx(void)
     GPIO_PinWrite(GPIO_RF_ant_switch, Pin_RF_ant_switch, ANTENNA_SWITCH_TX);
 
 	// TX PA on
-	if (trxCheckFrequencyIsUHF(currentTxFrequency))
+	if (trxCurrentBand[TRX_TX_FREQ_BAND] == RADIO_BAND_UHF)
 	{
 		GPIO_PinWrite(GPIO_VHF_TX_amp_power, Pin_VHF_TX_amp_power, 0);// I can't see why this would be needed. Its probably just for safety.
 		GPIO_PinWrite(GPIO_UHF_TX_amp_power, Pin_UHF_TX_amp_power, 1);
@@ -521,7 +543,7 @@ void trxCalcBandAndFrequencyOffset(int *band_offset, int *freq_offset)
 // NOTE. For crossband duplex DMR, the calibration potentially needs to be changed every time the Tx/Rx is switched over on each 30ms cycle
 // But at the moment this is an unnecessary complication and I'll just use the Rx frequency to get the calibration offsets
 
-	if (trxCheckFrequencyIsUHF(currentRxFrequency))
+	if (trxCurrentBand[TRX_RX_FREQ_BAND] == RADIO_BAND_UHF)
 	{
 		*band_offset=0x00000000;
 		if (currentRxFrequency<4100000)
@@ -853,12 +875,12 @@ void trxUpdateDeviation(int channel)
 	{
 	case AT1846_VOICE_CHANNEL_TONE1:
 	case AT1846_VOICE_CHANNEL_TONE2:
-		read_val_dev_tone(currentTxFrequency, CAL_DEV_TONE, &deviation);
+		read_val_dev_tone(CAL_DEV_TONE, &deviation);
 		deviation &= 0x7f;
 		I2C_AT1846_set_register_with_mask(0x59, 0x003f, deviation, 6); // Tone deviation value
 		break;
 	case AT1846_VOICE_CHANNEL_DTMF:
-		read_val_dev_tone(currentTxFrequency, CAL_DEV_DTMF, &deviation);
+		read_val_dev_tone(CAL_DEV_DTMF, &deviation);
 		deviation &= 0x7f;
 		I2C_AT1846_set_register_with_mask(0x59, 0x003f, deviation, 6); // Tone deviation value
 		break;

--- a/firmware/source/functions/fw_trx.c
+++ b/firmware/source/functions/fw_trx.c
@@ -155,18 +155,6 @@ void trxSetModeAndBandwidth(int mode, bool bandwidthIs25kHz)
 	}
 }
 
-int trxGetBandFromFrequencyssss(int frequency)
-{
-	for(int i=0;i<RADIO_BANDS_TOTAL_NUM;i++)
-	{
-		if (frequency >= RADIO_FREQUENCY_BANDS[i].minFreq && frequency < RADIO_FREQUENCY_BANDS[i].maxFreq)
-		{
-			return i;
-		}
-	}
-	return -1;
-}
-
 int trxGetBandFromFrequency(int frequency)
 {
 	for(int i=0;i<RADIO_BANDS_TOTAL_NUM;i++)

--- a/firmware/source/user_interface/menuOptions.c
+++ b/firmware/source/user_interface/menuOptions.c
@@ -27,6 +27,7 @@ enum OPTIONS_MENU_LIST { OPTIONS_MENU_TIMEOUT_BEEP=0,OPTIONS_MENU_FACTORY_RESET,
 							OPTIONS_MENU_TX_FREQ_LIMITS,OPTIONS_MENU_BEEP_VOLUME,OPTIONS_MIC_GAIN_DMR,
 							OPTIONS_MENU_KEYPAD_TIMER_LONG, OPTIONS_MENU_KEYPAD_TIMER_REPEAT, OPTIONS_MENU_DMR_MONITOR_CAPTURE_TIMEOUT,
 							OPTIONS_MENU_SCAN_DELAY,OPTIONS_MENU_SCAN_MODE,
+							OPTIONS_MENU_SQUELCH_DEFAULT_VHF,OPTIONS_MENU_SQUELCH_DEFAULT_220MHz,OPTIONS_MENU_SQUELCH_DEFAULT_UHF,
 							NUM_OPTIONS_MENU_ITEMS};
 
 
@@ -134,6 +135,15 @@ static void updateScreen(void)
 					snprintf(buf, bufferLen, "%s:%s", currentLanguage->scan_mode, currentLanguage->hold);
 				}
 				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_VHF:
+				snprintf(buf, bufferLen, "%s VHF:%d%%", currentLanguage->squelch, (nonVolatileSettings.squelchDefaults[RADIO_BAND_VHF] - 1) * 5);// 5% steps
+				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_220MHz:
+				snprintf(buf, bufferLen, "%s 220:%d%%", currentLanguage->squelch, (nonVolatileSettings.squelchDefaults[RADIO_BAND_220MHz] - 1) * 5);// 5% steps
+				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_UHF:
+				snprintf(buf, bufferLen, "%s UHF:%d%%", currentLanguage->squelch, (nonVolatileSettings.squelchDefaults[RADIO_BAND_UHF] - 1) * 5);// 5% steps
+				break;
 		}
 
 		buf[bufferLen - 1] = 0;
@@ -213,6 +223,25 @@ static void handleEvent(int buttons, int keys, int events)
 			case OPTIONS_MENU_SCAN_MODE:
 				nonVolatileSettings.scanModePause=true;
 				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_VHF:
+				if (nonVolatileSettings.squelchDefaults[RADIO_BAND_VHF] < CODEPLUG_MAX_VARIABLE_SQUELCH)
+				{
+					nonVolatileSettings.squelchDefaults[RADIO_BAND_VHF]++;
+				}
+				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_220MHz:
+				if (nonVolatileSettings.squelchDefaults[RADIO_BAND_220MHz] < CODEPLUG_MAX_VARIABLE_SQUELCH)
+				{
+					nonVolatileSettings.squelchDefaults[RADIO_BAND_220MHz]++;
+				}
+				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_UHF:
+				if (nonVolatileSettings.squelchDefaults[RADIO_BAND_UHF] < CODEPLUG_MAX_VARIABLE_SQUELCH)
+				{
+					nonVolatileSettings.squelchDefaults[RADIO_BAND_UHF]++;
+				}
+				break;
+
 		}
 	}
 	else if (KEYCHECK_PRESS(keys,KEY_LEFT))
@@ -274,6 +303,24 @@ static void handleEvent(int buttons, int keys, int events)
 				break;
 			case OPTIONS_MENU_SCAN_MODE:
 				nonVolatileSettings.scanModePause=false;
+				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_VHF:
+				if (nonVolatileSettings.squelchDefaults[RADIO_BAND_VHF] > 1)
+				{
+					nonVolatileSettings.squelchDefaults[RADIO_BAND_VHF]--;
+				}
+				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_220MHz:
+				if (nonVolatileSettings.squelchDefaults[RADIO_BAND_220MHz] > 1)
+				{
+					nonVolatileSettings.squelchDefaults[RADIO_BAND_220MHz]--;
+				}
+				break;
+			case OPTIONS_MENU_SQUELCH_DEFAULT_UHF:
+				if (nonVolatileSettings.squelchDefaults[RADIO_BAND_UHF] > 1)
+				{
+					nonVolatileSettings.squelchDefaults[RADIO_BAND_UHF]--;
+				}
 				break;
 		}
 	}

--- a/firmware/source/user_interface/menuRSSIScreen.c
+++ b/firmware/source/user_interface/menuRSSIScreen.c
@@ -20,6 +20,7 @@
 #include <user_interface/uiLocalisation.h>
 #include "fw_calibration.h"
 #include "fw_settings.h"
+#include "fw_trx.h"
 
 static calibrationRSSIMeter_t rssiCalibration;
 static void updateScreen(void);
@@ -30,7 +31,7 @@ int menuRSSIScreen(int buttons, int keys, int events, bool isFirstRun)
 	if (isFirstRun)
 	{
 		RssiUpdateCounter = RSSI_UPDATE_COUNTER_RELOAD;
-		calibrationGetRSSIMeterParams(currentChannelData->rxFreq,&rssiCalibration);
+		calibrationGetRSSIMeterParams(&rssiCalibration);
 	}
 	else
 	{
@@ -55,7 +56,7 @@ static void updateScreen(void)
 	int barGraphLength;
 	char buffer[17];
 
-		if (trxCheckFrequencyIsUHF(trxGetFrequency()))
+		if (trxCurrentBand[TRX_RX_FREQ_BAND] == RADIO_BAND_UHF)
 		{
 			// Use fixed point maths to scale the RSSI value to dBm, based on data from VK4JWT and VK7ZJA
 			dBm = -151 + trxRxSignal;// Note no the RSSI value on UHF does not need to be scaled like it does on VHF

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -511,9 +511,9 @@ static void handleEvent(int buttons, int keys, int events)
 			}
 			else
 			{
-				if(currentChannelData->sql==0)			//If we were using default squelch level
+				if(currentChannelData->sql == 0)			//If we were using default squelch level
 				{
-					currentChannelData->sql=10;			//start the adjustment from that point.
+					currentChannelData->sql=nonVolatileSettings.squelchDefaults[trxCurrentBand[TRX_RX_FREQ_BAND]];			//start the adjustment from that point.
 				}
 				else
 				{
@@ -577,9 +577,9 @@ static void handleEvent(int buttons, int keys, int events)
 			}
 			else
 			{
-				if(currentChannelData->sql==0)			//If we were using default squelch level
+				if(currentChannelData->sql == 0)			//If we were using default squelch level
 				{
-					currentChannelData->sql=10;			//start the adjustment from that point.
+					currentChannelData->sql=nonVolatileSettings.squelchDefaults[trxCurrentBand[TRX_RX_FREQ_BAND]];			//start the adjustment from that point.
 				}
 				else
 				{

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -643,7 +643,7 @@ void drawRSSIBarGraph(void)
 
 	UC1701_fillRect(0, BAR_Y_POS,128,4,true);
 
-	if (trxCheckFrequencyIsUHF(trxGetFrequency()))
+	if (trxCurrentBand[TRX_RX_FREQ_BAND] == RADIO_BAND_UHF)
 	{
 		// Use fixed point maths to scale the RSSI value to dBm, based on data from VK4JWT and VK7ZJA
 		dBm = -151 + trxRxSignal;// Note no the RSSI value on UHF does not need to be scaled like it does on VHF

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -298,7 +298,7 @@ static void update_frequency(int frequency)
 {
 	if (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX)
 	{
-		if (trxCheckFrequencyIsSupportedByTheRadioHardware(frequency))
+		if (trxGetBandFromFrequency(frequency)!=-1)
 		{
 			currentChannelData->txFreq = frequency;
 			trxSetFrequency(currentChannelData->rxFreq,currentChannelData->txFreq,DMR_MODE_AUTO);
@@ -308,20 +308,21 @@ static void update_frequency(int frequency)
 	else
 	{
 		int deltaFrequency = frequency - currentChannelData->rxFreq;
-		if (trxCheckFrequencyIsSupportedByTheRadioHardware(frequency))
+		if (trxGetBandFromFrequency(frequency)!=-1)
 		{
 			currentChannelData->rxFreq = frequency;
 			currentChannelData->txFreq = currentChannelData->txFreq + deltaFrequency;
 			trxSetFrequency(currentChannelData->rxFreq,currentChannelData->txFreq,DMR_MODE_AUTO);
 
-			if (!trxCheckFrequencyIsSupportedByTheRadioHardware(currentChannelData->txFreq))
+			if (trxGetBandFromFrequency(currentChannelData->txFreq)!=-1)
 			{
-				currentChannelData->txFreq = frequency;
-				set_melody(melody_ERROR_beep);
+				set_melody(melody_ACK_beep);
 			}
 			else
 			{
-				set_melody(melody_ACK_beep);
+				currentChannelData->txFreq = frequency;
+				set_melody(melody_ERROR_beep);
+
 			}
 		}
 		else
@@ -560,9 +561,9 @@ static void handleEvent(int buttons, int keys, int events)
 				}
 				else
 				{
-					if(currentChannelData->sql==0)			//If we were using default squelch level
+					if(currentChannelData->sql == 0)			//If we were using default squelch level
 					{
-						currentChannelData->sql=10;			//start the adjustment from that point.
+						currentChannelData->sql = nonVolatileSettings.squelchDefaults[trxCurrentBand[TRX_RX_FREQ_BAND]];			//start the adjustment from that point.
 					}
 					else
 					{
@@ -628,9 +629,9 @@ static void handleEvent(int buttons, int keys, int events)
 				}
 				else
 				{
-					if(currentChannelData->sql==0)			//If we were using default squelch level
+					if(currentChannelData->sql == 0) //If we were using default squelch level
 					{
-						currentChannelData->sql=10;			//start the adjustment from that point.
+						currentChannelData->sql = nonVolatileSettings.squelchDefaults[trxCurrentBand[TRX_RX_FREQ_BAND]];//start the adjustment from that point.
 					}
 					else
 					{
@@ -663,7 +664,7 @@ static void handleEvent(int buttons, int keys, int events)
 		else if (KEYCHECK_SHORTUP(keys, KEY_GREEN))
 		{
 			int tmp_frequency=read_freq_enter_digits();
-			if (trxCheckFrequencyIsSupportedByTheRadioHardware(tmp_frequency))
+			if (trxGetBandFromFrequency(tmp_frequency)!=-1)
 			{
 				update_frequency(tmp_frequency);
 				reset_freq_enter_digits();
@@ -686,7 +687,7 @@ static void handleEvent(int buttons, int keys, int events)
 			if (freq_enter_idx==8)
 			{
 				int tmp_frequency=read_freq_enter_digits();
-				if (trxCheckFrequencyIsSupportedByTheRadioHardware(tmp_frequency))
+				if (trxGetBandFromFrequency(tmp_frequency)!=-1)
 				{
 					update_frequency(tmp_frequency);
 					reset_freq_enter_digits();
@@ -720,7 +721,7 @@ static void stepFrequency(int increment)
 		tmp_frequencyRx  = currentChannelData->rxFreq + increment;
 		tmp_frequencyTx  = currentChannelData->txFreq + increment;
 	}
-	if (trxCheckFrequencyIsSupportedByTheRadioHardware(tmp_frequencyRx))
+	if (trxGetBandFromFrequency(tmp_frequencyRx)!=-1)
 	{
 		currentChannelData->txFreq = tmp_frequencyTx;
 		currentChannelData->rxFreq =  tmp_frequencyRx;


### PR DESCRIPTION
I'm doing this a pull request to myself as its quite a complicated change and will be easier to review.

The initial purpose was to add squelch defaults in the Options for VHF, 220Mhz and UHF bands.

But I realised that the squelch code would need to constantly check which band was in use, so I added a new variable to old the current Rx and Tx band etc, and modified the code which used code that does a band lookup from the frequency.

This ended up being a much bigger change than I anticipated, but I think does improve things, as there is not so much need to lookup the band from the frequency.

