### PR TITLE
While CC scan is running, "Color Code #" is displayed at Contact location, 

### DIFF
--- a/firmware/include/user_interface/menuUtilityQSOData.h
+++ b/firmware/include/user_interface/menuUtilityQSOData.h
@@ -24,6 +24,7 @@
 extern const int QSO_TIMER_TIMEOUT;
 extern const int TX_TIMER_Y_OFFSET;
 extern const int CONTACT_Y_POS;
+extern const int FREQUENCY_X_POS;
 
 typedef struct dmrIdDataStruct
 {

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -32,8 +32,8 @@ void updateLastHeardList(int id,int talkGroup);
 const int QSO_TIMER_TIMEOUT = 2400;
 const int TX_TIMER_Y_OFFSET = 8;
 const int CONTACT_Y_POS = 16;
+const int FREQUENCY_X_POS = /* '>Ta'*/ (3 * 8) + 4;
 static const int BAR_Y_POS = 10;
-
 
 static const int DMRID_MEMORY_STORAGE_START = 0x30000;
 static const int DMRID_HEADER_LENGTH = 0x0C;

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -344,7 +344,6 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 				}
 			}
 
-			displayLightTrigger();
 			ucRender();
 			break;
 
@@ -449,6 +448,8 @@ static void loadContact(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (ev->events & BUTTON_EVENT)
 	{
 		uint32_t tg = (LinkHead->talkGroupOrPcId & 0xFFFFFF);

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -295,13 +295,21 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 				{
 					val_before_dp = currentChannelData->rxFreq/100000;
 					val_after_dp = currentChannelData->rxFreq - val_before_dp*100000;
-					snprintf(buffer, bufferLen, "%cR %d.%05d MHz", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_RX) ? '>' : ' ', val_before_dp, val_after_dp);
-					buffer[bufferLen - 1 ] = 0;
 
 					// if CC scan is active, Rx freq is moved down to the Tx location,
 					// as Contact Info will be displayed here
-					ucPrintCentered((CCScanActive ? 48 : 32), buffer, FONT_8x16);
+
+					// Focus + direction
+					snprintf(buffer, bufferLen, "%cR", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_RX) ? '>' : ' ');
+					ucPrintAt(0, (CCScanActive ? 48 : 32), buffer, FONT_8x16);
+					// VFO
 					ucPrintAt(16, (CCScanActive ? 48 : 32) + 8, (nonVolatileSettings.currentVFONumber == 0) ? "A" : "B", FONT_8x8);
+					// Frequency
+					snprintf(buffer, bufferLen, "%d.%05d", val_before_dp, val_after_dp);
+					buffer[bufferLen - 1] = 0;
+					ucPrintAt(FREQUENCY_X_POS, (CCScanActive ? 48 : 32), buffer, FONT_8x16);
+					// Unit
+					ucPrintAt(128 - (3 * 8), (CCScanActive ? 48 : 32), "MHz", FONT_8x16);
 
 					if (CCScanActive)
 					{
@@ -328,10 +336,17 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 				{
 					val_before_dp = currentChannelData->txFreq/100000;
 					val_after_dp = currentChannelData->txFreq - val_before_dp*100000;
-					snprintf(buffer, bufferLen, "%cT %d.%05d MHz", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX || trxIsTransmitting) ? '>' : ' ', val_before_dp, val_after_dp);
-					buffer[bufferLen - 1 ] = 0;
-					ucPrintCentered(48, buffer, FONT_8x16);
-				ucPrintAt(16, 48 + 8, (nonVolatileSettings.currentVFONumber == 0) ? "A" : "B", FONT_8x8);
+					// Focus + direction
+					snprintf(buffer, bufferLen, "%cT", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX || trxIsTransmitting) ? '>' : ' ');
+					ucPrintAt(0, 48, buffer, FONT_8x16);
+					// VFO
+					ucPrintAt(16, 48 + 8, (nonVolatileSettings.currentVFONumber == 0) ? "A" : "B", FONT_8x8);
+					// Frequency
+					snprintf(buffer, bufferLen, "%d.%05d", val_before_dp, val_after_dp);
+					buffer[bufferLen - 1] = 0;
+					ucPrintAt(FREQUENCY_X_POS, 48, buffer, FONT_8x16);
+					// Unit
+					ucPrintAt(128 - (3 * 8), 48, "MHz", FONT_8x16);
 				}
 			}
 			else

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -200,10 +200,28 @@ int menuVFOMode(uiEvent_t *ev, bool isFirstRun)
 	return 0;
 }
 
