### PR TITLE
Correct Rx Preamp Initial Selection

### DIFF
--- a/firmware/source/functions/fw_trx.c
+++ b/firmware/source/functions/fw_trx.c
@@ -341,7 +341,7 @@ void trxSetFrequency(int fRx,int fTx, int dmrMode)
 
 		if (!txPAEnabled)
 		{
-			if (trxCurrentBand[TRX_TX_FREQ_BAND] == RADIO_BAND_UHF)
+			if (trxCurrentBand[TRX_RX_FREQ_BAND] == RADIO_BAND_UHF)
 			{
 				GPIO_PinWrite(GPIO_VHF_RX_amp_power, Pin_VHF_RX_amp_power, 0);
 				GPIO_PinWrite(GPIO_UHF_RX_amp_power, Pin_UHF_RX_amp_power, 1);


### PR DESCRIPTION
Initial selection of Rx Preamp was based on Tx frequency. Should be Rx Frequency.
Affected crossband operation.