### PR TITLE
Change menuFunction()s and handleEvent() prototypes, use a new ui_event_t struct to propagate the events.

### DIFF
--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -19,16 +19,24 @@
 #define _FW_MENUSYSTEM_H_
 #include "fw_main.h"
 
+typedef struct
+{
+	int      buttons;
+	int      keys;
+	int      events;
+	bool     hasEvent;
+	uint32_t ticks;
+} ui_event_t;
+
 #define MENU_MAX_DISPLAYED_ENTRIES 3
 #define MENU_INC(O, M) do { O = (O + 1) % M; } while(0)
 #define MENU_DEC(O, M) do { O = (O + M - 1) % M; } while(0)
 
 extern bool uiChannelModeScanActive;
 extern int menuDisplayLightTimer;
-extern int menuTimer;
 
 
-typedef int (*MenuFunctionPointer_t)(int,int,int,bool); // Typedef for menu function pointers.  Functions are passed the key, the button and the event data. Event can be a Key or a button or both. Last arg is for when the function is only called to initialise and display its screen.
+typedef int (*MenuFunctionPointer_t)(ui_event_t *,bool); // Typedef for menu function pointers.  Functions are passed the key, the button and the event data. Event can be a Key or a button or both. Last arg is for when the function is only called to initialise and display its screen.
 typedef struct menuControlDataStruct
 {
 	int currentMenuNumber;
@@ -67,7 +75,7 @@ void menuSystemPopPreviousMenu(void);
 void menuSystemPopAllAndDisplayRootMenu(void);
 void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu);
 
-void menuSystemCallCurrentMenuTick(int buttons, int keys, int events);
+void menuSystemCallCurrentMenuTick(ui_event_t *ev);
 
 /*
  * ---------------------- IMPORTANT ----------------------------

--- a/firmware/include/user_interface/menuUtilityQSOData.h
+++ b/firmware/include/user_interface/menuUtilityQSOData.h
@@ -17,6 +17,7 @@
  */
 #ifndef _MENU_UTILITY_QSO_DATA_H_
 #define _MENU_UTILITY_QSO_DATA_H_                    /**< Symbol preventing repeated inclusion */
+#include <user_interface/menuSystem.h>
 #include "fw_common.h"
 
 #define NUM_LASTHEARD_STORED 16
@@ -55,15 +56,14 @@ extern int menuDisplayQSODataState;
 extern int qsodata_timer;
 extern uint32_t menuUtilityReceivedPcId;
 extern uint32_t menuUtilityTgBeforePcMode;
-extern int RssiUpdateCounter;
-extern const int RSSI_UPDATE_COUNTER_RELOAD;
+extern const uint32_t RSSI_UPDATE_COUNTER_RELOAD;
 
 bool dmrIDLookup(int targetId, dmrIdDataStruct_t *foundRecord);
 void menuUtilityRenderQSOData(void);
 void menuUtilityRenderHeader(void);
 void lastheardInitList(void);
 bool lastHeardListUpdate(uint8_t *dmrDataBuffer);
-bool menuUtilityHandlePrivateCallActions(int buttons, int keys, int events);
+bool menuUtilityHandlePrivateCallActions(ui_event_t *ev);
 void lastHeardClearLastID(void);
 void drawRSSIBarGraph(void);
 void drawDMRMicLevelBarGraph(void);

--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include <functions/fw_ticks.h>
 #include <user_interface/menuSystem.h>
 #include <user_interface/menuUtilityQSOData.h>
 #include "fw_main.h"
@@ -61,6 +62,10 @@ void fw_main_task(void *data)
 	int key_event;
 	uint32_t buttons;
 	int button_event;
+	ui_event_t ev = { .buttons = 0, .keys = 0, .events = 0, .hasEvent = false, .ticks = 0 };
+	int oldButtons = 0;
+	int oldKeys = 0;
+	int oldEvents = 0;
 	
     USB_DeviceApplicationInit();
 
@@ -267,7 +272,17 @@ void fw_main_task(void *data)
     			updateLastHeard=false;
     		}
 
