### PR TITLE
Add .gitattributes, and force eol to lf (to avoid crlf mergings).

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+firmware/source/user_interface/languages/*.h	eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /ComTool/.vs
 /ComTool/ComTool/bin
 /ComTool/ComTool/obj
+/font_tools/font_converter/font_*


### PR DESCRIPTION
I've also added a gitignore entry for extracted fonts in font_tools/font_converter/ subdir.
