### PR TITLE
Enable access to lower SRAM for data, heap and stack

### DIFF
--- a/firmware/.cproject
+++ b/firmware/.cproject
@@ -261,8 +261,8 @@
 								<option id="com.crt.advproject.link.gcc.lto.optmization.level.462098137" name="Link-time optimization level" superClass="com.crt.advproject.link.gcc.lto.optmization.level"/>
 								<option id="com.crt.advproject.link.fpu.1745550976" name="Floating point" superClass="com.crt.advproject.link.fpu" value="com.crt.advproject.link.fpu.fpv4.hard" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.manage.477226748" name="Manage linker script" superClass="com.crt.advproject.link.manage" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="com.crt.advproject.link.script.2040275712" name="Linker script" superClass="com.crt.advproject.link.script" useByScannerDiscovery="false" value="&quot;../linkerscripts/firmware.ld&quot;" valueType="string"/>
-								<option id="com.crt.advproject.link.scriptdir.1977291216" name="Script path" superClass="com.crt.advproject.link.scriptdir"/>
+								<option id="com.crt.advproject.link.script.2040275712" name="Linker script" superClass="com.crt.advproject.link.script" useByScannerDiscovery="false" value="../linkerscripts/firmware.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.scriptdir.1977291216" name="Script path" superClass="com.crt.advproject.link.scriptdir" useByScannerDiscovery="false" value="" valueType="string"/>
 								<option id="com.crt.advproject.link.crpenable.827555481" name="Enable automatic placement of Code Read Protection field in image" superClass="com.crt.advproject.link.crpenable"/>
 								<option id="com.crt.advproject.link.flashconfigenable.558366596" name="Enable automatic placement of Flash Configuration field in image" superClass="com.crt.advproject.link.flashconfigenable" value="true" valueType="boolean"/>
 								<option id="com.crt.advproject.link.ecrp.1134718176" name="Enhanced CRP" superClass="com.crt.advproject.link.ecrp"/>
@@ -969,9 +969,9 @@
 &lt;memory id="RAM" size="128" type="RAM"/&gt;
 &lt;memoryInstance derived_from="Flash" driver="FTFA_2K.cfx" edited="true" id="PROGRAM_FLASH" location="0x0" size="0x80000"/&gt;
 &lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_UPPER" location="0x20000000" size="0x10000"/&gt;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_BOTTOM" location="0x1fff0000" size="0x4000"/&gt;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_AMBE" location="0x1fff4000" size="0x8000"/&gt;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_TOP" location="0x1fffc000" size="0x4000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_BOTTOM" location="0x1fff0000" size="0x6b60"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_AMBE" location="0x1fff6b60" size="0x2228"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_TOP" location="0x1fff8d88" size="0x7278"/&gt;
 &lt;/chip&gt;
 &lt;processor&gt;
 &lt;name gcc_name="cortex-m4"&gt;Cortex-M4&lt;/name&gt;

--- a/firmware/.cproject
+++ b/firmware/.cproject
@@ -617,12 +617,6 @@
 							<inputType id="com.crt.advproject.compiler.input.1249022339" superClass="com.crt.advproject.compiler.input"/>
 						</tool>
 					</fileInfo>
-					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.2055907086" name="fw_HR-C6000.c" rcbsApplicability="disable" resourcePath="source/hardware/fw_HR-C6000.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1594970954">
-						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1594970954" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
-							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1182816199" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.none" valueType="enumerated"/>
-							<inputType id="com.crt.advproject.compiler.input.1368636321" superClass="com.crt.advproject.compiler.input"/>
-						</tool>
-					</fileInfo>
 					<sourceEntries>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH" kind="sourcePath" name="CMSIS"/>
 						<entry excluding="FreeRTOS/portable/heap_1.c|FreeRTOS/portable/heap_2.c|FreeRTOS/portable/heap_3.c|FreeRTOS/portable/heap_5.c" flags="LOCAL|VALUE_WORKSPACE_PATH" kind="sourcePath" name="amazon-freertos"/>
