### PR TITLE
When displaying channel details within VFO, instead of an empty channel name, mark it as N/A.

### DIFF
--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -56,8 +56,19 @@ int menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
 				CTCSSRxIndex=i;
 			}
 		}
-		codeplugUtilConvertBufToString(tmpChannel.name, channelName, 16);
-		namePos = strlen(channelName);
+
+		if (settingsCurrentChannelNumber == -1) // In VFO
+		{
+			snprintf(channelName, 17, "%s", currentLanguage->n_a);
+			channelName[16] = 0;
+			namePos = 0;
+		}
+		else
+		{
+			codeplugUtilConvertBufToString(tmpChannel.name, channelName, 16);
+			namePos = strlen(channelName);
+		}
+
 		updateScreen();
 		updateCursor(true);
 	}
@@ -203,7 +214,7 @@ static void updateScreen(void)
 			case CH_DETAILS_TOT:// TOT
 				if (tmpChannel.tot != 0)
 				{
-					snprintf(buf, bufferLen, "%s:%d", currentLanguage->tot, tmpChannel.tot * 15);
+					snprintf(buf, bufferLen, "%s:%ds", currentLanguage->tot, tmpChannel.tot * 15);
 				}
 				else
 				{

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -330,9 +330,9 @@ void menuUpdateCursor(int pos, bool moved, bool render)
 	if (moved) {
 		blink = true;
 	}
-	if ((m - lastBlink) > 1000 || moved)
+	if (moved || (m - lastBlink) > 1000)
 	{
-		ucDrawFastHLine(pos*8-1, 46, 8, blink);
+		ucDrawFastHLine(pos*8, 46, 8, blink);
 
 		blink = !blink;
 		lastBlink = m;


### PR DESCRIPTION
Add 's' unit to TOT.
Shift editing cursor to 1px on the right, it was misaligned with the character above.