+void displayFrequency(bool isTX, bool hasFocus, uint8_t y, uint32_t frequency)
+{
+	static const int bufferLen = 17;
+	char buffer[bufferLen];
+	int val_before_dp = frequency / 100000;
+	int val_after_dp = frequency - val_before_dp * 100000;
+
+	// Focus + direction
+	snprintf(buffer, bufferLen, "%c%c", (hasFocus ? '>' : ' '), (isTX ? 'T' : 'R'));
+	ucPrintAt(0, y, buffer, FONT_8x16);
+	// VFO
+	ucPrintAt(16, y + 8, (nonVolatileSettings.currentVFONumber == 0) ? "A" : "B", FONT_8x8);
+	// Frequency
+	snprintf(buffer, bufferLen, "%d.%05d", val_before_dp, val_after_dp);
+	buffer[bufferLen - 1] = 0;
+	ucPrintAt(FREQUENCY_X_POS, y, buffer, FONT_8x16);
+	// Unit
+	ucPrintAt(128 - (3 * 8), y, "MHz", FONT_8x16);
+}
+
 void menuVFOModeUpdateScreen(int txTimeSecs)
 {
-	int val_before_dp;
-	int val_after_dp;
 	static const int bufferLen = 17;
 	char buffer[bufferLen];
 	struct_codeplugContact_t contact;
@@ -293,23 +311,10 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 			{
 				if (!trxIsTransmitting)
 				{
-					val_before_dp = currentChannelData->rxFreq/100000;
-					val_after_dp = currentChannelData->rxFreq - val_before_dp*100000;
-
 					// if CC scan is active, Rx freq is moved down to the Tx location,
 					// as Contact Info will be displayed here
 
-					// Focus + direction
-					snprintf(buffer, bufferLen, "%cR", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_RX) ? '>' : ' ');
-					ucPrintAt(0, (CCScanActive ? 48 : 32), buffer, FONT_8x16);
-					// VFO
-					ucPrintAt(16, (CCScanActive ? 48 : 32) + 8, (nonVolatileSettings.currentVFONumber == 0) ? "A" : "B", FONT_8x8);
-					// Frequency
-					snprintf(buffer, bufferLen, "%d.%05d", val_before_dp, val_after_dp);
-					buffer[bufferLen - 1] = 0;
-					ucPrintAt(FREQUENCY_X_POS, (CCScanActive ? 48 : 32), buffer, FONT_8x16);
-					// Unit
-					ucPrintAt(128 - (3 * 8), (CCScanActive ? 48 : 32), "MHz", FONT_8x16);
+					displayFrequency(false, (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_RX), (CCScanActive ? 48 : 32), currentChannelData->rxFreq);
 
 					if (CCScanActive)
 					{
@@ -334,19 +339,7 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 
 				if (CCScanActive == false)
 				{
-					val_before_dp = currentChannelData->txFreq/100000;
-					val_after_dp = currentChannelData->txFreq - val_before_dp*100000;
-					// Focus + direction
-					snprintf(buffer, bufferLen, "%cT", (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX || trxIsTransmitting) ? '>' : ' ');
-					ucPrintAt(0, 48, buffer, FONT_8x16);
-					// VFO
-					ucPrintAt(16, 48 + 8, (nonVolatileSettings.currentVFONumber == 0) ? "A" : "B", FONT_8x8);
-					// Frequency
-					snprintf(buffer, bufferLen, "%d.%05d", val_before_dp, val_after_dp);
-					buffer[bufferLen - 1] = 0;
-					ucPrintAt(FREQUENCY_X_POS, 48, buffer, FONT_8x16);
-					// Unit
-					ucPrintAt(128 - (3 * 8), 48, "MHz", FONT_8x16);
+					displayFrequency(true, (selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX || trxIsTransmitting), 48, currentChannelData->txFreq);
 				}
 			}
 			else

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -180,12 +180,14 @@ int menuVFOMode(uiEvent_t *ev, bool isFirstRun)
 					sqm = ev->ticks;
 				}
 
-				toneScanActive = false;
-
-				if(CCScanActive == true)
+				if(toneScanActive || CCScanActive)
 				{
+					if (CCScanActive)
+					{
+						trxSetDMRColourCode(currentChannelData->rxColor);
+					}
+					toneScanActive = false;
 					CCScanActive = false;
-					trxSetDMRColourCode(currentChannelData->rxColor);
 					menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 					menuVFOModeUpdateScreen(0); // Needs to redraw the screen now
 				}


### PR DESCRIPTION
and all infos are moved down by one row. Tx info is hidden.
Any user key event stops the scan (as before), and screen redrawn with default layout.

![GD-77_screengrab-2019-12-23_04_47_36](https://user-images.githubusercontent.com/10473896/71334860-2d844800-2540-11ea-9571-92c95270750d.png)
The scrambled header line is due to scanning while screen grabbing.

This PR may conflit with the one related to VFO A/B changes.
 