@@ -962,27 +956,29 @@
 		<coreId>core0_MK22FN512xxx12</coreId>
 	</storageModule>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MK22FN512xxx12" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MK22FN512xxx12" name="MK22FN512xxx12"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MK22FN512xxx12&lt;/name&gt;&#13;
-&lt;family&gt;K2x&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="512" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="128" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="Flash" driver="FTFA_2K.cfx" id="PROGRAM_FLASH" location="0x00000000" size="0x00080000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" id="SRAM_UPPER" location="0x20000000" size="0x00010000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" id="SRAM_LOWER" location="0x1fff0000" size="0x00010000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m4"&gt;Cortex-M4&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MK22FN512xxx12" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MK22FN512xxx12" name="MK22FN512xxx12"&gt;
+&lt;chip&gt;
+&lt;name&gt;MK22FN512xxx12&lt;/name&gt;
+&lt;family&gt;K2x&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="512" type="Flash"/&gt;
+&lt;memory id="RAM" size="128" type="RAM"/&gt;
+&lt;memoryInstance derived_from="Flash" driver="FTFA_2K.cfx" edited="true" id="PROGRAM_FLASH" location="0x0" size="0x80000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_UPPER" location="0x20000000" size="0x10000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_BOTTOM" location="0x1fff0000" size="0x4000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_AMBE" location="0x1fff4000" size="0x8000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_LOWER_TOP" location="0x1fffc000" size="0x4000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m4"&gt;Cortex-M4&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="refreshScope" versionNumber="2">
@@ -994,4 +990,5 @@
 		</configuration>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>

--- a/firmware/include/fw_main.h
+++ b/firmware/include/fw_main.h
@@ -19,6 +19,10 @@
 #ifndef _FW_MAIN_H_
 #define _FW_MAIN_H_
 
+#define BSS_LOWER_BOTTOM  __attribute__((section(".bss.$RAM2")))
+#define BSS_LOWER_TOP     __attribute__((section(".bss.$RAM4")))
+#define DATA_LOWER_TOP    __attribute__((section(".data.$RAM4")))
+
 #include <stdint.h>
 #include <stdio.h>
 

--- a/firmware/linkerscripts/firmware.ld
+++ b/firmware/linkerscripts/firmware.ld
@@ -19,18 +19,25 @@ SECTIONS
         . = ALIGN(4) ;
         __section_table_start = .;
         __data_section_table = .;
-        LONG(LOADADDR(.data));
-        LONG(    ADDR(.data));
-        LONG(  SIZEOF(.data));
         LONG(LOADADDR(.data_RAM2));
         LONG(    ADDR(.data_RAM2));
         LONG(  SIZEOF(.data_RAM2));
+        LONG(LOADADDR(.data_RAM3));
+        LONG(    ADDR(.data_RAM3));
+        LONG(  SIZEOF(.data_RAM3));
+        LONG(LOADADDR(.data_RAM4));
+        LONG(    ADDR(.data_RAM4));
+        LONG(  SIZEOF(.data_RAM4));
         __data_section_table_end = .;
         __bss_section_table = .;
         LONG(    ADDR(.bss));
         LONG(  SIZEOF(.bss));
         LONG(    ADDR(.bss_RAM2));
         LONG(  SIZEOF(.bss_RAM2));
+        LONG(    ADDR(.bss_RAM3));
+        LONG(  SIZEOF(.bss_RAM3));
+        LONG(    ADDR(.bss_RAM4));
+        LONG(  SIZEOF(.bss_RAM4));
         __bss_section_table_end = .;
         __section_table_end = . ;
         /* End of Global Section Table */
@@ -59,12 +66,39 @@ SECTIONS
         FILL(0xff)
         PROVIDE(__start_data_RAM2 = .) ;
         *(.ramfunc.$RAM2)
