### PR TITLE
Fix a buffer overflow when using All_Channels zone.

### DIFF
--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -50,10 +50,12 @@ void menuDisplayEntry(int loopOffset, int focusedItem,const char *entryText);
 int menuGetMenuOffset(int maxMenuEntries, int loopOffset);
 
 void menuChannelModeUpdateScreen(int txTimeSecs);
+void menuChannelColdStart();
 void menuVFOModeUpdateScreen(int txTimeSecs);
 void menuCPSUpdate(int command,int x, int y, UC1701_Font_t fontSize, UC1701_Text_Align_t alignment, bool isInverted,char *szMsg);
 
 void menuInitMenuSystem(void);
+void menuSystemLanguageHasChanged(void);
 void displayLightTrigger(void);
 void displayLightOverrideTimeout(int timeout);
 void menuSystemPushNewMenu(int menuNumber);

--- a/firmware/source/functions/fw_codeplug.c
+++ b/firmware/source/functions/fw_codeplug.c
@@ -134,13 +134,14 @@ int codeplugZonesGetCount(void)
 	return numZones+1; // Add one extra zone to allow for the special 'All Channels' Zone
 }
 
-void codeplugZoneGetDataForNumber(int zoneNum,struct_codeplugZone_t *returnBuf)
+void codeplugZoneGetDataForNumber(int zoneNum, struct_codeplugZone_t *returnBuf)
 {
-
 
 	if (zoneNum==codeplugZonesGetCount()-1) //special case: return a special Zone called 'All Channels'
 	{
-		sprintf(returnBuf->name,currentLanguage->all_channels);
+		memset(returnBuf->name, 0, sizeof(returnBuf->name));
+		strncpy(returnBuf->name, currentLanguage->all_channels, sizeof(returnBuf->name) - 1);
+
 		for(int i=0;i<codeplugChannelsPerZone;i++)
 		{
 			returnBuf->channels[i]=0;

--- a/firmware/source/user_interface/menuLanguage.c
+++ b/firmware/source/user_interface/menuLanguage.c
@@ -72,6 +72,7 @@ static void handleEvent(int buttons, int keys, int events)
 	{
 		nonVolatileSettings.languageIndex = gMenusCurrentItemIndex;
 		currentLanguage = &languages[gMenusCurrentItemIndex];
+		menuSystemLanguageHasChanged();
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -138,6 +138,7 @@ void menuSystemPopPreviousMenu(void)
 	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0,0,0,true);
 	fw_reset_keyboard();
 }
+
 void menuSystemPopAllAndDisplayRootMenu(void)
 {
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
@@ -200,6 +201,13 @@ void menuInitMenuSystem(void)
 	gMenusCurrentItemIndex = 0;
 	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0,0,0,true);// Init and display this screen
 }
+
+void menuSystemLanguageHasChanged(void)
+{
+	// Force full update of menuChannelMode() on next call (if isFirstRun arg. is true)
+	menuChannelColdStart();
+}
+
 
 /*
 const char menuStringTable[32][17] = { "",//0

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -58,6 +58,7 @@ static int nuisanceDeleteIndex = 0;
 
 int menuChannelMode(int buttons, int keys, int events, bool isFirstRun)
 {
+
 	if (isFirstRun)
 	{
 		nonVolatileSettings.initialMenuNumber = MENU_CHANNEL_MODE;// This menu.
@@ -71,8 +72,8 @@ int menuChannelMode(int buttons, int keys, int events, bool isFirstRun)
 		else
 		{
 			isTxRxFreqSwap = false;
-			codeplugZoneGetDataForNumber(nonVolatileSettings.currentZone,&currentZone);
-			codeplugUtilConvertBufToString(currentZone.name,currentZoneName,16);// need to convert to zero terminated string
+			codeplugZoneGetDataForNumber(nonVolatileSettings.currentZone, &currentZone);
+			codeplugUtilConvertBufToString(currentZone.name, currentZoneName, 16);// need to convert to zero terminated string
 			loadChannelData(false);
 		}
 
@@ -1033,4 +1034,10 @@ static void scanning(void)
 			}
 		}
 	}
+}
+
+void menuChannelColdStart(void)
+{
+	// Force to re-read codeplug data (needed due to "All Channels" translation)
+	channelScreenChannelData.rxFreq = 0;
 }


### PR DESCRIPTION
Fix a bug when using All_Channels and switching language, everything is messed up. Now, menuChannelMode() is forced to do a cold start if language has changed.