### PR TITLE
Display VFO A or B (see screengrabs).

### DIFF
--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -294,6 +294,7 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 					snprintf(buffer, bufferLen, "%cR %d.%05d MHz", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_RX) ? '>' : ' ', val_before_dp, val_after_dp);
 					buffer[bufferLen - 1 ] = 0;
 					ucPrintCentered(32, buffer, FONT_8x16);
+					ucPrintAt(16, 32 + 7, (nonVolatileSettings.currentVFONumber == 0) ? "A" : "B", FONT_8x8);
 				}
 				else
 				{
@@ -314,6 +315,7 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 				snprintf(buffer, bufferLen, "%cT %d.%05d MHz", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX || trxIsTransmitting) ? '>' : ' ', val_before_dp, val_after_dp);
 				buffer[bufferLen - 1 ] = 0;
 				ucPrintCentered(48, buffer, FONT_8x16);
+				ucPrintAt(16, 48 + 7, (nonVolatileSettings.currentVFONumber == 0) ? "A" : "B", FONT_8x8);
 			}
 			else
 			{
@@ -434,6 +436,8 @@ static void loadContact(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (ev->events & BUTTON_EVENT)
 	{
 		uint32_t tg = (LinkHead->talkGroupOrPcId & 0xFFFFFF);
@@ -911,11 +915,12 @@ static void updateQuickMenuScreen(void)
 	}
 
 	ucRender();
-	displayLightTrigger();
 }
 
 static void handleQuickMenuEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		toneScanActive=false;


### PR DESCRIPTION
Fix two backlight triggering bugs.

![vfoA](https://user-images.githubusercontent.com/10473896/71322382-46044c00-24c7-11ea-9814-00610823295a.png)

![vfoB](https://user-images.githubusercontent.com/10473896/71322387-4dc3f080-24c7-11ea-8048-52e865140740.png)

The Y misalignment is here on purpose.

Cheers.

**EDIT:**

There is also inverted version (not pushed until further notice):
![vfoA_inverted](https://user-images.githubusercontent.com/10473896/71322661-8618fe00-24ca-11ea-93c6-92d3184df669.png)
![vfoB_inverted](https://user-images.githubusercontent.com/10473896/71322663-87e2c180-24ca-11ea-8e68-8f6b30d70c37.png)