-        *(.ramfunc.$SRAM_LOWER)
+        *(.ramfunc.$SRAM_LOWER_BOTTOM)
         *(.data.$RAM2*)
-        *(.data.$SRAM_LOWER*)
+        *(.data.$SRAM_LOWER_BOTTOM*)
         . = ALIGN(4) ;
         PROVIDE(__end_data_RAM2 = .) ;
-     } > SRAM_LOWER AT>PROGRAM_FLASH
+     } > SRAM_LOWER_BOTTOM AT>PROGRAM_FLASH
+     
+    /* DATA section for SRAM_LOWER */
+    .data_RAM3 : ALIGN(4)
+    {
+        FILL(0xff)
+        PROVIDE(__start_data_RAM3 = .) ;
+        *(.ramfunc.$RAM3)
+        *(.ramfunc.$SRAM_LOWER_AMBE)
+        *(.data.$RAM3*)
+        *(.data.$SRAM_LOWER_AMBE*)
+        . = ALIGN(4) ;
+        PROVIDE(__end_data_RAM3 = .) ;
+     } > SRAM_LOWER_AMBE AT>PROGRAM_FLASH
+     
+    /* DATA section for SRAM_LOWER */
+    .data_RAM4 : ALIGN(4)
+    {
+        FILL(0xff)
+        PROVIDE(__start_data_RAM4 = .) ;
+        *(vtable)
+        *(.ramfunc.$RAM4)
+        *(.ramfunc.$SRAM_LOWER_TOP)
+        *(.data.$RAM4*)
+        *(.data.$SRAM_LOWER_TOP*)
+        . = ALIGN(4) ;
+        PROVIDE(__end_data_RAM4 = .) ;
+     } > SRAM_LOWER_TOP AT>PROGRAM_FLASH
      
     /* MAIN DATA SECTION */
     .uninit_RESERVED : ALIGN(4)
@@ -98,10 +132,31 @@ SECTIONS
     {
        PROVIDE(__start_bss_RAM2 = .) ;
        *(.bss.$RAM2*)
-       *(.bss.$SRAM_LOWER*)
+       *(.bss.$SRAM_LOWER_BOTTOM*)
+       *(COMMON)
        . = ALIGN (. != 0 ? 4 : 1) ; /* avoid empty segment */
        PROVIDE(__end_bss_RAM2 = .) ;
-    } > SRAM_LOWER 
+    } > SRAM_LOWER_BOTTOM 
+
+    /* BSS section for SRAM_LOWER */
+    .bss_RAM3 : ALIGN(4)
+    {
+       PROVIDE(__start_bss_RAM3 = .) ;
+       *(.bss.$RAM3*)
+       *(.bss.$SRAM_LOWER_AMBE*)
+       . = ALIGN (. != 0 ? 4 : 1) ; /* avoid empty segment */
+       PROVIDE(__end_bss_RAM3 = .) ;
+    } > SRAM_LOWER_AMBE 
+
+    /* BSS section for SRAM_LOWER */
+    .bss_RAM4 : ALIGN(4)
+    {
+       PROVIDE(__start_bss_RAM4 = .) ;
+       *(.bss.$RAM4*)
+       *(.bss.$SRAM_LOWER_TOP*)
+       . = ALIGN (. != 0 ? 4 : 1) ; /* avoid empty segment */
+       PROVIDE(__end_bss_RAM4 = .) ;
+    } > SRAM_LOWER_TOP 
 
     /* MAIN BSS SECTION */
     .bss : ALIGN(4)
@@ -118,9 +173,9 @@ SECTIONS
     .noinit_RAM2 (NOLOAD) : ALIGN(4)
     {
        *(.noinit.$RAM2*)
-       *(.noinit.$SRAM_LOWER*)
+       *(.noinit.$SRAM_LOWER_BOTTOM*)
        . = ALIGN(4) ;
-    } > SRAM_LOWER 
+    } > SRAM_LOWER_BOTTOM 
 
     /* DEFAULT NOINIT SECTION */
     .noinit (NOLOAD): ALIGN(4)