-        	menuSystemCallCurrentMenuTick(buttons,keys,(button_event<<1) | key_event);
+    		ev.buttons = buttons;
+    		ev.keys = keys;
+    		ev.events = (button_event<<1) | key_event;
+    		ev.hasEvent = (ev.buttons != oldButtons) || (ev.keys != oldKeys) || (ev.events != oldEvents);
+    		ev.ticks = fw_millis();
+
+    		oldButtons = ev.buttons;
+    		oldKeys = ev.keys;
+    		oldEvents = ev.events;
+
+        	menuSystemCallCurrentMenuTick(&ev);
 
         	if (((GPIO_PinRead(GPIO_Power_Switch, Pin_Power_Switch)!=0)
         			|| (battery_voltage<CUTOFF_VOLTAGE_LOWER_HYST))

--- a/firmware/source/user_interface/menuBattery.c
+++ b/firmware/source/user_interface/menuBattery.c
@@ -19,27 +19,26 @@
 #include <user_interface/uiLocalisation.h>
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
-static int updateCounter;
+static void handleEvent(ui_event_t *ev);
 
-int menuBattery(int buttons, int keys, int events, bool isFirstRun)
+int menuBattery(ui_event_t *ev, bool isFirstRun)
 {
+	static uint32_t m = 0;
+
 	if (isFirstRun)
 	{
-		updateCounter=0;
 		updateScreen();
 	}
 	else
 	{
-		if (++updateCounter > 10000)
+		if ((ev->ticks - m) > 10000)
 		{
-			updateCounter=0;
+			m = ev->ticks;
 			updateScreen();// update the screen once per second to show any changes to the battery voltage
 		}
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -47,7 +46,7 @@ int menuBattery(int buttons, int keys, int events, bool isFirstRun)
 static void updateScreen(void)
 {
 	const int MAX_BATTERY_BAR_HEIGHT = 36;
-	char buffer[33];
+	char buffer[17];
 
 	UC1701_clearBuf();
 	menuDisplayTitle(currentLanguage->battery);
@@ -78,14 +77,14 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_GREEN))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -25,7 +25,7 @@
 #include "fw_settings.h"
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
 static int CTCSSRxIndex=0;
 static int CTCSSTxIndex=0;
@@ -35,7 +35,7 @@ enum CHANNEL_DETAILS_DISPLAY_LIST { CH_DETAILS_MODE = 0, CH_DETAILS_DMR_CC, CH_D
 									CH_DETAILS_FREQ_STEP, CH_DETAILS_TOT, CH_DETAILS_ZONE_SKIP,CH_DETAILS_ALL_SKIP,CH_DETAILS_RXGROUP,
 									NUM_CH_DETAILS_ITEMS};// The last item in the list is used so that we automatically get a total number of items in the list
 
-int menuChannelDetails(int buttons, int keys, int events, bool isFirstRun)
+int menuChannelDetails(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -56,10 +56,8 @@ int menuChannelDetails(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -208,20 +206,20 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
 	int tmpVal;
 	struct_codeplugRxGroup_t rxGroupBuf;
 
-	if (KEYCHECK_PRESS(keys,KEY_DOWN))
+	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 	{
 		MENU_INC(gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_RIGHT))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 	{
 		switch(gMenusCurrentItemIndex)
 		{
@@ -307,7 +305,7 @@ static void handleEvent(int buttons, int keys, int events)
 				break;
 		}
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_LEFT))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 	{
 		switch(gMenusCurrentItemIndex)
 		{
@@ -394,7 +392,7 @@ static void handleEvent(int buttons, int keys, int events)
 
 		}
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		memcpy(currentChannelData,&tmpChannel,sizeof(struct_codeplugChannel_t));
 
@@ -408,7 +406,7 @@ static void handleEvent(int buttons, int keys, int events)
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;

--- a/firmware/source/user_interface/menuContactDetails.c
+++ b/firmware/source/user_interface/menuContactDetails.c
@@ -25,7 +25,7 @@
 #include "fw_settings.h"
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
 static struct_codeplugContact_t tmpContact;
 static const char *callTypeString[3];// = { "Group", "Private", "All" };
@@ -39,7 +39,7 @@ static int menuContactDetailsState;
 static int menuContactDetailsTimeout;
 enum MENU_CONTACT_DETAILS_STATE {MENU_CONTACT_DETAILS_DISPLAY=0, MENU_CONTACT_DETAILS_SAVED, MENU_CONTACT_DETAILS_EXISTS};
 
-int menuContactDetails(int buttons, int keys, int events, bool isFirstRun)
+int menuContactDetails(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -66,9 +66,9 @@ int menuContactDetails(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if ((events!=0 && keys!=0) || menuContactDetailsTimeout > 0)
+		if (ev->hasEvent || (menuContactDetailsTimeout > 0))
 		{
-			handleEvent(buttons, keys, events);
+			handleEvent(ev);
 
 		}
 	}
@@ -156,7 +156,7 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
 	dmrIdDataStruct_t foundRecord;
 	static const int bufferLen = 17;
@@ -165,16 +165,16 @@ static void handleEvent(int buttons, int keys, int events)
 
 	switch (menuContactDetailsState) {
 	case MENU_CONTACT_DETAILS_DISPLAY:
-		if (events & 0x01) {
-			if (KEYCHECK_PRESS(keys,KEY_DOWN))
+		if (ev->events & 0x01) {
+			if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 			{
 				MENU_INC(gMenusCurrentItemIndex, NUM_CONTACT_DETAILS_ITEMS);
 			}
-			else if (KEYCHECK_PRESS(keys,KEY_UP))
+			else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 			{
 				MENU_DEC(gMenusCurrentItemIndex, NUM_CONTACT_DETAILS_ITEMS);
 			}
-			else if (KEYCHECK_PRESS(keys,KEY_RIGHT))
+			else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 			{
 				switch(gMenusCurrentItemIndex)
 				{
@@ -201,7 +201,7 @@ static void handleEvent(int buttons, int keys, int events)
 					break;
 				}
 			}
-			else if (KEYCHECK_PRESS(keys,KEY_LEFT))
+			else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 			{
 				switch(gMenusCurrentItemIndex)
 				{
@@ -232,7 +232,7 @@ static void handleEvent(int buttons, int keys, int events)
 					break;
 				}
 			}
-			else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+			else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 			{
 				if (tmpContact.callType == CONTACT_CALLTYPE_ALL)
 				{
@@ -284,7 +284,7 @@ static void handleEvent(int buttons, int keys, int events)
 					}
 				}
 			}
-			else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+			else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 			{
 //				contactListContactIndex = 0;
 				menuSystemPopPreviousMenu();
@@ -296,43 +296,43 @@ static void handleEvent(int buttons, int keys, int events)
 				{
 					char c[2] = {0, 0};
 
-					if (KEYCHECK_PRESS(keys,KEY_0))
+					if (KEYCHECK_PRESS(ev->keys,KEY_0))
 					{
 						c[0]='0';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_1))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_1))
 					{
 						c[0]='1';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_2))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_2))
 					{
 						c[0]='2';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_3))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_3))
 					{
 						c[0]='3';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_4))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_4))
 					{
 						c[0]='4';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_5))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_5))
 					{
 						c[0]='5';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_6))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_6))
 					{
 						c[0]='6';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_7))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_7))
 					{
 						c[0]='7';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_8))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_8))
 					{
 						c[0]='8';
 					}
-					else if (KEYCHECK_PRESS(keys,KEY_9))
+					else if (KEYCHECK_PRESS(ev->keys,KEY_9))
 					{
 						c[0]='9';
 					}
@@ -349,7 +349,7 @@ static void handleEvent(int buttons, int keys, int events)
 		break;
 	case MENU_CONTACT_DETAILS_SAVED:
         menuContactDetailsTimeout--;
-		if ((menuContactDetailsTimeout == 0) || (KEYCHECK_SHORTUP(keys, KEY_GREEN)))
+		if ((menuContactDetailsTimeout == 0) || (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN)))
 		{
 			contactListContactIndex = 0;
 			menuSystemPopPreviousMenu();
@@ -360,7 +360,7 @@ static void handleEvent(int buttons, int keys, int events)
 		break;
 	case MENU_CONTACT_DETAILS_EXISTS:
         menuContactDetailsTimeout--;
-		if ((menuContactDetailsTimeout == 0) || (KEYCHECK_SHORTUP(keys, KEY_GREEN)))
+		if ((menuContactDetailsTimeout == 0) || (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN)))
 		{
 			menuContactDetailsState = MENU_CONTACT_DETAILS_DISPLAY;
 		}

--- a/firmware/source/user_interface/menuContactList.c
+++ b/firmware/source/user_interface/menuContactList.c
@@ -23,7 +23,7 @@
 #include "fw_settings.h"
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 static struct_codeplugContact_t contact;
 static int contactCallType;
 static int menuContactListDisplayState;
@@ -49,7 +49,7 @@ static void reloadContactList(void)
 	}
 }
 
