### PR TITLE
Checking if new root menu is MENU_MAIN_MENU in menuSystemPopAllAndDisplaySpecificRootMenu(), as it should display [1] instead of [0].

### DIFF
--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -152,7 +152,7 @@ void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu)
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
 	menuControlData.stack[0]  = newRootMenu;
 	menuControlData.stackPosition = 0;
-	gMenusCurrentItemIndex = 0;
+	gMenusCurrentItemIndex = (newRootMenu == MENU_MAIN_MENU) ? 1 : 0;
 	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0,0,0,true);
 	fw_reset_keyboard();
 }


### PR DESCRIPTION
Forgotten one.