@@ -139,21 +194,22 @@ SECTIONS
         . += _HeapSize;
         . = ALIGN(4);
         _pvHeapLimit = .;
-    } > SRAM_UPPER
+    } > SRAM_LOWER_TOP
 
      _StackSize = 0x1000;
      /* Reserve space in memory for Stack */
     .heap2stackfill  :
     {
         . += _StackSize;
-    } > SRAM_UPPER
+    } > SRAM_LOWER_TOP
+    
     /* Locate actual Stack in memory map */
-    .stack ORIGIN(SRAM_UPPER) + LENGTH(SRAM_UPPER) - _StackSize - 0:  ALIGN(4)
+    .stack ORIGIN(SRAM_LOWER_TOP) + LENGTH(SRAM_LOWER_TOP) - _StackSize - 0:  ALIGN(4)
     {
         _vStackBase = .;
         . = ALIGN(4);
         _vStackTop = . + _StackSize;
-    } > SRAM_UPPER
+    } > SRAM_LOWER_TOP
 
     /* Provide basic symbols giving location and size of main text
      * block, including initial values of RW data sections. Note that

--- a/firmware/linkerscripts/firmware.ld
+++ b/firmware/linkerscripts/firmware.ld
@@ -19,12 +19,9 @@ SECTIONS
         . = ALIGN(4) ;
         __section_table_start = .;
         __data_section_table = .;
-        LONG(LOADADDR(.data_RAM2));
-        LONG(    ADDR(.data_RAM2));
-        LONG(  SIZEOF(.data_RAM2));
-        LONG(LOADADDR(.data_RAM3));
-        LONG(    ADDR(.data_RAM3));
-        LONG(  SIZEOF(.data_RAM3));
+        LONG(LOADADDR(.data));
+        LONG(    ADDR(.data));
+        LONG(  SIZEOF(.data));
         LONG(LOADADDR(.data_RAM4));
         LONG(    ADDR(.data_RAM4));
         LONG(  SIZEOF(.data_RAM4));
@@ -34,8 +31,6 @@ SECTIONS
         LONG(  SIZEOF(.bss));
         LONG(    ADDR(.bss_RAM2));
         LONG(  SIZEOF(.bss_RAM2));
-        LONG(    ADDR(.bss_RAM3));
-        LONG(  SIZEOF(.bss_RAM3));
         LONG(    ADDR(.bss_RAM4));
         LONG(  SIZEOF(.bss_RAM4));
         __bss_section_table_end = .;
@@ -61,54 +56,32 @@ SECTIONS
     } > PROGRAM_FLASH
     
     /* DATA section for SRAM_LOWER */
-    .data_RAM2 : ALIGN(4)
-    {
-        FILL(0xff)
-        PROVIDE(__start_data_RAM2 = .) ;
-        *(.ramfunc.$RAM2)
-        *(.ramfunc.$SRAM_LOWER_BOTTOM)
-        *(.data.$RAM2*)
-        *(.data.$SRAM_LOWER_BOTTOM*)
-        . = ALIGN(4) ;
-        PROVIDE(__end_data_RAM2 = .) ;
-     } > SRAM_LOWER_BOTTOM AT>PROGRAM_FLASH
-     
-    /* DATA section for SRAM_LOWER */
-    .data_RAM3 : ALIGN(4)
-    {
-        FILL(0xff)
-        PROVIDE(__start_data_RAM3 = .) ;
-        *(.ramfunc.$RAM3)
-        *(.ramfunc.$SRAM_LOWER_AMBE)
-        *(.data.$RAM3*)
-        *(.data.$SRAM_LOWER_AMBE*)
-        . = ALIGN(4) ;
-        PROVIDE(__end_data_RAM3 = .) ;
-     } > SRAM_LOWER_AMBE AT>PROGRAM_FLASH
-     
-    /* DATA section for SRAM_LOWER */
     .data_RAM4 : ALIGN(4)
     {
         FILL(0xff)
-        PROVIDE(__start_data_RAM4 = .) ;
-        *(vtable)
+        PROVIDE(__start_data_RAM2 = .) ;
         *(.ramfunc.$RAM4)
         *(.ramfunc.$SRAM_LOWER_TOP)
         *(.data.$RAM4*)
         *(.data.$SRAM_LOWER_TOP*)
         . = ALIGN(4) ;
-        PROVIDE(__end_data_RAM4 = .) ;
+        PROVIDE(__end_data_RAM2 = .) ;
      } > SRAM_LOWER_TOP AT>PROGRAM_FLASH
      
