### PR TITLE
Cleanup uiEvent_t.hasEvent checking code in main loop.

### DIFF
--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -63,9 +63,7 @@ void fw_main_task(void *data)
 	uint32_t buttons;
 	int button_event;
 	uiEvent_t ev = { .buttons = 0, .keys = 0, .events = NO_EVENT, .hasEvent = false, .ticks = 0 };
-	int oldButtons = 0;
-	int oldKeys = 0;
-	int oldEvents = 0;
+	bool keyOrButtonChanged = false;
 	
     USB_DeviceApplicationInit();
 
@@ -167,6 +165,9 @@ void fw_main_task(void *data)
 
 			fw_check_button_event(&buttons, &button_event); // Read button state and event
 			fw_check_key_event(&keys, &key_event); // Read keyboard state and event
+
+			// EVENT_*_CHANGED can be cleared later, so check this now as hasEvent has to be set anyway.
+			keyOrButtonChanged = ((key_event != NO_EVENT) || (button_event != NO_EVENT));
 
 			if (keypadLocked)
 			{
@@ -280,13 +281,8 @@ void fw_main_task(void *data)
     		ev.buttons = buttons;
     		ev.keys = keys;
     		ev.events = (button_event<<1) | key_event;
-    		ev.hasEvent = (ev.buttons != oldButtons) || (ev.keys != oldKeys) || (ev.events != oldEvents) ||
-    				((key_event & EVENT_KEY_CHANGE) && (keys & KEY_MOD_LONG));
+    		ev.hasEvent = keyOrButtonChanged || ((key_event & EVENT_KEY_CHANGE) && (keys & KEY_MOD_LONG));
     		ev.ticks = fw_millis();
-
-    		oldButtons = ev.buttons;
-    		oldKeys = ev.keys;
-    		oldEvents = ev.events;
 
         	menuSystemCallCurrentMenuTick(&ev);
 

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -237,6 +237,14 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 			menuUtilityReceivedPcId = 0x00;
 			if (trxIsTransmitting)
 			{
+				// Squelch is displayed, PTT was pressed
+				// Clear its region
+				if (displaySquelch)
+				{
+					displaySquelch = false;
+					ucFillRect(0, 16, 128, 16, true);
+				}
+
 				snprintf(buffer, bufferLen, " %d ", txTimeSecs);
 				buffer[bufferLen - 1] = 0;
 				ucPrintCentered(TX_TIMER_Y_OFFSET, buffer, FONT_16x32);

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -293,6 +293,14 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 				}
 				else
 				{
+					// Squelch is displayed, PTT was pressed
+					// Clear its region
+					if (displaySquelch)
+					{
+						displaySquelch = false;
+						ucFillRect(0, 16, 128, 16, true);
+					}
+
 					snprintf(buffer, bufferLen, " %d ", txTimeSecs);
 					ucPrintCentered(TX_TIMER_Y_OFFSET, buffer, FONT_16x32);
 				}


### PR DESCRIPTION
Clear squelch region if still displayed while PTT is triggered.