### PR TITLE
Fix hidden lockscreen on keypad locking.

### DIFF
--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -185,11 +185,11 @@ void fw_main_task(void *data)
 				// Lockout ORANGE AND BLUE (BLACK stay active regarless lock status, useful to trigger backlight)
 				if (button_event == EVENT_BUTTON_CHANGE && ((buttons & BUTTON_ORANGE) || (buttons & BUTTON_SK2)))
 				{
-					button_event = EVENT_BUTTON_NONE;
 					if (menuSystemGetCurrentMenuNumber() != MENU_LOCK_SCREEN)
 					{
 						menuSystemPushNewMenu(MENU_LOCK_SCREEN);
 					}
+					button_event = EVENT_BUTTON_NONE;
 				}
 			}
 
@@ -262,6 +262,8 @@ void fw_main_task(void *data)
 						{
 							if (currentMenu == MENU_VFO_MODE)
 								menuVFOModeStopScan();
+							else if (currentMenu == MENU_LOCK_SCREEN)
+								menuSystemPopPreviousMenu();
 
 							menuSystemPushNewMenu(MENU_TX_SCREEN);
 						}

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -114,7 +114,7 @@ void menuSystemPopPreviousMenu(void)
 
 	fw_reset_keyboard();
 	menuControlData.itemIndex[menuControlData.stackPosition] = 0;
-	menuControlData.stackPosition--;
+	menuControlData.stackPosition -= (menuControlData.stackPosition > 0) ? 1 : 0; // Avoid crashing if something goes wrong.
 	gMenusCurrentItemIndex = menuControlData.itemIndex[menuControlData.stackPosition];
 	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev,true);
 }

--- a/firmware/source/user_interface/uiLockScreen.c
+++ b/firmware/source/user_interface/uiLockScreen.c
@@ -36,12 +36,13 @@ int menuLockScreen(uiEvent_t *ev, bool isFirstRun)
 	if (isFirstRun)
 	{
 		m = fw_millis();
-		updateScreen();
 		lockScreenState = LOCK_SCREEN_STATE_CHANGED;
+		updateScreen();
+		lockDisplay = true;
 	}
 	else
 	{
-		if ((ev->ticks - m) > TIMEOUT_MS)
+		if (lockDisplay && ((ev->ticks - m) > TIMEOUT_MS))
 		{
 			menuSystemPopPreviousMenu();
 			lockDisplay = false;
@@ -102,6 +103,15 @@ static void handleEvent(uiEvent_t *ev)
 		PTTLocked = false;
 		menuSystemPopAllAndDisplayRootMenu();
 		menuSystemPushNewMenu(MENU_LOCK_SCREEN);
-
+	}
+	else
+	{
+		// Hide immediately the lock/unlock window on key event, without waiting for timeout.
+		if (lockDisplay && (((ev->keys.key != 0) && (ev->keys.event & KEY_MOD_UP)) ||
+				((ev->events & BUTTON_EVENT) && (ev->buttons == BUTTON_NONE))))
+		{
+			menuSystemPopPreviousMenu();
+			lockDisplay = false;
+		}
 	}
 }


### PR DESCRIPTION
Hide lockscreen on key/button event (button events is quite hard to handle, so if the lockscreen pops up on button press event, it will be hidden on button release).
Call menuSystemPopPreviousMenu() on PTT event if lockscreen is running (as it will be redisplayed after a short PTT event).
Also (I forgot to mention in commit's comment), stack offset is checked in menuSystemPopPreviousMenu(), preventing reboots if called more than necessary.