-    /* MAIN DATA SECTION */
-    .uninit_RESERVED : ALIGN(4)
+    /* DATA section for SRAM_LOWER */
+    .data_AMBE : ALIGN(4)
     {
-        KEEP(*(.bss.$RESERVED*))
+        FILL(0xff)
+        PROVIDE(__start_data_RAM3 = .) ;
+        *(.ramfunc.$AMBE)
+        *(.ramfunc.$SRAM_LOWER_AMBE)
+        *(.data.$AMBE*)
+        *(.data.$SRAM_LOWER_AMBE*)
         . = ALIGN(4) ;
-        _end_uninit_RESERVED = .;
-    } > SRAM_UPPER
-
-    /* Main DATA section (SRAM_UPPER) */
+        PROVIDE(__end_data_RAM3 = .) ;
+     } > SRAM_LOWER_AMBE
+     
+         /* Main DATA section (SRAM_UPPER) */
     .data : ALIGN(4)
     {
        FILL(0xff)
@@ -118,7 +91,16 @@ SECTIONS
        *(.data*)
        . = ALIGN(4) ;
        _edata = . ;
-    } > SRAM_UPPER AT>PROGRAM_FLASH
+    } > SRAM_LOWER_BOTTOM AT>PROGRAM_FLASH
+     
+    /* MAIN DATA SECTION */
+    .uninit_RESERVED : ALIGN(4)
+    {
+        KEEP(*(.bss.$RESERVED*))
+        . = ALIGN(4) ;
+        _end_uninit_RESERVED = .;
+    } > SRAM_UPPER
+
 
     .fw_311_0x00050000_0x0007afff : ALIGN(4)
     {
@@ -137,16 +119,6 @@ SECTIONS
        . = ALIGN (. != 0 ? 4 : 1) ; /* avoid empty segment */
        PROVIDE(__end_bss_RAM2 = .) ;
     } > SRAM_LOWER_BOTTOM 
-
-    /* BSS section for SRAM_LOWER */
-    .bss_RAM3 : ALIGN(4)
-    {
-       PROVIDE(__start_bss_RAM3 = .) ;
-       *(.bss.$RAM3*)
-       *(.bss.$SRAM_LOWER_AMBE*)
-       . = ALIGN (. != 0 ? 4 : 1) ; /* avoid empty segment */
-       PROVIDE(__end_bss_RAM3 = .) ;
-    } > SRAM_LOWER_AMBE 
 
     /* BSS section for SRAM_LOWER */
     .bss_RAM4 : ALIGN(4)
@@ -169,13 +141,29 @@ SECTIONS
         PROVIDE(end = .);
     } > SRAM_UPPER
 
-    /* NOINIT section for SRAM_LOWER */
+    /* NOINIT section for SRAM_LOWER_BOTTOM */
     .noinit_RAM2 (NOLOAD) : ALIGN(4)
     {
        *(.noinit.$RAM2*)
        *(.noinit.$SRAM_LOWER_BOTTOM*)
        . = ALIGN(4) ;
     } > SRAM_LOWER_BOTTOM 
