### PR TITLE
Before TXing, check if VFO is scanning before blindly stopping it.

### DIFF
--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -279,7 +279,7 @@ void fw_main_task(void *data)
 							currentMenu != MENU_SPLASH_SCREEN &&
 							currentMenu != MENU_TX_SCREEN )
 					{
-						if (currentMenu == MENU_VFO_MODE)
+						if ((currentMenu == MENU_VFO_MODE) && menuVFOModeIsScanning())
 							menuVFOModeStopScanning();
 						else if (currentMenu == MENU_LOCK_SCREEN)
 							menuLockScreenPop();


### PR DESCRIPTION
Since menuVFOModeIsScanning() exists, use it.