-int menuContactList(int buttons, int keys, int events, bool isFirstRun)
+int menuContactList(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -68,9 +68,9 @@ int menuContactList(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if ((events!=0 && keys!=0) || menuContactListTimeout > 0)
+		if (ev->hasEvent || (menuContactListTimeout > 0))
 		{
-			handleEvent(buttons, keys, events);
+			handleEvent(ev);
 		}
 	}
 	return 0;
@@ -133,12 +133,12 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
 	switch (menuContactListDisplayState)
 	{
 	case MENU_CONTACT_LIST_DISPLAY:
-		if (KEYCHECK_PRESS(keys, KEY_DOWN))
+		if (KEYCHECK_PRESS(ev->keys, KEY_DOWN))
 		{
 			MENU_INC(gMenusCurrentItemIndex, gMenusEndIndex);
 			contactListContactIndex = codeplugContactGetDataForNumber(
@@ -146,7 +146,7 @@ static void handleEvent(int buttons, int keys, int events)
 					&contactListContactData);
 			updateScreen();
 		}
-		else if (KEYCHECK_PRESS(keys, KEY_UP))
+		else if (KEYCHECK_PRESS(ev->keys, KEY_UP))
 		{
 			MENU_DEC(gMenusCurrentItemIndex, gMenusEndIndex);
 			contactListContactIndex = codeplugContactGetDataForNumber(
@@ -154,7 +154,7 @@ static void handleEvent(int buttons, int keys, int events)
 					&contactListContactData);
 			updateScreen();
 		}
-		else if (KEYCHECK_SHORTUP(keys, KEY_HASH))
+		else if (KEYCHECK_SHORTUP(ev->keys, KEY_HASH))
 		{
 			if (contactCallType == CONTACT_CALLTYPE_TG)
 			{
@@ -167,7 +167,7 @@ static void handleEvent(int buttons, int keys, int events)
 			reloadContactList();
 			updateScreen();
 		}
-		else if (KEYCHECK_SHORTUP(keys, KEY_GREEN))
+		else if (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN))
 		{
 			if (menuSystemGetCurrentMenuNumber() == MENU_CONTACT_QUICKLIST)
 			{
@@ -180,7 +180,7 @@ static void handleEvent(int buttons, int keys, int events)
 				return;
 			}
 		}
-		else if (KEYCHECK_SHORTUP(keys, KEY_RED))
+		else if (KEYCHECK_SHORTUP(ev->keys, KEY_RED))
 		{
 			contactListContactIndex = 0;
 			menuSystemPopPreviousMenu();
@@ -189,7 +189,7 @@ static void handleEvent(int buttons, int keys, int events)
 		break;
 
 	case MENU_CONTACT_LIST_CONFIRM:
-		if (KEYCHECK_SHORTUP(keys, KEY_GREEN))
+		if (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN))
 		{
 			memset(contact.name, 0xff, 16);
 			contact.tgNumber = 0;
@@ -201,7 +201,7 @@ static void handleEvent(int buttons, int keys, int events)
 			reloadContactList();
 			updateScreen();
 		}
-		else if (KEYCHECK_SHORTUP(keys, KEY_RED))
+		else if (KEYCHECK_SHORTUP(ev->keys, KEY_RED))
 		{
 			menuContactListDisplayState = MENU_CONTACT_LIST_DISPLAY;
 			reloadContactList();
@@ -212,7 +212,7 @@ static void handleEvent(int buttons, int keys, int events)
 	case MENU_CONTACT_LIST_DELETED:
 	case MENU_CONTACT_LIST_TG_IN_RXGROUP:
 		menuContactListTimeout--;
-		if ((menuContactListTimeout == 0) || KEYCHECK_SHORTUP(keys, KEY_GREEN) || KEYCHECK_SHORTUP(keys, KEY_RED))
+		if ((menuContactListTimeout == 0) || KEYCHECK_SHORTUP(ev->keys, KEY_GREEN) || KEYCHECK_SHORTUP(ev->keys, KEY_RED))
 		{
 			menuContactListDisplayState = MENU_CONTACT_LIST_DISPLAY;
 			reloadContactList();

--- a/firmware/source/user_interface/menuCredits.c
+++ b/firmware/source/user_interface/menuCredits.c
@@ -19,7 +19,7 @@
 #include <user_interface/uiLocalisation.h>
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 static void scrollDownOneLine(void);
 
 //#define CREDIT_TEXT_LENGTH 33
@@ -28,20 +28,17 @@ const int NUM_CREDITS = 6;
 static const char *creditTexts[] = {"Roger VK3KYY","Kai DG4KLU","Jason VK7ZJA","Alex DL4LEX","Daniel F1RMB","Colin G4EML"};
 static int currentDisplayIndex=0;
 
-int menuCredits(int buttons, int keys, int events, bool isFirstRun)
+int menuCredits(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
 		gMenusCurrentItemIndex=5000;
-		menuTimer = 3000;
 		updateScreen();
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 /*
  * Uncomment to enable auto scrolling
 		if ((gMenusCurrentItemIndex--)==0)
@@ -79,19 +76,19 @@ static void scrollDownOneLine(void)
 	updateScreen();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
 
-	if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_DOWN))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 	{
 		scrollDownOneLine();
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		if (currentDisplayIndex>0)
 		{
@@ -99,7 +96,7 @@ static void handleEvent(int buttons, int keys, int events)
 		}
 		updateScreen();
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;

--- a/firmware/source/user_interface/menuDisplayMenuList.c
+++ b/firmware/source/user_interface/menuDisplayMenuList.c
@@ -20,9 +20,9 @@
 #include "fw_main.h"
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
-int menuDisplayMenuList(int buttons, int keys, int events, bool isFirstRun)
+int menuDisplayMenuList(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -33,10 +33,8 @@ int menuDisplayMenuList(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -61,17 +59,17 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_PRESS(keys,KEY_DOWN))
+	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 	{
 		MENU_INC(gMenusCurrentItemIndex, gMenusEndIndex);
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, gMenusEndIndex);
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		if (gMenuCurrentMenuList[gMenusCurrentItemIndex].menuNum!=-1)
 		{
@@ -79,19 +77,19 @@ static void handleEvent(int buttons, int keys, int events)
 		}
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_STAR) && (menuSystemGetCurrentMenuNumber() == MENU_MAIN_MENU))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_STAR) && (menuSystemGetCurrentMenuNumber() == MENU_MAIN_MENU))
 	{
 		keypadLocked = true;
 		menuSystemPopAllAndDisplayRootMenu();
 		menuSystemPushNewMenu(MENU_LOCK_SCREEN);
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_HASH) && (menuSystemGetCurrentMenuNumber() == MENU_MAIN_MENU))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_HASH) && (menuSystemGetCurrentMenuNumber() == MENU_MAIN_MENU))
 	{
 		PTTLocked = true;
 		menuSystemPopAllAndDisplayRootMenu();

--- a/firmware/source/user_interface/menuDisplayOptions.c
+++ b/firmware/source/user_interface/menuDisplayOptions.c
@@ -21,7 +21,7 @@
 #include "fw_settings.h"
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
 static uint8_t originalBrightness;
 static uint8_t contrast;
@@ -33,7 +33,7 @@ const int CONTRAST_MAX_VALUE = 30;// Maximum value which still seems to be reada
 const int CONTRAST_MIN_VALUE = 12;// Minimum value which still seems to be readable
 enum DISPLAY_MENU_LIST { DISPLAY_MENU_BRIGHTNESS = 0, DISPLAY_MENU_CONTRAST, DISPLAY_MENU_TIMEOUT, DISPLAY_MENU_COLOUR_INVERT, NUM_DISPLAY_MENU_ITEMS};
 
-int menuDisplayOptions(int buttons, int keys, int events, bool isFirstRun)
+int menuDisplayOptions(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -45,10 +45,8 @@ int menuDisplayOptions(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -99,17 +97,17 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_PRESS(keys,KEY_DOWN) && gMenusEndIndex!=0)
+	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
 		MENU_INC(gMenusCurrentItemIndex, NUM_DISPLAY_MENU_ITEMS);
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, NUM_DISPLAY_MENU_ITEMS);
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_RIGHT))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 	{
 		switch(gMenusCurrentItemIndex)
 		{
@@ -149,7 +147,7 @@ static void handleEvent(int buttons, int keys, int events)
 				break;
 		}
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_LEFT))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 	{
 		switch(gMenusCurrentItemIndex)
 		{
@@ -189,7 +187,7 @@ static void handleEvent(int buttons, int keys, int events)
 				break;
 		}
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		nonVolatileSettings.displayInverseVideo = inverseVideo;
 		nonVolatileSettings.displayContrast = contrast;
@@ -198,7 +196,7 @@ static void handleEvent(int buttons, int keys, int events)
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		if (nonVolatileSettings.displayContrast != contrast || nonVolatileSettings.displayInverseVideo != inverseVideo)
 		{

--- a/firmware/source/user_interface/menuFirmwareInfoScreen.c
+++ b/firmware/source/user_interface/menuFirmwareInfoScreen.c
@@ -19,21 +19,18 @@
 #include <user_interface/uiLocalisation.h>
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
-int menuFirmwareInfoScreen(int buttons, int keys, int events, bool isFirstRun)
+int menuFirmwareInfoScreen(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
-		menuTimer = 3000;// Increased so its easier to see what version of fw is being run
 		updateScreen();
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -56,14 +53,14 @@ static void updateScreen(void)
 }
 
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_PRESS(keys,KEY_RED))
+	if (KEYCHECK_PRESS(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_GREEN))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;

--- a/firmware/source/user_interface/menuLanguage.c
+++ b/firmware/source/user_interface/menuLanguage.c
@@ -21,10 +21,10 @@
 
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
 
-int menuLanguage(int buttons, int keys, int events, bool isFirstRun)
+int menuLanguage(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -32,10 +32,8 @@ int menuLanguage(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -58,17 +56,17 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_PRESS(keys,KEY_DOWN) && gMenusEndIndex!=0)
+	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
 		MENU_INC(gMenusCurrentItemIndex, NUM_LANGUAGES);
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, NUM_LANGUAGES);
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		nonVolatileSettings.languageIndex = gMenusCurrentItemIndex;
 		currentLanguage = &languages[gMenusCurrentItemIndex];
@@ -76,7 +74,7 @@ static void handleEvent(int buttons, int keys, int events)
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -21,9 +21,9 @@
 const int LAST_HEARD_NUM_LINES_ON_DISPLAY = 3;
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
-int menuLastHeard(int buttons, int keys, int events, bool isFirstRun)
+int menuLastHeard(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -41,10 +41,9 @@ int menuLastHeard(int buttons, int keys, int events, bool isFirstRun)
 			gMenusEndIndex=0;
 			updateScreen();
 		}
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -106,14 +105,14 @@ static void updateScreen(void)
 	menuDisplayQSODataState = QSO_DISPLAY_IDLE;
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
 
-	if (KEYCHECK_PRESS(keys,KEY_DOWN) && gMenusEndIndex!=0)
+	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
 		gMenusCurrentItemIndex++;
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		gMenusCurrentItemIndex--;
 		if (gMenusCurrentItemIndex<0)
@@ -121,12 +120,12 @@ static void handleEvent(int buttons, int keys, int events)
 			gMenusCurrentItemIndex=0;
 		}
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;

--- a/firmware/source/user_interface/menuMessageScreen.c
+++ b/firmware/source/user_interface/menuMessageScreen.c
@@ -19,10 +19,10 @@
 #include <user_interface/menuSystem.h>
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 static int updateCounter;
 
-int menuMessageScreen(int buttons, int keys, int events, bool isFirstRun)
+int menuMessageScreen(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -31,10 +31,8 @@ int menuMessageScreen(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -51,14 +49,14 @@ static void updateScreen(void)
 }
 
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;

--- a/firmware/source/user_interface/menuOptions.c
+++ b/firmware/source/user_interface/menuOptions.c
@@ -21,7 +21,7 @@
 #include "fw_wdog.h"
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 static bool	doFactoryReset;
 enum OPTIONS_MENU_LIST { OPTIONS_MENU_TIMEOUT_BEEP=0,OPTIONS_MENU_FACTORY_RESET,OPTIONS_MENU_USE_CALIBRATION,
 							OPTIONS_MENU_TX_FREQ_LIMITS,OPTIONS_MENU_BEEP_VOLUME,OPTIONS_MIC_GAIN_DMR,
@@ -31,7 +31,7 @@ enum OPTIONS_MENU_LIST { OPTIONS_MENU_TIMEOUT_BEEP=0,OPTIONS_MENU_FACTORY_RESET,
 							NUM_OPTIONS_MENU_ITEMS};
 
 
-int menuOptions(int buttons, int keys, int events, bool isFirstRun)
+int menuOptions(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -40,10 +40,8 @@ int menuOptions(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -153,17 +151,17 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_PRESS(keys,KEY_DOWN) && gMenusEndIndex!=0)
+	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
 		MENU_INC(gMenusCurrentItemIndex, NUM_OPTIONS_MENU_ITEMS);
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, NUM_OPTIONS_MENU_ITEMS);
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_RIGHT))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 	{
 		switch(gMenusCurrentItemIndex)
 		{
@@ -243,7 +241,7 @@ static void handleEvent(int buttons, int keys, int events)
 
 		}
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_LEFT))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 	{
 
 		switch(gMenusCurrentItemIndex)
@@ -323,7 +321,7 @@ static void handleEvent(int buttons, int keys, int events)
 				break;
 		}
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		if (doFactoryReset==true)
 		{
@@ -333,7 +331,7 @@ static void handleEvent(int buttons, int keys, int events)
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;

--- a/firmware/source/user_interface/menuRSSIScreen.c
+++ b/firmware/source/user_interface/menuRSSIScreen.c
@@ -24,26 +24,25 @@
 
 static calibrationRSSIMeter_t rssiCalibration;
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
-int menuRSSIScreen(int buttons, int keys, int events, bool isFirstRun)
+int menuRSSIScreen(ui_event_t *ev, bool isFirstRun)
 {
+	static uint32_t m = 0;
+
 	if (isFirstRun)
 	{
-		RssiUpdateCounter = RSSI_UPDATE_COUNTER_RELOAD;
 		calibrationGetRSSIMeterParams(&rssiCalibration);
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 
-		if (RssiUpdateCounter-- == 0)
+		if((ev->ticks - m) > RSSI_UPDATE_COUNTER_RELOAD)
 		{
+			m = ev->ticks;
 			updateScreen();
-			RssiUpdateCounter = RSSI_UPDATE_COUNTER_RELOAD;
 		}
 	}
 	return 0;
@@ -97,14 +96,14 @@ static void updateScreen(void)
 }
 
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -17,40 +17,40 @@
  */
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiLocalisation.h>
+#include <functions/fw_ticks.h>
 #include "fw_settings.h"
 
 int menuDisplayLightTimer=-1;
-int menuTimer;
 menuItemNew_t *gMenuCurrentMenuList;
 
 menuControlDataStruct_t menuControlData = { .stackPosition = 0, .stack = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, .itemIndex = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}};
 
 
-int menuVFOMode(int buttons, int keys, int events, bool isFirstRun);
-int menuVFOModeQuickMenu(int buttons, int keys, int events, bool isFirstRun);
-int menuChannelMode(int buttons, int keys, int events, bool isFirstRun);
-int menuChannelModeQuickMenu(int buttons, int keys, int events, bool isFirstRun);
-int menuZoneList(int buttons, int keys, int events, bool isFirstRun);
-int menuDisplayMenuList(int buttons, int keys, int events, bool isFirstRun);
-int menuBattery(int buttons, int keys, int events, bool isFirstRun);
-int menuSplashScreen(int buttons, int keys, int events, bool isFirstRun);
-int menuPowerOff(int buttons, int keys, int events, bool isFirstRun);
-int menuFirmwareInfoScreen(int buttons, int keys, int events, bool isFirstRun);
-int menuNumericalEntry(int buttons, int keys, int events, bool isFirstRun);
-int menuTxScreen(int buttons, int keys, int events, bool isFirstRun);
-int menuRSSIScreen(int buttons, int keys, int events, bool isFirstRun);
-int menuLastHeard(int buttons, int keys, int events, bool isFirstRun);
-int menuOptions(int buttons, int keys, int events, bool isFirstRun);
-int menuDisplayOptions(int buttons, int keys, int events, bool isFirstRun);
-int menuCredits(int buttons, int keys, int events, bool isFirstRun);
-int menuChannelDetails(int buttons, int keys, int events, bool isFirstRun);
-int menuHotspotMode(int buttons, int keys, int events, bool isFirstRun);
-int menuCPS(int buttons, int keys, int events, bool isFirstRun);
-int menuLockScreen(int buttons, int keys, int events, bool isFirstRun);
-int menuContactList(int buttons, int keys, int events, bool isFirstRun);
-int menuContactListSubMenu(int buttons, int keys, int events, bool isFirstRun);
-int menuContactDetails(int buttons, int keys, int events, bool isFirstRun);
-int menuLanguage(int buttons, int keys, int events, bool isFirstRun);
+int menuVFOMode(ui_event_t *event, bool isFirstRun);
+int menuVFOModeQuickMenu(ui_event_t *event, bool isFirstRun);
+int menuChannelMode(ui_event_t *event, bool isFirstRun);
+int menuChannelModeQuickMenu(ui_event_t *event, bool isFirstRun);
+int menuZoneList(ui_event_t *event, bool isFirstRun);
+int menuDisplayMenuList(ui_event_t *event, bool isFirstRun);
+int menuBattery(ui_event_t *event, bool isFirstRun);
+int menuSplashScreen(ui_event_t *event, bool isFirstRun);
+int menuPowerOff(ui_event_t *event, bool isFirstRun);
+int menuFirmwareInfoScreen(ui_event_t *event, bool isFirstRun);
+int menuNumericalEntry(ui_event_t *event, bool isFirstRun);
+int menuTxScreen(ui_event_t *event, bool isFirstRun);
+int menuRSSIScreen(ui_event_t *event, bool isFirstRun);
+int menuLastHeard(ui_event_t *event, bool isFirstRun);
+int menuOptions(ui_event_t *event, bool isFirstRun);
+int menuDisplayOptions(ui_event_t *event, bool isFirstRun);
+int menuCredits(ui_event_t *event, bool isFirstRun);
+int menuChannelDetails(ui_event_t *event, bool isFirstRun);
+int menuHotspotMode(ui_event_t *event, bool isFirstRun);
+int menuCPS(ui_event_t *event, bool isFirstRun);
+int menuLockScreen(ui_event_t *event, bool isFirstRun);
+int menuContactList(ui_event_t *event, bool isFirstRun);
+int menuContactListSubMenu(ui_event_t *event, bool isFirstRun);
+int menuContactDetails(ui_event_t *event, bool isFirstRun);
+int menuLanguage(ui_event_t *event, bool isFirstRun);
 
 /*
  * ---------------------- IMPORTANT ----------------------------
@@ -122,47 +122,57 @@ void menuSystemPushNewMenu(int menuNumber)
 {
 	if (menuControlData.stackPosition < 15)
 	{
+		ui_event_t ev = { .buttons = 0, .keys = 0, .events = 0, .hasEvent = false, .ticks = fw_millis() };
+
 		menuControlData.itemIndex[menuControlData.stackPosition] = gMenusCurrentItemIndex;
 		menuControlData.stackPosition++;
 		menuControlData.stack[menuControlData.stackPosition] = menuNumber;
 		gMenusCurrentItemIndex = (menuNumber == MENU_MAIN_MENU) ? 1 : 0;
-		menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0, 0, 0, true);
+		menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev, true);
 		fw_reset_keyboard();
 	}
 }
 void menuSystemPopPreviousMenu(void)
 {
+	ui_event_t ev = { .buttons = 0, .keys = 0, .events = 0, .hasEvent = false, .ticks = fw_millis() };
+
 	menuControlData.itemIndex[menuControlData.stackPosition] = 0;
 	menuControlData.stackPosition--;
 	gMenusCurrentItemIndex = menuControlData.itemIndex[menuControlData.stackPosition];
-	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0,0,0,true);
+	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev,true);
 	fw_reset_keyboard();
 }
 
 void menuSystemPopAllAndDisplayRootMenu(void)
 {
+	ui_event_t ev = { .buttons = 0, .keys = 0, .events = 0, .hasEvent = false, .ticks = fw_millis() };
+
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
 	menuControlData.stackPosition = 0;
 	gMenusCurrentItemIndex = 0;
-	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0,0,0,true);
+	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev,true);
 	fw_reset_keyboard();
 }
 
 void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu)
 {
+	ui_event_t ev = { .buttons = 0, .keys = 0, .events = 0, .hasEvent = false, .ticks = fw_millis() };
+
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
 	menuControlData.stack[0]  = newRootMenu;
 	menuControlData.stackPosition = 0;
 	gMenusCurrentItemIndex = (newRootMenu == MENU_MAIN_MENU) ? 1 : 0;
-	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0,0,0,true);
+	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev,true);
 	fw_reset_keyboard();
 }
 
 void menuSystemSetCurrentMenu(int menuNumber)
 {
+	ui_event_t ev = { .buttons = 0, .keys = 0, .events = 0, .hasEvent = false, .ticks = fw_millis() };
+
 	menuControlData.stack[menuControlData.stackPosition] = menuNumber;
 	gMenusCurrentItemIndex = menuControlData.itemIndex[menuControlData.stackPosition];
-	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0,0,0,true);
+	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev,true);
 	fw_reset_keyboard();
 }
 int menuSystemGetCurrentMenuNumber(void)
@@ -170,9 +180,9 @@ int menuSystemGetCurrentMenuNumber(void)
 	return menuControlData.stack[menuControlData.stackPosition];
 }
 
-void menuSystemCallCurrentMenuTick(int buttons, int keys, int events)
+void menuSystemCallCurrentMenuTick(ui_event_t *ev)
 {
-	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](buttons,keys,events,false);
+	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](ev,false);
 }
 
 void displayLightTrigger(void)
@@ -196,10 +206,12 @@ int gMenusEndIndex;// as above
 
 void menuInitMenuSystem(void)
 {
+	ui_event_t ev = { .buttons = 0, .keys = 0, .events = 0, .hasEvent = false, .ticks = fw_millis() };
+
 	menuDisplayLightTimer = -1;
 	menuControlData.stack[menuControlData.stackPosition]  = MENU_SPLASH_SCREEN;// set the very first screen as the splash screen
 	gMenusCurrentItemIndex = 0;
-	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](0,0,0,true);// Init and display this screen
+	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev,true);// Init and display this screen
 }
 
 void menuSystemLanguageHasChanged(void)

--- a/firmware/source/user_interface/menuZoneList.c
+++ b/firmware/source/user_interface/menuZoneList.c
@@ -22,9 +22,9 @@
 #include "fw_settings.h"
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
-int menuZoneList(int buttons, int keys, int events, bool isFirstRun)
+int menuZoneList(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -34,10 +34,8 @@ int menuZoneList(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events!=0 && keys!=0)
-		{
-			handleEvent(buttons, keys, events);
-		}
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 	return 0;
 }
@@ -70,19 +68,19 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_PRESS(keys,KEY_DOWN))
+	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 	{
 		MENU_INC(gMenusCurrentItemIndex, gMenusEndIndex);
 		updateScreen();
 	}
-	else if (KEYCHECK_PRESS(keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, gMenusEndIndex);
 		updateScreen();
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		nonVolatileSettings.overrideTG = 0; // remove any TG override
 		nonVolatileSettings.currentZone = gMenusCurrentItemIndex;
@@ -93,7 +91,7 @@ static void handleEvent(int buttons, int keys, int events)
 
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;

--- a/firmware/source/user_interface/uiCPS.c
+++ b/firmware/source/user_interface/uiCPS.c
@@ -28,7 +28,7 @@ static int radioMode;
 static int radioBandWidth;
 
 
-int menuCPS(int buttons, int keys, int events, bool isFirstRun)
+int menuCPS(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -101,6 +101,7 @@ int menuChannelMode(ui_event_t *ev, bool isFirstRun)
 			{
 				if ((ev->ticks - m) > RSSI_UPDATE_COUNTER_RELOAD)
 				{
+					m = ev->ticks;
 					drawRSSIBarGraph();
 					UC1701RenderRows(1,2);// Only render the second row which contains the bar graph, as there is no need to redraw the rest of the screen
 					//UC1701_render();

--- a/firmware/source/user_interface/uiHotspot.c
+++ b/firmware/source/user_interface/uiHotspot.c
@@ -150,7 +150,7 @@ const uint8_t DMR_AUDIO_SEQ_MASK[]  = 		{0x0FU, 0xF0U, 0x00U, 0x00U, 0x00U, 0x0F
 const uint8_t DMR_EMBED_SEQ_MASK[]  = 		{0x00U, 0x0FU, 0xFFU, 0xFFU, 0xFFU, 0xF0U, 0x00U};
 
 static void updateScreen(int rxState);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 void handleHotspotRequest(void);
 /*
  *
@@ -738,7 +738,7 @@ static void hotspotStateMachine(void)
 	}
 }
 
-int menuHotspotMode(int buttons, int keys, int events, bool isFirstRun)
+int menuHotspotMode(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -762,7 +762,8 @@ int menuHotspotMode(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		handleEvent(buttons, keys, events);
+		if (ev->hasEvent)
+			handleEvent(ev);
 	}
 
 	processUSBDataQueue();
@@ -867,9 +868,9 @@ static void updateScreen(int rxCommandState)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		//enableHotspot = false;
 		if (trxIsTransmitting)

--- a/firmware/source/user_interface/uiSplashScreen.c
+++ b/firmware/source/user_interface/uiSplashScreen.c
@@ -19,18 +19,17 @@
 #include "fw_settings.h"
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
-int menuSplashScreen(int buttons, int keys, int events, bool isFirstRun)
+int menuSplashScreen(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
-		menuTimer = 2000;
 		updateScreen();
 	}
 	else
 	{
-		handleEvent(buttons, keys, events);
+		handleEvent(ev);
 	}
 	return 0;
 }
@@ -49,10 +48,17 @@ static void updateScreen(void)
 	displayLightTrigger();
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
-	menuTimer--;
-	if (menuTimer == 0)
+	static uint32_t m = 0;
+
+	if (m == 0)
+	{
+		m = ev->ticks;
+		return;
+	}
+
+	if ((ev->ticks - m) > 2000)
 	{
 		menuSystemSetCurrentMenu(nonVolatileSettings.initialMenuNumber);
 	}

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -23,7 +23,7 @@
 
 
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
 static const int PIT_COUNTS_PER_SECOND = 10000;
 static int timeInSeconds;
@@ -31,7 +31,7 @@ static uint32_t nextSecondPIT;
 
 static int micLevelUpdateCounter=100;
 
-int menuTxScreen(int buttons, int keys, int events, bool isFirstRun)
+int menuTxScreen(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -125,7 +125,8 @@ int menuTxScreen(int buttons, int keys, int events, bool isFirstRun)
 			}
 
 		}
-		handleEvent(buttons, keys, events);
+
+		handleEvent(ev);
 	}
 	return 0;
 }
@@ -145,11 +146,11 @@ static void updateScreen(void)
 	}
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
 	int keyval;
 
-	if ((buttons & BUTTON_PTT) == 0
+	if ((ev->buttons & BUTTON_PTT) == 0
 			|| (currentChannelData->tot != 0 && timeInSeconds == 0))
 	{
 		if (trxIsTransmitting)
@@ -180,9 +181,9 @@ static void handleEvent(int buttons, int keys, int events)
 			}
 		}
 	}
-	if (!trxIsTransmittingTone && (buttons & BUTTON_PTT) != 0 && trxIsTransmitting && trxGetMode() == RADIO_MODE_ANALOG)
+	if (!trxIsTransmittingTone && (ev->buttons & BUTTON_PTT) != 0 && trxIsTransmitting && trxGetMode() == RADIO_MODE_ANALOG)
 	{
-		if ((buttons & BUTTON_SK2) != 0)
+		if ((ev->buttons & BUTTON_SK2) != 0)
 		{
 			trxIsTransmittingTone = true;
 			trxSetTone1(1750);
@@ -193,67 +194,67 @@ static void handleEvent(int buttons, int keys, int events)
 		else
 		{
 			keyval = 99;
-			if (KEYCHECK_DOWN(keys,KEY_0))
+			if (KEYCHECK_DOWN(ev->keys,KEY_0))
 			{
 				keyval = 0;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_1))
+			if (KEYCHECK_DOWN(ev->keys,KEY_1))
 			{
 				keyval = 1;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_2))
+			if (KEYCHECK_DOWN(ev->keys,KEY_2))
 			{
 				keyval = 2;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_3))
+			if (KEYCHECK_DOWN(ev->keys,KEY_3))
 			{
 				keyval = 3;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_4))
+			if (KEYCHECK_DOWN(ev->keys,KEY_4))
 			{
 				keyval = 4;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_5))
+			if (KEYCHECK_DOWN(ev->keys,KEY_5))
 			{
 				keyval = 5;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_6))
+			if (KEYCHECK_DOWN(ev->keys,KEY_6))
 			{
 				keyval = 6;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_7))
+			if (KEYCHECK_DOWN(ev->keys,KEY_7))
 			{
 				keyval = 7;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_8))
+			if (KEYCHECK_DOWN(ev->keys,KEY_8))
 			{
 				keyval = 8;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_9))
+			if (KEYCHECK_DOWN(ev->keys,KEY_9))
 			{
 				keyval = 9;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_LEFT))  // A
+			if (KEYCHECK_DOWN(ev->keys,KEY_LEFT))  // A
 			{
 				keyval = 10;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_RIGHT)) // B
+			if (KEYCHECK_DOWN(ev->keys,KEY_RIGHT)) // B
 			{
 				keyval = 11;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_UP))    // C
+			if (KEYCHECK_DOWN(ev->keys,KEY_UP))    // C
 			{
 				keyval = 12;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_DOWN))  // D
+			if (KEYCHECK_DOWN(ev->keys,KEY_DOWN))  // D
 			{
 				keyval = 13;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_STAR))
+			if (KEYCHECK_DOWN(ev->keys,KEY_STAR))
 			{
 				keyval = 14;
 			}
-			if (KEYCHECK_DOWN(keys,KEY_HASH))
+			if (KEYCHECK_DOWN(ev->keys,KEY_HASH))
 			{
 				keyval = 15;
 			}
@@ -267,7 +268,7 @@ static void handleEvent(int buttons, int keys, int events)
 			}
 		}
 	}
-	if (trxIsTransmittingTone && (buttons & BUTTON_SK2) == 0 && (keys == 0))
+	if (trxIsTransmittingTone && (ev->buttons & BUTTON_SK2) == 0 && (ev->keys == 0))
 	{
 		trxIsTransmittingTone = false;
 		trxSelectVoiceChannel(AT1846_VOICE_CHANNEL_MIC);

--- a/firmware/source/user_interface/uiTxTgPcContactOwnId.c
+++ b/firmware/source/user_interface/uiTxTgPcContactOwnId.c
@@ -29,14 +29,14 @@ static struct_codeplugContact_t contact;
 
 static void updateCursor(void);
 static void updateScreen(void);
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 
 static const uint32_t CURSOR_UPDATE_TIMEOUT = 1000;
 
 static const char *menuName[4];
 enum DISPLAY_MENU_LIST { ENTRY_TG = 0, ENTRY_PC, ENTRY_SELECT_CONTACT, ENTRY_USER_DMR_ID, NUM_ENTRY_ITEMS};
 // public interface
-int menuNumericalEntry(int buttons, int keys, int events, bool isFirstRun)
+int menuNumericalEntry(ui_event_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -51,13 +51,13 @@ int menuNumericalEntry(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events == EVENT_BUTTON_NONE)
+		if (ev->events == EVENT_BUTTON_NONE)
 		{
 			updateCursor();
 		}
 		else
 		{
-			handleEvent(buttons, keys, events);
+			handleEvent(ev);
 		}
 	}
 	return 0;
@@ -141,16 +141,16 @@ static int getNextContact(int curidx, int dir, struct_codeplugContact_t *contact
 	return idx;
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
 	size_t sLen;
 
-	if (KEYCHECK_SHORTUP(keys,KEY_RED))
+	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		if (gMenusCurrentItemIndex != ENTRY_USER_DMR_ID)
 		{
@@ -172,7 +172,7 @@ static void handleEvent(int buttons, int keys, int events)
 		else
 		{
 			trxDMRID = atoi(digits);
-			if (buttons & BUTTON_SK2)
+			if (ev->buttons & BUTTON_SK2)
 			{
 				// make the change to DMR ID permanent if Function + Green is pressed
 				codeplugSetUserDMRID(trxDMRID);
@@ -180,10 +180,10 @@ static void handleEvent(int buttons, int keys, int events)
 		}
 		menuSystemPopAllAndDisplayRootMenu();
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_HASH))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_HASH))
 	{
 		pcIdx = 0;
-		if ((buttons & BUTTON_SK2)!= 0  && gMenusCurrentItemIndex == ENTRY_SELECT_CONTACT)
+		if ((ev->buttons & BUTTON_SK2)!= 0  && gMenusCurrentItemIndex == ENTRY_SELECT_CONTACT)
 		{
 			digits[0] = 0x00;
 			gMenusCurrentItemIndex = ENTRY_USER_DMR_ID;
@@ -209,9 +209,9 @@ static void handleEvent(int buttons, int keys, int events)
 	{
 		int idx = pcIdx;
 
-		if (KEYCHECK_PRESS(keys,KEY_DOWN)) {
+		if (KEYCHECK_PRESS(ev->keys,KEY_DOWN)) {
 			idx = getNextContact(pcIdx, 1, &contact);
-		} else if (KEYCHECK_PRESS(keys,KEY_UP)) {
+		} else if (KEYCHECK_PRESS(ev->keys,KEY_UP)) {
 			idx = getNextContact(pcIdx, -1, &contact);
 		}
 		if (pcIdx != idx ) {
@@ -225,13 +225,13 @@ static void handleEvent(int buttons, int keys, int events)
 		bool refreshScreen = false;
 
 		// Inc / Dec entered value.
-		if (KEYCHECK_PRESS(keys,KEY_UP) || KEYCHECK_PRESS(keys,KEY_DOWN))
+		if (KEYCHECK_PRESS(ev->keys,KEY_UP) || KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 		{
 			if (strlen(digits))
 			{
 				unsigned long int ccs7 = strtoul(digits, NULL, 10);
 
-				if (KEYCHECK_PRESS(keys,KEY_UP))
+				if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 				{
 					if (ccs7 < 9999999)
 						ccs7++;
@@ -252,7 +252,7 @@ static void handleEvent(int buttons, int keys, int events)
 				}
 			}
 		} // Delete a digit
-		else if (KEYCHECK_PRESS(keys,KEY_LEFT))
+		else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 		{
 			if ((sLen = strlen(digits)) > 0)
 			{
@@ -266,7 +266,7 @@ static void handleEvent(int buttons, int keys, int events)
 			if (sLen < 7)
 			{
 				char c[2] = {0, 0};
-				c[0] = keypressToNumberChar(keys);
+				c[0] = keypressToNumberChar(ev->keys);
 				
 				if (c[0]!=0)
 				{

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -42,8 +42,7 @@ LinkItem_t *LinkHead = callsList;
 int numLastHeard=0;
 int menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 int qsodata_timer;
-int RssiUpdateCounter;
-const int RSSI_UPDATE_COUNTER_RELOAD = 500;
+const uint32_t RSSI_UPDATE_COUNTER_RELOAD = 500;
 
 uint32_t menuUtilityReceivedPcId 	= 0;// No current Private call awaiting acceptance
 uint32_t menuUtilityTgBeforePcMode 	= 0;// No TG saved, prior to a Private call being accepted.
@@ -349,9 +348,9 @@ bool dmrIDLookup( int targetId,dmrIdDataStruct_t *foundRecord)
 	return false;
 }
 
-bool menuUtilityHandlePrivateCallActions(int buttons, int keys, int events)
+bool menuUtilityHandlePrivateCallActions(ui_event_t *ev)
 {
-	if ((buttons & BUTTON_SK2 )!=0 &&   menuUtilityTgBeforePcMode != 0 && KEYCHECK_SHORTUP(keys,KEY_RED))
+	if ((ev->buttons & BUTTON_SK2 )!=0 &&   menuUtilityTgBeforePcMode != 0 && KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		trxTalkGroupOrPcId = menuUtilityTgBeforePcMode;
 		nonVolatileSettings.overrideTG = menuUtilityTgBeforePcMode;
@@ -364,7 +363,7 @@ bool menuUtilityHandlePrivateCallActions(int buttons, int keys, int events)
 	// Note.  menuUtilityReceivedPcId is used to store the PcId but also used as a flag to indicate that a Pc request has occurred.
 	if (menuUtilityReceivedPcId != 0x00 && (LinkHead->talkGroupOrPcId>>24) == PC_CALL_FLAG && nonVolatileSettings.overrideTG != LinkHead->talkGroupOrPcId)
 	{
-		if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+		if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 		{
 			// User has accepted the private call
 			menuUtilityTgBeforePcMode = trxTalkGroupOrPcId;// save the current TG

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -140,7 +140,7 @@ int menuVFOMode(ui_event_t *ev, bool isFirstRun)
 			}
 			else
 			{
-				if (ev->ticks - m > RSSI_UPDATE_COUNTER_RELOAD)
+				if ((ev->ticks - m) > RSSI_UPDATE_COUNTER_RELOAD)
 				{
 					m = ev->ticks;
 					drawRSSIBarGraph();

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -36,7 +36,7 @@ static struct_codeplugContact_t contactData;
 static bool displaySquelch=false;
 
 // internal prototypes
-static void handleEvent(int buttons, int keys, int events);
+static void handleEvent(ui_event_t *ev);
 static void reset_freq_enter_digits(void);
 static int read_freq_enter_digits(void);
 static void update_frequency(int tmp_frequency);
@@ -55,11 +55,12 @@ static const int CCSCANINTERVAL=500;
 static int scanIndex=0;
 
 // public interface
-int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
+int menuVFOMode(ui_event_t *ev, bool isFirstRun)
 {
+	static uint32_t m = 0;
+
 	if (isFirstRun)
 	{
-		RssiUpdateCounter = RSSI_UPDATE_COUNTER_RELOAD;
 		isDisplayingQSOData=false;
 		nonVolatileSettings.initialMenuNumber=MENU_VFO_MODE;
 		currentChannelData = &settingsVFOChannel[nonVolatileSettings.currentVFONumber];
@@ -130,7 +131,7 @@ int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
 	}
 	else
 	{
-		if (events==0)
+		if (ev->events==0)
 		{
 			// is there an incoming DMR signal
 			if (menuDisplayQSODataState != QSO_DISPLAY_IDLE)
@@ -139,12 +140,12 @@ int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
 			}
 			else
 			{
-				if (RssiUpdateCounter-- == 0)
+				if (ev->ticks - m > RSSI_UPDATE_COUNTER_RELOAD)
 				{
+					m = ev->ticks;
 					drawRSSIBarGraph();
 					UC1701RenderRows(1,2);// Only render the second row which contains the bar graph, as there is no need to redraw the rest of the screen
 					//UC1701_render();
-					RssiUpdateCounter = RSSI_UPDATE_COUNTER_RELOAD;
 				}
 			}
 			if(toneScanActive==true)
@@ -158,7 +159,7 @@ int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
 		}
 		else
 		{
-			handleEvent(buttons, keys, events);
+			handleEvent(ev);
 			toneScanActive=false;
 			if(CCScanActive==true)
 			{
@@ -387,12 +388,12 @@ static void loadContact(void)
 	}
 }
 
-static void handleEvent(int buttons, int keys, int events)
+static void handleEvent(ui_event_t *ev)
 {
 	uint32_t tg = (LinkHead->talkGroupOrPcId & 0xFFFFFF);
 	// If Blue button is pressed during reception it sets the Tx TG to the incoming TG
 
-	if (isDisplayingQSOData && (buttons & BUTTON_SK2)!=0 && trxGetMode() == RADIO_MODE_DIGITAL &&
+	if (isDisplayingQSOData && (ev->buttons & BUTTON_SK2)!=0 && trxGetMode() == RADIO_MODE_DIGITAL &&
 				(trxTalkGroupOrPcId != tg ||
 				(dmrMonitorCapturedTS!=-1 && dmrMonitorCapturedTS != trxGetDMRTimeSlot())))
 	{
@@ -416,11 +417,11 @@ static void handleEvent(int buttons, int keys, int events)
 		return;
 	}
 
-	if (events & 0x02)
+	if (ev->events & 0x02)
 	{
-		if (buttons & BUTTON_ORANGE)
+		if (ev->buttons & BUTTON_ORANGE)
 		{
-			if (buttons & BUTTON_SK2)
+			if (ev->buttons & BUTTON_SK2)
 			{
 				settingsPrivateCallMuteMode = !settingsPrivateCallMuteMode;// Toggle PC mute only mode
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
@@ -434,14 +435,14 @@ static void handleEvent(int buttons, int keys, int events)
 		}
 	}
 
-	if (KEYCHECK_SHORTUP(keys,KEY_GREEN))
+	if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
-		if (menuUtilityHandlePrivateCallActions(buttons,keys,events))
+		if (menuUtilityHandlePrivateCallActions(ev))
 		{
 			reset_freq_enter_digits();
 			return;
 		}
-		if (buttons & BUTTON_SK2 )
+		if (ev->buttons & BUTTON_SK2 )
 		{
 			menuSystemPushNewMenu(MENU_CHANNEL_DETAILS);
 			reset_freq_enter_digits();
@@ -456,11 +457,11 @@ static void handleEvent(int buttons, int keys, int events)
 			}
 		}
 	}
-	else if (KEYCHECK_SHORTUP(keys,KEY_HASH))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_HASH))
 	{
 		if (trxGetMode() == RADIO_MODE_DIGITAL)
 		{
-			if ((buttons & BUTTON_SK2) != 0)
+			if ((ev->buttons & BUTTON_SK2) != 0)
 			{
 				menuSystemPushNewMenu(MENU_CONTACT_QUICKLIST);
 			} else {
@@ -472,9 +473,9 @@ static void handleEvent(int buttons, int keys, int events)
 
 	if (freq_enter_idx==0)
 	{
-		if (KEYCHECK_SHORTUP(keys,KEY_STAR))
+		if (KEYCHECK_SHORTUP(ev->keys,KEY_STAR))
 		{
-			if (buttons & BUTTON_SK2 )
+			if (ev->buttons & BUTTON_SK2 )
 			{
 				if (trxGetMode() == RADIO_MODE_ANALOG)
 				{
@@ -516,9 +517,9 @@ static void handleEvent(int buttons, int keys, int events)
 				}
 			}
 		}
-		else if (KEYCHECK_PRESS(keys,KEY_DOWN))
+		else if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 		{
-			if (buttons & BUTTON_SK2 )
+			if (ev->buttons & BUTTON_SK2 )
 			{
 				selectedFreq = VFO_SELECTED_FREQUENCY_INPUT_TX;
 			}
@@ -528,9 +529,9 @@ static void handleEvent(int buttons, int keys, int events)
 			}
 			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
-		else if (KEYCHECK_PRESS(keys,KEY_UP))
+		else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 		{
-			if (buttons & BUTTON_SK2 )
+			if (ev->buttons & BUTTON_SK2 )
 			{
 				selectedFreq = VFO_SELECTED_FREQUENCY_INPUT_RX;
 			}
@@ -541,9 +542,9 @@ static void handleEvent(int buttons, int keys, int events)
 			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 
 		}
-		else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+		else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 		{
-			if (menuUtilityHandlePrivateCallActions(buttons,keys,events))
+			if (menuUtilityHandlePrivateCallActions(ev))
 			{
 				return;
 			}
@@ -551,9 +552,9 @@ static void handleEvent(int buttons, int keys, int events)
 			return;
 		}
 		else
-		if (KEYCHECK_PRESS(keys,KEY_RIGHT))
+		if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 		{
-			if (buttons & BUTTON_SK2)
+			if (ev->buttons & BUTTON_SK2)
 			{
 				if (nonVolatileSettings.txPowerLevel < 7)
 				{
@@ -613,9 +614,9 @@ static void handleEvent(int buttons, int keys, int events)
 				}
 			}
 		}
-		else if (KEYCHECK_PRESS(keys,KEY_LEFT))
+		else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 		{
-			if (buttons & BUTTON_SK2)
+			if (ev->buttons & BUTTON_SK2)
 			{
 				if (nonVolatileSettings.txPowerLevel > 0)
 				{
@@ -682,19 +683,19 @@ static void handleEvent(int buttons, int keys, int events)
 	}
 	else
 	{
-		if (KEYCHECK_PRESS(keys,KEY_LEFT))
+		if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 		{
 			freq_enter_idx--;
 			freq_enter_digits[freq_enter_idx]='-';
 			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
-		else if (KEYCHECK_SHORTUP(keys,KEY_RED))
+		else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 		{
 			reset_freq_enter_digits();
     	    set_melody(melody_NACK_beep);
     		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
-		else if (KEYCHECK_SHORTUP(keys, KEY_GREEN))
+		else if (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN))
 		{
 			int tmp_frequency=read_freq_enter_digits();
 			if (trxGetBandFromFrequency(tmp_frequency)!=-1)
@@ -712,7 +713,7 @@ static void handleEvent(int buttons, int keys, int events)
 	}
 	if (freq_enter_idx<8)
 	{
-		char c = keypressToNumberChar(keys);
+		char c = keypressToNumberChar(ev->keys);
 		if (c!='\0')
 		{
 			freq_enter_digits[freq_enter_idx]=c;


### PR DESCRIPTION
This struct also embeds a tick counter, issued from fw_millis().
The boolean member hasEvent is true if the current key/button/event is different from the previous sent event.
handleEvent() is only called if necessary.
Removed: int menuTimer, int RssiUpdateCounter. Timeout is calc from ui_event_t.ticks instead.