+    
+    /* NOINIT section for SRAM_LOWER_AMBE */
+    .noinit_AMBE (NOLOAD) : ALIGN(4)
+    {
+       *(.noinit.$AMBE*)
+       *(.noinit.$SRAM_LOWER_AMBE*)
+       . = ALIGN(4) ;
+    } > SRAM_LOWER_AMBE 
+
+    /* NOINIT section for SRAM_LOWER_TOP */
+    .noinit_RAM4 (NOLOAD) : ALIGN(4)
+    {
+       *(.noinit.$RAM4*)
+       *(.noinit.$SRAM_LOWER_TOP*)
+       . = ALIGN(4) ;
+    } > SRAM_LOWER_TOP 
 
     /* DEFAULT NOINIT SECTION */
     .noinit (NOLOAD): ALIGN(4)

--- a/firmware/linkerscripts/firmware_memory.ld
+++ b/firmware/linkerscripts/firmware_memory.ld
@@ -7,7 +7,9 @@ MEMORY
   /* Define each memory region */
   PROGRAM_FLASH (rx) : ORIGIN = 0x4000, LENGTH = 0x7B800 /* 0x00004000-0x007f7ff (alias Flash) */  
   SRAM_UPPER (rwx) : ORIGIN = 0x20000000, LENGTH = 0x10000 /* 64K bytes (alias RAM) */  
-  SRAM_LOWER (rwx) : ORIGIN = 0x1fff0000, LENGTH = 0x10000 /* 64K bytes (alias RAM2) */  
+  SRAM_LOWER_BOTTOM (rwx) : ORIGIN = 0x1fff0000, LENGTH = 0x4000 /* 16K bytes (alias RAM2_BOTTOM) */
+  SRAM_LOWER_AMBE (rwx) : ORIGIN = 0x1fff4000, LENGTH = 0x8000 /* 32K bytes (alias RAM2_AMBE) */
+  SRAM_LOWER_TOP (rwx) : ORIGIN = 0x1fffc000, LENGTH = 0x4000 /* 16K bytes (alias RAM2_TOP) */
 }
 
   /* Define a symbol for the top of each memory region */
@@ -19,7 +21,11 @@ MEMORY
   __base_RAM = 0x20000000 ; /* RAM */  
   __top_SRAM_UPPER = 0x20000000 + 0x10000 ; /* 64K bytes */  
   __top_RAM = 0x20000000 + 0x10000 ; /* 64K bytes */  
-  __base_SRAM_LOWER = 0x1fff0000  ; /* SRAM_LOWER */  
+  __base_SRAM_LOWER_BOTTOM = 0x1fff0000  ; /* SRAM_LOWER */  
+  __base_SRAM_LOWER_AMDE = 0x1fff4000 ;
+  __base_SRAM_LOWER_TOP = 0x1fffc000 ;
   __base_RAM2 = 0x1fff0000 ; /* RAM2 */  
-  __top_SRAM_LOWER = 0x1fff0000 + 0x10000 ; /* 64K bytes */  
+  __top_SRAM_LOWER_BOTTOM = 0x1fff0000 + 0x4000 ; /* 64K bytes */  
+  __top_SRAM_LOWER_AMBE = 0x1fff4000 + 0x8000 ; /* 64K bytes */  
+  __top_SRAM_LOWER_TOP = 0x1fffc000 + 0x4000 ; /* 64K bytes */  
   __top_RAM2 = 0x1fff0000 + 0x10000 ; /* 64K bytes */  

--- a/firmware/linkerscripts/firmware_memory.ld
+++ b/firmware/linkerscripts/firmware_memory.ld
@@ -7,9 +7,9 @@ MEMORY
   /* Define each memory region */
   PROGRAM_FLASH (rx) : ORIGIN = 0x4000, LENGTH = 0x7B800 /* 0x00004000-0x007f7ff (alias Flash) */  
   SRAM_UPPER (rwx) : ORIGIN = 0x20000000, LENGTH = 0x10000 /* 64K bytes (alias RAM) */  
-  SRAM_LOWER_BOTTOM (rwx) : ORIGIN = 0x1fff0000, LENGTH = 0x4000 /* 16K bytes (alias RAM2_BOTTOM) */
-  SRAM_LOWER_AMBE (rwx) : ORIGIN = 0x1fff4000, LENGTH = 0x8000 /* 32K bytes (alias RAM2_AMBE) */
-  SRAM_LOWER_TOP (rwx) : ORIGIN = 0x1fffc000, LENGTH = 0x4000 /* 16K bytes (alias RAM2_TOP) */
+  SRAM_LOWER_BOTTOM (rwx) : ORIGIN = 0x1fff0000, LENGTH = 0x6b60 /* (alias RAM2_BOTTOM) */
+  SRAM_LOWER_AMBE (rwx) : ORIGIN = 0x1fff6b60, LENGTH = 0x2228 /* (alias RAM2_AMBE) */
+  SRAM_LOWER_TOP (rwx) : ORIGIN = 0x1fff8d88, LENGTH = 0x7278 /* (alias RAM2_TOP) */
 }
 
   /* Define a symbol for the top of each memory region */
@@ -22,10 +22,10 @@ MEMORY
   __top_SRAM_UPPER = 0x20000000 + 0x10000 ; /* 64K bytes */  
   __top_RAM = 0x20000000 + 0x10000 ; /* 64K bytes */  
   __base_SRAM_LOWER_BOTTOM = 0x1fff0000  ; /* SRAM_LOWER */  
-  __base_SRAM_LOWER_AMDE = 0x1fff4000 ;
-  __base_SRAM_LOWER_TOP = 0x1fffc000 ;
+  __base_SRAM_LOWER_AMBE = 0x1fff6b60 ;
+  __base_SRAM_LOWER_TOP = 0x1fff8d88 ;
   __base_RAM2 = 0x1fff0000 ; /* RAM2 */  
-  __top_SRAM_LOWER_BOTTOM = 0x1fff0000 + 0x4000 ; /* 64K bytes */  
-  __top_SRAM_LOWER_AMBE = 0x1fff4000 + 0x8000 ; /* 64K bytes */  
-  __top_SRAM_LOWER_TOP = 0x1fffc000 + 0x4000 ; /* 64K bytes */  
+  __top_SRAM_LOWER_BOTTOM = 0x1fff0000 + 0x6b60 ;
+  __top_SRAM_LOWER_AMBE = 0x1fff6b60 + 0x2228 ;
+  __top_SRAM_LOWER_TOP = 0x1fff8d88 + 0x7278 ;
   __top_RAM2 = 0x1fff0000 + 0x10000 ; /* 64K bytes */  


### PR DESCRIPTION
The AMBE coder uses a block of ~8.5K In the middle of the lower 64K-SRAM for decoding and encoding. The space before and after is currently not used.

The .data section is now moved into the space before the AMBE RAM.
Heap (4KB) and stack (4KB) are moved to the space after the AMBE RAM.
This frees around 8.5K bytes in the upper 64K-SRAM.

This results in a memory usage of:
- upper SRAM: 64KB used ~41KB
- lower SRAM before AMBE: ~26.8KB used: 604B
- lower SRAM after AMBE: ~28.6KB used: 8KB
 
The compiler/linker positions all uninitialized variables into the .bss section in the upper SRAM and all initialized variables will get into the lower SRAM.

Moving a variable to a specific section is possible like this:
`BSS_LOWER_BOTTOM int var_in_lower_before_ambe_bss;`
`BSS_LOWER_TOP int var_in_lower_after_ambe_bss;`
`DATA_LOWER_TOP int var_in_lower_after_ambe_data;`

