### PR TITLE
[UPDATED] Fix timing (based on ticks) problems, fw_millis() returns ms. uiEvent ticks member renamed to time.

### DIFF
--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -96,7 +96,7 @@ void menuBatteryPushBackVoltage(int32_t voltage);
 
 void menuLockScreenPop(void);
 
-void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool shortVersion);
+void menuLastHeardUpdateScreen(bool showTitleOrHeader);
 
 void menuClearPrivateCall(void);
 void menuAcceptPrivateCall(int id);

--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -27,7 +27,7 @@ typedef struct
 	keyboardCode_t  keys;
 	uiEventInput_t	events;
 	bool		    hasEvent;
-	uint32_t 	    ticks;
+	uint32_t 	    time;
 } uiEvent_t;
 
 #define MENU_MAX_DISPLAYED_ENTRIES 3
@@ -92,7 +92,7 @@ void menuBatteryPushBackVoltage(int32_t voltage);
 
 void menuLockScreenPop(void);
 
-void menuLastHeardupdateScreen(bool showTitleOrHeader);
+void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool shortVersion);
 
 /*
  * ---------------------- IMPORTANT ----------------------------

--- a/firmware/include/user_interface/uiUtilityQSOData.h
+++ b/firmware/include/user_interface/uiUtilityQSOData.h
@@ -65,7 +65,6 @@ extern const uint32_t RSSI_UPDATE_COUNTER_RELOAD;
 
 char *chomp(char *str);
 int32_t getCallsignEndingPos(char *str);
-void printSplitOrSpanText(uint8_t y, char *text, bool smallFont);
 bool dmrIDLookup(int targetId, dmrIdDataStruct_t *foundRecord);
 bool contactIDLookup(uint32_t id, int calltype, char *buffer);
 void menuUtilityRenderQSOData(void);

--- a/firmware/include/user_interface/uiUtilityQSOData.h
+++ b/firmware/include/user_interface/uiUtilityQSOData.h
@@ -61,6 +61,9 @@ extern uint32_t menuUtilityReceivedPcId;
 extern uint32_t menuUtilityTgBeforePcMode;
 extern const uint32_t RSSI_UPDATE_COUNTER_RELOAD;
 
+char *chomp(char *str);
+int32_t getCallsignEndingPos(char *str);
+void printSplitOrSpanText(uint8_t y, char *text, bool smallFont);
 bool dmrIDLookup(int targetId, dmrIdDataStruct_t *foundRecord);
 bool contactIDLookup(uint32_t id, int calltype, char *buffer);
 void menuUtilityRenderQSOData(void);

--- a/firmware/source/functions/fw_ticks.c
+++ b/firmware/source/functions/fw_ticks.c
@@ -16,10 +16,9 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "fw_ticks.h"
+#include <functions/fw_ticks.h>
 
-#define PIT_COUNTS_PER_SECOND  10000U
-#define PIT_COUNTS_PER_MS      (PIT_COUNTS_PER_SECOND / 1000U)
+#define PIT_COUNTS_PER_MS  10U
 
 extern volatile uint32_t PITCounter;
 

--- a/firmware/source/functions/fw_ticks.c
+++ b/firmware/source/functions/fw_ticks.c
@@ -18,9 +18,13 @@
 
 #include "fw_ticks.h"
 
+#define PIT_COUNTS_PER_SECOND  10000U
+#define PIT_COUNTS_PER_MS      (PIT_COUNTS_PER_SECOND / 1000U)
+
+extern volatile uint32_t PITCounter;
 
 uint32_t fw_millis(void)
 {
-	return xTaskGetTickCount();
+	return (PITCounter / PIT_COUNTS_PER_MS);
 }
 

--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -66,7 +66,7 @@ void fw_main_task(void *data)
 	int key_event;
 	uint32_t buttons;
 	int button_event;
-	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .ticks = 0 };
+	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .time = 0 };
 	bool keyOrButtonChanged = false;
 	
     USB_DeviceApplicationInit();
@@ -389,7 +389,7 @@ void fw_main_task(void *data)
     		ev.keys = keys;
     		ev.events = (button_event<<1) | key_event;
     		ev.hasEvent = keyOrButtonChanged;
-    		ev.ticks = fw_millis();
+    		ev.time = fw_millis();
 
         	menuSystemCallCurrentMenuTick(&ev);
 

--- a/firmware/source/user_interface/menuBattery.c
+++ b/firmware/source/user_interface/menuBattery.c
@@ -108,10 +108,10 @@ int menuBattery(uiEvent_t *ev, bool isFirstRun)
 	}
 	else
 	{
-		if ((ev->ticks - m) > 2000)
+		if ((ev->time - m) > 500)
 		{
-			m = ev->ticks;
-			updateScreen(false);// update the screen each two seconds to show any changes to the battery voltage
+			m = ev->time;
+			updateScreen(false);// update the screen each 500ms to show any changes to the battery voltage or low battery
 		}
 
 		if (ev->hasEvent)

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -18,25 +18,17 @@
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiUtilityQSOData.h>
 #include <user_interface/uiLocalisation.h>
-#include <functions/fw_ticks.h>
-
 const int LAST_HEARD_NUM_LINES_ON_DISPLAY = 3;
-static bool displayLHDetails = false;
 
 static void handleEvent(uiEvent_t *ev);
-static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_t now, uint32_t TGorPC, size_t maxLen, bool displayDetails);
 
 int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 {
-	static uint32_t m = 0;
-
 	if (isFirstRun)
 	{
 		gMenusStartIndex = LinkHead->id;// reuse this global to store the ID of the first item in the list
 		gMenusEndIndex=0;
-		displayLHDetails = false;
-		menuLastHeardUpdateScreen(true, displayLHDetails);
-		m = ev->time;
+		menuLastHeardUpdateScreen(true);
 	}
 	else
 	{
@@ -46,35 +38,22 @@ int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 			gMenusStartIndex = LinkHead->id;
 			gMenusCurrentItemIndex=0;
 			gMenusEndIndex=0;
-			menuLastHeardUpdateScreen(true, displayLHDetails);
+			menuLastHeardUpdateScreen(true);
 		}
 
 		if (ev->hasEvent)
-		{
-			m = ev->time;
-
 			handleEvent(ev);
-		}
-		else
-		{
-			// Just refresh the list while displaying extra infos, it's all about elapsed time
-			if (displayLHDetails && ((fw_millis() - m) > 500))
-			{
-				menuLastHeardUpdateScreen(true, true);
-			}
-		}
 	}
 	return 0;
 }
 
-void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool displayDetails)
+void menuLastHeardUpdateScreen(bool showTitleOrHeader)
 {
 	static const int bufferLen = 17;
 	char buffer[bufferLen];
 	dmrIdDataStruct_t foundRecord;
-	int numDisplayed = 0;
+	int numDisplayed=0;
 	LinkItem_t *item = LinkHead;
-	uint32_t now = fw_millis();
 
 	ucClearBuf();
 	if (showTitleOrHeader)
@@ -87,58 +66,53 @@ void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool displayDetails)
 	}
 
 	// skip over the first gMenusCurrentItemIndex in the listing
-	for(int i = 0; i < gMenusCurrentItemIndex; i++)
+	for(int i=0;i<gMenusCurrentItemIndex;i++)
 	{
-		item = item->next;
+		item=item->next;
 	}
-
 	while((item != NULL) && item->id != 0)
 	{
-		if (dmrIDLookup(item->id, &foundRecord))
+		if (dmrIDLookup(item->id,&foundRecord))
 		{
-			menuLastHeardDisplayTA(16 + (numDisplayed * 16), foundRecord.text, item->time, now, item->talkGroupOrPcId, 20, displayDetails);
-			//ucPrintCentered(16 + (numDisplayed * 16), foundRecord.text, FONT_8x16);
+			ucPrintCentered(16+(numDisplayed*16), foundRecord.text, FONT_8x16);
 		}
 		else
 		{
 			if (item->talkerAlias[0] != 0x00)
 			{
-				menuLastHeardDisplayTA(16 + (numDisplayed * 16), item->talkerAlias, item->time, now, item->talkGroupOrPcId, 32, displayDetails);
-				//memcpy(buffer, item->talkerAlias, bufferLen - 1);// limit to 1 line of the display which is 16 chars at the normal font size
+				memcpy(buffer, item->talkerAlias, bufferLen - 1);// limit to 1 line of the display which is 16 chars at the normal font size
 			}
 			else
 			{
 				snprintf(buffer, bufferLen, "ID:%d", item->id);
-				buffer[bufferLen - 1] = 0;
-				menuLastHeardDisplayTA(16 + (numDisplayed * 16), buffer, item->time, now, item->talkGroupOrPcId, bufferLen, displayDetails);
-				//ucPrintCentered(16 + (numDisplayed * 16), buffer, FONT_8x16);
 			}
+			buffer[bufferLen - 1] = 0;
+			ucPrintCentered(16+(numDisplayed*16), buffer, FONT_8x16);
 		}
 
 		numDisplayed++;
 
-		item = item->next;
-		if (numDisplayed > (LAST_HEARD_NUM_LINES_ON_DISPLAY - 1))
+		item=item->next;
+		if (numDisplayed > (LAST_HEARD_NUM_LINES_ON_DISPLAY -1))
 		{
-			if (item != NULL && item->id != 0)
+			if (item!=NULL && item->id != 0)
 			{
-				gMenusEndIndex = 0x01;
+				gMenusEndIndex=0x01;
 			}
 			else
 			{
-				gMenusEndIndex = 0;
+				gMenusEndIndex=0;
 			}
 			break;
 		}
 	}
-
 	ucRender();
+	displayLightTrigger();
 	menuDisplayQSODataState = QSO_DISPLAY_IDLE;
 }
 
 static void handleEvent(uiEvent_t *ev)
 {
-	displayLightTrigger();
 
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
@@ -162,140 +136,5 @@ static void handleEvent(uiEvent_t *ev)
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}
-
-	// Display Last Heard details while SK1 is pressed
-	if ((displayLHDetails == false) && (ev->buttons == BUTTON_SK1))
-	{
-		displayLHDetails = true;
-		menuLastHeardUpdateScreen(true, displayLHDetails);
-		return;
-	}
-	else if (displayLHDetails && ((ev->buttons & BUTTON_SK1) == 0))
-	{
-		displayLHDetails = false;
-		menuLastHeardUpdateScreen(true, displayLHDetails);
-		return;
-	}
-
-	menuLastHeardUpdateScreen(true, false);
-}
-
-static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_t now, uint32_t TGorPC, size_t maxLen, bool displayDetails)
-{
-	static bool alt = true;
-	char buffer[37]; // Max: TA 27 (in 7bit format) + ' [' + 6 (Maidenhead)  + ']' + NULL
-	static uint32_t m = 0;
-
-	if ((now - m) > 2000)
-	{
-		m = now;
-		alt = !alt;
-	}
-
-	// Display elapsed time or TG/PC
-	if (displayDetails)
-	{
-		char buf[17]; // hhh:mm:ss or TG/PC
-
-		if (alt)
-		{
-			sprintf(buf, "%u", TGorPC);
-		}
-		else
-		{
-			uint32_t diffTimeInSecs = ((now - time) / 1000U);
-			uint16_t h = (diffTimeInSecs / 3600);
-			uint16_t m = (diffTimeInSecs - (3600 * h)) / 60;
-			uint16_t s = (diffTimeInSecs - (3600 * h) - (m * 60));
-			snprintf(buf, 10, "%02d:%02d:%02d", h, m, s);
-			buf[9] = 0;
-		}
-
-		ucPrintAt((128 - (strlen(buf) * 6) - 4), y, buf, FONT_6x8_BOLD);
-	}
-
-	if (strlen(text) >= 5)
-	{
-		char    *pbuf;
-		int32_t  cpos;
-
-		if ((cpos = getCallsignEndingPos(text)) != -1)
-		{
-			// Callsign found
-
-			if (displayDetails == false)
-			{
-				if (cpos > 15)
-					cpos = 16;
-
-				memcpy(buffer, text, cpos);
-				buffer[cpos] = 0;
-				ucPrintCentered(y, chomp(buffer), FONT_8x16);
-			}
-			else
-			{
-				if (cpos > 10)
-					cpos = 11;
-
-				memcpy(buffer, text, cpos);
-				buffer[cpos] = 0;
-
-				ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
-
-				memcpy(buffer, text + (cpos + 1), (maxLen - (cpos + 1)));
-				buffer[(strlen(text) - (cpos + 1))] = 0;
-
-				pbuf = chomp(buffer);
-
-				size_t len = strlen(pbuf);
-				if (len)
-				{
-					if (len > 21)
-						*(pbuf + 21) = 0;
-
-					printSplitOrSpanText(y + 8, pbuf, true);
-				}
-			}
-		}
-		else
-		{
-			// No space found, use a chainsaw
-
-			if (displayDetails == false)
-			{
-				memcpy(buffer, text, 16);
-				buffer[16] = 0;
-				ucPrintCentered(y, chomp(buffer), FONT_8x16);
-			}
-			else
-			{
-				memcpy(buffer, text, 11);
-				buffer[11] = 0;
-
-				ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
-
-				memcpy(buffer, text + 11, 21);
-				buffer[21] = 0;
-
-				pbuf = chomp(buffer);
-
-				if (strlen(pbuf))
-					printSplitOrSpanText(y + 8, pbuf, true);
-			}
-		}
-	}
-	else
-	{
-		memcpy(buffer, text, strlen(text));
-		buffer[strlen(text)] = 0;
-
-		if (displayDetails == false)
-		{
-			ucPrintCentered(y, chomp(buffer), FONT_8x16);
-		}
-		else
-		{
-			ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
-		}
-	}
+	menuLastHeardUpdateScreen(true);
 }

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -208,15 +208,24 @@ static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_
 		if ((cpos = getCallsignEndingPos(text)) != -1)
 		{
 			// Callsign found
-			memcpy(buffer, text, cpos);
-			buffer[cpos] = 0;
 
 			if (displayDetails == false)
 			{
+				if (cpos > 15)
+					cpos = 16;
+
+				memcpy(buffer, text, cpos);
+				buffer[cpos] = 0;
 				ucPrintCentered(y, chomp(buffer), FONT_8x16);
 			}
 			else
 			{
+				if (cpos > 10)
+					cpos = 11;
+
+				memcpy(buffer, text, cpos);
+				buffer[cpos] = 0;
+
 				ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
 
 				memcpy(buffer, text + (cpos + 1), (maxLen - (cpos + 1)));
@@ -231,19 +240,22 @@ static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_
 		else
 		{
 			// No space found, use a chainsaw
-			memcpy(buffer, text, 16);
-			buffer[16] = 0;
 
 			if (displayDetails == false)
 			{
+				memcpy(buffer, text, 16);
+				buffer[16] = 0;
 				ucPrintCentered(y, chomp(buffer), FONT_8x16);
 			}
 			else
 			{
+				memcpy(buffer, text, 11);
+				buffer[11] = 0;
+
 				ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
 
-				memcpy(buffer, text + 16, (maxLen - 16));
-				buffer[(strlen(text) - 16)] = 0;
+				memcpy(buffer, text + 11, (maxLen - 11));
+				buffer[(strlen(text) - 11)] = 0;
 
 				pbuf = chomp(buffer);
 

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -18,9 +18,13 @@
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiUtilityQSOData.h>
 #include <user_interface/uiLocalisation.h>
+#include <functions/fw_ticks.h>
+
 const int LAST_HEARD_NUM_LINES_ON_DISPLAY = 3;
+static bool displayLHDetails = false;
 
 static void handleEvent(uiEvent_t *ev);
+static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, size_t maxLen, bool displayDetails);
 
 int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 {
@@ -28,7 +32,8 @@ int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 	{
 		gMenusStartIndex = LinkHead->id;// reuse this global to store the ID of the first item in the list
 		gMenusEndIndex=0;
-		menuLastHeardupdateScreen(true);
+		displayLHDetails = false;
+		menuLastHeardUpdateScreen(true, displayLHDetails);
 	}
 	else
 	{
@@ -38,7 +43,7 @@ int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 			gMenusStartIndex = LinkHead->id;
 			gMenusCurrentItemIndex=0;
 			gMenusEndIndex=0;
-			menuLastHeardupdateScreen(true);
+			menuLastHeardUpdateScreen(true, displayLHDetails);
 		}
 
 		if (ev->hasEvent)
@@ -47,14 +52,12 @@ int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 	return 0;
 }
 
-
-
-void menuLastHeardupdateScreen(bool showTitleOrHeader)
+void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool displayDetails)
 {
 	static const int bufferLen = 17;
 	char buffer[bufferLen];
 	dmrIdDataStruct_t foundRecord;
-	int numDisplayed=0;
+	int numDisplayed = 0;
 	LinkItem_t *item = LinkHead;
 
 	ucClearBuf();
@@ -68,53 +71,58 @@ void menuLastHeardupdateScreen(bool showTitleOrHeader)
 	}
 
 	// skip over the first gMenusCurrentItemIndex in the listing
-	for(int i=0;i<gMenusCurrentItemIndex;i++)
+	for(int i = 0; i < gMenusCurrentItemIndex; i++)
 	{
-		item=item->next;
+		item = item->next;
 	}
+
 	while((item != NULL) && item->id != 0)
 	{
-		if (dmrIDLookup(item->id,&foundRecord))
+		if (dmrIDLookup(item->id, &foundRecord))
 		{
-			ucPrintCentered(16+(numDisplayed*16), foundRecord.text, FONT_8x16);
+			menuLastHeardDisplayTA(16 + (numDisplayed * 16), foundRecord.text, item->time, 20, displayDetails);
+			//ucPrintCentered(16 + (numDisplayed * 16), foundRecord.text, FONT_8x16);
 		}
 		else
 		{
 			if (item->talkerAlias[0] != 0x00)
 			{
-				memcpy(buffer, item->talkerAlias, bufferLen - 1);// limit to 1 line of the display which is 16 chars at the normal font size
+				menuLastHeardDisplayTA(16 + (numDisplayed * 16), item->talkerAlias, item->time, 32, displayDetails);
+				//memcpy(buffer, item->talkerAlias, bufferLen - 1);// limit to 1 line of the display which is 16 chars at the normal font size
 			}
 			else
 			{
 				snprintf(buffer, bufferLen, "ID:%d", item->id);
+				buffer[bufferLen - 1] = 0;
+				menuLastHeardDisplayTA(16 + (numDisplayed * 16), buffer, item->time, bufferLen, displayDetails);
+				//ucPrintCentered(16 + (numDisplayed * 16), buffer, FONT_8x16);
 			}
-			buffer[bufferLen - 1] = 0;
-			ucPrintCentered(16+(numDisplayed*16), buffer, FONT_8x16);
 		}
 
 		numDisplayed++;
 
-		item=item->next;
-		if (numDisplayed > (LAST_HEARD_NUM_LINES_ON_DISPLAY -1))
+		item = item->next;
+		if (numDisplayed > (LAST_HEARD_NUM_LINES_ON_DISPLAY - 1))
 		{
-			if (item!=NULL && item->id != 0)
+			if (item != NULL && item->id != 0)
 			{
-				gMenusEndIndex=0x01;
+				gMenusEndIndex = 0x01;
 			}
 			else
 			{
-				gMenusEndIndex=0;
+				gMenusEndIndex = 0;
 			}
 			break;
 		}
 	}
+
 	ucRender();
-	displayLightTrigger();
 	menuDisplayQSODataState = QSO_DISPLAY_IDLE;
 }
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
 
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
@@ -138,5 +146,108 @@ static void handleEvent(uiEvent_t *ev)
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}
-	menuLastHeardupdateScreen(true);
+
+	// Display Last Heard details while SK1 is pressed
+	if ((displayLHDetails == false) && (ev->buttons == BUTTON_SK1))
+	{
+		displayLHDetails = true;
+		menuLastHeardUpdateScreen(true, displayLHDetails);
+		return;
+	}
+	else if (displayLHDetails && ((ev->buttons & BUTTON_SK1) == 0))
+	{
+		displayLHDetails = false;
+		menuLastHeardUpdateScreen(true, displayLHDetails);
+		return;
+	}
+
+	menuLastHeardUpdateScreen(true, false);
+}
+
+static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, size_t maxLen, bool displayDetails)
+{
+	char buffer[37]; // Max: TA 27 (in 7bit format) + ' [' + 6 (Maidenhead)  + ']' + NULL
+
+	// Display elapsed time
+	if (displayDetails)
+	{
+
+		char buf[10]; // hhh:mm:ss
+		uint32_t diffTimeInSecs = ((fw_millis() - time) / 1000U);
+		uint16_t h = (diffTimeInSecs / 3600);
+		uint16_t m = (diffTimeInSecs - (3600 * h)) / 60;
+		uint16_t s = (diffTimeInSecs - (3600 * h) - (m * 60));
+		snprintf(buf, 10, "%02d:%02d:%02d", h, m, s);
+		buf[9] = 0;
+
+		ucPrintAt(((128 - (8 * 6)) - 4), y, buf, FONT_6x8_BOLD);
+
+	}
+
+	if (strlen(text) >= 5)
+	{
+		char    *pbuf;
+		int32_t  cpos;
+
+		if ((cpos = getCallsignEndingPos(text)) != -1)
+		{
+			// Callsign found
+			memcpy(buffer, text, cpos);
+			buffer[cpos] = 0;
+
+			if (displayDetails == false)
+			{
+				ucPrintCentered(y, chomp(buffer), FONT_8x16);
+			}
+			else
+			{
+				ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
+
+				memcpy(buffer, text + (cpos + 1), (maxLen - (cpos + 1)));
+				buffer[(strlen(text) - (cpos + 1))] = 0;
+
+				pbuf = chomp(buffer);
+
+				if (strlen(pbuf))
+					printSplitOrSpanText(y + 8, pbuf, true);
+			}
+		}
+		else
+		{
+			// No space found, use a chainsaw
+			memcpy(buffer, text, 16);
+			buffer[16] = 0;
+
+			if (displayDetails == false)
+			{
+				ucPrintCentered(y, chomp(buffer), FONT_8x16);
+			}
+			else
+			{
+				ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
+
+				memcpy(buffer, text + 16, (maxLen - 16));
+				buffer[(strlen(text) - 16)] = 0;
+
+				pbuf = chomp(buffer);
+
+				if (strlen(pbuf))
+					printSplitOrSpanText(y + 8, pbuf, true);
+			}
+		}
+	}
+	else
+	{
+		memcpy(buffer, text, strlen(text));
+		buffer[strlen(text)] = 0;
+
+		if (displayDetails == false)
+		{
+			ucPrintCentered(y, chomp(buffer), FONT_8x16);
+		}
+		else
+		{
+			ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
+		}
+	}
 }

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -247,8 +247,14 @@ static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_
 
 				pbuf = chomp(buffer);
 
-				if (strlen(pbuf))
+				size_t len = strlen(pbuf);
+				if (len)
+				{
+					if (len > 21)
+						*(pbuf + 21) = 0;
+
 					printSplitOrSpanText(y + 8, pbuf, true);
+				}
 			}
 		}
 		else
@@ -268,8 +274,8 @@ static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_
 
 				ucPrintAt(4, y, chomp(buffer), FONT_6x8_BOLD);
 
-				memcpy(buffer, text + 11, (maxLen - 11));
-				buffer[(strlen(text) - 11)] = 0;
+				memcpy(buffer, text + 11, 21);
+				buffer[21] = 0;
 
 				pbuf = chomp(buffer);
 

--- a/firmware/source/user_interface/menuRSSIScreen.c
+++ b/firmware/source/user_interface/menuRSSIScreen.c
@@ -39,9 +39,9 @@ int menuRSSIScreen(uiEvent_t *ev, bool isFirstRun)
 		if (ev->hasEvent)
 			handleEvent(ev);
 
-		if((ev->ticks - m) > RSSI_UPDATE_COUNTER_RELOAD)
+		if((ev->time - m) > RSSI_UPDATE_COUNTER_RELOAD)
 		{
-			m = ev->ticks;
+			m = ev->time;
 			updateScreen();
 		}
 	}

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -98,7 +98,7 @@ void menuSystemPushNewMenu(int menuNumber)
 {
 	if (menuControlData.stackPosition < 15)
 	{
-		uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .ticks = fw_millis() };
+		uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
 		fw_reset_keyboard();
 		menuControlData.itemIndex[menuControlData.stackPosition] = gMenusCurrentItemIndex;
@@ -110,7 +110,7 @@ void menuSystemPushNewMenu(int menuNumber)
 }
 void menuSystemPopPreviousMenu(void)
 {
-	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .ticks = fw_millis() };
+	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
 	fw_reset_keyboard();
 	menuControlData.itemIndex[menuControlData.stackPosition] = 0;
@@ -121,7 +121,7 @@ void menuSystemPopPreviousMenu(void)
 
 void menuSystemPopAllAndDisplayRootMenu(void)
 {
-	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .ticks = fw_millis() };
+	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
 	fw_reset_keyboard();
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
@@ -132,7 +132,7 @@ void menuSystemPopAllAndDisplayRootMenu(void)
 
 void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu)
 {
-	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .ticks = fw_millis() };
+	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
 	fw_reset_keyboard();
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
@@ -144,7 +144,7 @@ void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu)
 
 void menuSystemSetCurrentMenu(int menuNumber)
 {
-	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .ticks = fw_millis() };
+	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
 	fw_reset_keyboard();
 	menuControlData.stack[menuControlData.stackPosition] = menuNumber;
@@ -193,7 +193,7 @@ int gMenusEndIndex;// as above
 
 void menuInitMenuSystem(void)
 {
-	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .ticks = fw_millis() };
+	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
 	menuDisplayLightTimer = -1;
 	menuControlData.stack[menuControlData.stackPosition]  = MENU_SPLASH_SCREEN;// set the very first screen as the splash screen
@@ -340,7 +340,7 @@ void menuUpdateCursor(int pos, bool moved, bool render)
 	if (moved) {
 		blink = true;
 	}
-	if (moved || (m - lastBlink) > 1000)
+	if (moved || (m - lastBlink) > 500)
 	{
 		ucDrawFastHLine(pos*8, 46, 8, blink);
 

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -113,7 +113,7 @@ void menuSystemPushNewMenuWithQuickFunction(int menuNumber, int quickFunction)
 {
 	if (menuControlData.stackPosition < 15)
 	{
-		uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .function = quickFunction, .events = FUNCTION_EVENT, .hasEvent = false, .ticks = fw_millis() };
+		uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .function = quickFunction, .events = FUNCTION_EVENT, .hasEvent = false, .time = fw_millis() };
 
 		fw_reset_keyboard();
 		menuControlData.itemIndex[menuControlData.stackPosition] = gMenusCurrentItemIndex;

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -110,7 +110,7 @@ int menuChannelMode(uiEvent_t *ev, bool isFirstRun)
 			else
 			{
 				// Clear squelch region
-				if (displaySquelch && ((ev->ticks - sqm) > 2000))
+				if (displaySquelch && ((ev->time - sqm) > 1000))
 				{
 					displaySquelch = false;
 
@@ -118,9 +118,9 @@ int menuChannelMode(uiEvent_t *ev, bool isFirstRun)
 					ucRenderRows(2,4);
 				}
 
-				if ((ev->ticks - m) > RSSI_UPDATE_COUNTER_RELOAD)
+				if ((ev->time - m) > RSSI_UPDATE_COUNTER_RELOAD)
 				{
-					m = ev->ticks;
+					m = ev->time;
 					drawRSSIBarGraph();
 					ucRenderRows(1,2);// Only render the second row which contains the bar graph, as there is no need to redraw the rest of the screen
 				}
@@ -138,7 +138,7 @@ int menuChannelMode(uiEvent_t *ev, bool isFirstRun)
 				if ((trxGetMode() == RADIO_MODE_ANALOG) &&
 						(ev->events & KEY_EVENT) && ((ev->keys.key == KEY_LEFT) || (ev->keys.key == KEY_RIGHT)))
 				{
-					sqm = ev->ticks;
+					sqm = ev->time;
 				}
 
 				handleEvent(ev);
@@ -343,7 +343,7 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 				}
 				ucPrintCentered(CONTACT_Y_POS + verticalPositionOffset, nameBuf, FONT_8x16);
 			}
-			// Squelch will be cleared later, 2000 ticks after last change
+			// Squelch will be cleared later, 1s after last change
 			else if(displaySquelch && !trxIsTransmitting && !displayChannelSettings)
 			{
 				static const int xbar = 74; // 128 - (51 /* max squelch px */ + 3);
@@ -357,7 +357,7 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 				ucFillRect(xbar, 19, bargraph, 9, false);
 			}
 
-			// SK1 is pressed, we don't want to clear the first info row after 2000 ticks
+			// SK1 is pressed, we don't want to clear the first info row after 1s
 			if (displayChannelSettings && displaySquelch)
 			{
 				displaySquelch = false;
@@ -1067,7 +1067,7 @@ static void scanning(void)
 	{
 
 		trx_measure_count=0;														//needed to allow time for Rx to settle after channel change.
-		uiEvent_t tmpEvent={ .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = 0, .ticks = 0 };
+		uiEvent_t tmpEvent={ .buttons = 0, .keys = NO_KEYCODE, .events = NO_EVENT, .hasEvent = 0, .time = 0 };
 
 		handleUpKey(&tmpEvent);
 		if ((trxGetMode() == RADIO_MODE_DIGITAL) && (trxDMRMode == DMR_MODE_ACTIVE) && (SCAN_TOTAL_INTERVAL < SCAN_DMR_SIMPLEX_MIN_INTERVAL) )				//allow extra time if scanning a simplex DMR channel.

--- a/firmware/source/user_interface/uiHotspot.c
+++ b/firmware/source/user_interface/uiHotspot.c
@@ -159,7 +159,7 @@ volatile int  	rfFrameBufWriteIdx = 0;
 volatile int	rfFrameBufCount = 0;
 static uint8_t lastRxState = HOTSPOT_RX_IDLE;
 static const int TX_BUFFERING_TIMEOUT = 5000;// 500mS
-static const uint32_t MMDVMHOST_TIMEOUT = 5000; // 1s
+static const uint32_t MMDVMHOST_TIMEOUT = 10000; // 10s
 static int timeoutCounter;
 static int savedPowerLevel = -1;// no power level saved yet
 static int hotspotPowerLevel = 0;// no power level saved yet

--- a/firmware/source/user_interface/uiHotspot.c
+++ b/firmware/source/user_interface/uiHotspot.c
@@ -159,6 +159,7 @@ volatile int  	rfFrameBufWriteIdx = 0;
 volatile int	rfFrameBufCount = 0;
 static uint8_t lastRxState = HOTSPOT_RX_IDLE;
 static const int TX_BUFFERING_TIMEOUT = 5000;// 500mS
+static const uint32_t MMDVMHOST_TIMEOUT = 5000; // 1s
 static int timeoutCounter;
 static int savedPowerLevel = -1;// no power level saved yet
 static int hotspotPowerLevel = 0;// no power level saved yet
@@ -1227,7 +1228,7 @@ static void sendNAK(uint8_t err)
 
 static void hotspotStateMachine(void)
 {
-	static uint32_t rxFrameTicks = 0;
+	static uint32_t rxFrameTime = 0;
 
 	dbgAct1(hotspotState);
 	dbgPrint7("Host", mmdvmHostIsConnected);
@@ -1254,7 +1255,7 @@ static void hotspotStateMachine(void)
 			else
 			{
 				if ((nonVolatileSettings.hotspotType == HOTSPOT_TYPE_MMDVM) &&
-						((fw_millis() - mmdvmHostLastActiveTick) > 10000))
+						((fw_millis() - mmdvmHostLastActiveTick) > MMDVMHOST_TIMEOUT))
 				{
 					wavbuffer_count = 0;
 
@@ -1293,7 +1294,7 @@ static void hotspotStateMachine(void)
 			wavbuffer_read_idx = 0;
 			wavbuffer_write_idx = 0;
 			wavbuffer_count = 0;
-			rxFrameTicks = fw_millis();
+			rxFrameTime = fw_millis();
 
 			hotspotState = HOTSPOT_STATE_RX_PROCESS;
 			break;
@@ -1305,7 +1306,7 @@ static void hotspotStateMachine(void)
 			{
 				// No activity from MMDVMHost
 				if ((nonVolatileSettings.hotspotType == HOTSPOT_TYPE_MMDVM) &&
-						((fw_millis() - mmdvmHostLastActiveTick) > 10000))
+						((fw_millis() - mmdvmHostLastActiveTick) > MMDVMHOST_TIMEOUT))
 				{
 					mmdvmHostIsConnected = false;
 					hotspotState = HOTSPOT_STATE_NOT_CONNECTED;
@@ -1351,7 +1352,7 @@ static void hotspotStateMachine(void)
 							updateScreen(rx_command);
 							sendVoiceHeaderLC_Frame(audioAndHotspotDataBuffer.hotspotBuffer[rfFrameBufReadIdx]);
 							lastRxState = HOTSPOT_RX_START;
-							rxFrameTicks = fw_millis();
+							rxFrameTime = fw_millis();
 							break;
 
 						case HOTSPOT_RX_START_LATE:
@@ -1360,7 +1361,7 @@ static void hotspotStateMachine(void)
 							updateScreen(rx_command);
 							sendVoiceHeaderLC_Frame(audioAndHotspotDataBuffer.hotspotBuffer[rfFrameBufReadIdx]);
 							lastRxState = HOTSPOT_RX_START_LATE;
-							rxFrameTicks = fw_millis();
+							rxFrameTime = fw_millis();
 							break;
 
 						case HOTSPOT_RX_AUDIO_FRAME:
@@ -1368,7 +1369,7 @@ static void hotspotStateMachine(void)
 							//SEGGER_RTT_printf(0, "HOTSPOT_RX_AUDIO_FRAME\n");
 							hotspotSendVoiceFrame(audioAndHotspotDataBuffer.hotspotBuffer[rfFrameBufReadIdx]);
 							lastRxState = HOTSPOT_RX_AUDIO_FRAME;
-							rxFrameTicks = fw_millis();
+							rxFrameTime = fw_millis();
 							break;
 
 						case HOTSPOT_RX_STOP:
@@ -1425,7 +1426,7 @@ static void hotspotStateMachine(void)
         	{
         		// Timeout: no RF data for too long
         		if (((lastRxState == HOTSPOT_RX_AUDIO_FRAME) || (lastRxState == HOTSPOT_RX_START)) &&
-        				((fw_millis() - rxFrameTicks) > 3000))
+        				((fw_millis() - rxFrameTime) > 300)) // 300ms
         		{
         			dbgPrint5("DMR_LOST", modemState, hotspotState, lastRxState);
         			sendDMRLost();

--- a/firmware/source/user_interface/uiLockScreen.c
+++ b/firmware/source/user_interface/uiLockScreen.c
@@ -26,7 +26,7 @@ static void updateScreen(bool update);
 static void handleEvent(uiEvent_t *ev);
 
 static bool lockDisplayed = false;
-static const uint32_t TIMEOUT_MS = 1000;
+static const uint32_t TIMEOUT_MS = 500;
 int lockState = LOCK_NONE;
 
 int menuLockScreen(uiEvent_t *ev, bool isFirstRun)
@@ -41,7 +41,7 @@ int menuLockScreen(uiEvent_t *ev, bool isFirstRun)
 	}
 	else
 	{
-		if (lockDisplayed && ((ev->ticks - m) > TIMEOUT_MS))
+		if (lockDisplayed && ((ev->time - m) > TIMEOUT_MS))
 		{
 			lockDisplayed = false;
 			menuSystemPopPreviousMenu();

--- a/firmware/source/user_interface/uiPowerOff.c
+++ b/firmware/source/user_interface/uiPowerOff.c
@@ -58,11 +58,11 @@ static void handleEvent(uiEvent_t *ev)
 
 	if (m == 0)
 	{
-		m = ev->ticks;
+		m = ev->time;
 		return;
 	}
 
-	if ((ev->ticks - m) > 500)
+	if ((ev->time - m) > 500)
 	{
 		// This turns the power off to the CPU.
 		GPIO_PinWrite(GPIO_Keep_Power_On, Pin_Keep_Power_On, 0);

--- a/firmware/source/user_interface/uiSplashScreen.c
+++ b/firmware/source/user_interface/uiSplashScreen.c
@@ -79,15 +79,6 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
-	static uint32_t m = 0;
-
-	if (m == 0)
-	{
-		m = ev->ticks;
-		return;
-	}
-
-	//if (ev->ticks - m) > 2000)
 	if (melody_play==NULL)
 	{
 		menuSystemSetCurrentMenu(nonVolatileSettings.initialMenuNumber);

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -260,7 +260,7 @@ static void handleEvent(uiEvent_t *ev)
 	if (trxGetMode() == RADIO_MODE_DIGITAL && (KEYCHECK_DOWN(ev->keys, KEY_SK1)) && isShowingLastHeard==false && trxIsTransmitting==true)
 	{
 		isShowingLastHeard=true;
-		menuLastHeardUpdateScreen(false, false);
+		menuLastHeardUpdateScreen(false);
 	}
 	else
 	{

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -81,7 +81,7 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 			PTTToggledDown = false;
 		}
 
-		m = micm = ev->ticks;
+		m = micm = ev->time;
 	}
 	else
 	{
@@ -112,7 +112,7 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 					ucPrintCentered(20, currentLanguage->timeout, FONT_16x32);
 					ucRender();
 					PTTToggledDown = false;
-					mto = ev->ticks;
+					mto = ev->time;
 				}
 				else
 				{
@@ -128,11 +128,11 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 			{
 				if (trxGetMode() == RADIO_MODE_DIGITAL)
 				{
-					if ((ev->ticks - micm) > 100)
+					if ((ev->time - micm) > 100)
 					{
 						drawDMRMicLevelBarGraph();
 						ucRenderRows(1,2);
-						micm = ev->ticks;
+						micm = ev->time;
 					}
 				}
 			}
@@ -142,7 +142,7 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 		// screen won't be visible at all.
 		if ((currentChannelData->tot != 0) && (timeInSeconds == 0))
 		{
-			if ((ev->ticks - mto) < 1000)
+			if ((ev->time - mto) < 500)
 				return 0;
 		}
 
@@ -150,11 +150,11 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 		// Got an event, or
 		if (ev->hasEvent || // PTT released, Timeout triggered,
 				( (((ev->buttons & BUTTON_PTT) == 0) || ((currentChannelData->tot != 0) && (timeInSeconds == 0))) ||
-						// or waiting for DMR ending (meanwhile, updating every 200 ticks)
-						((trxIsTransmitting == false) && ((ev->ticks - m) > 200))))
+						// or waiting for DMR ending (meanwhile, updating every 100ms)
+						((trxIsTransmitting == false) && ((ev->time - m) > 100))))
 		{
 			handleEvent(ev);
-			m = ev->ticks;
+			m = ev->time;
 		}
 	}
 	return 0;
@@ -260,7 +260,7 @@ static void handleEvent(uiEvent_t *ev)
 	if (trxGetMode() == RADIO_MODE_DIGITAL && ev->buttons & BUTTON_SK1 && isShowingLastHeard==false && trxIsTransmitting==true)
 	{
 		isShowingLastHeard=true;
-		menuLastHeardupdateScreen(false);
+		menuLastHeardUpdateScreen(false, false);
 	}
 	else
 	{

--- a/firmware/source/user_interface/uiTxTgPcContactOwnId.c
+++ b/firmware/source/user_interface/uiTxTgPcContactOwnId.c
@@ -31,7 +31,7 @@ static void updateCursor(void);
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
-static const uint32_t CURSOR_UPDATE_TIMEOUT = 1000;
+static const uint32_t CURSOR_UPDATE_TIMEOUT = 500;
 
 static const char *menuName[4];
 enum DISPLAY_MENU_LIST { ENTRY_TG = 0, ENTRY_PC, ENTRY_SELECT_CONTACT, ENTRY_USER_DMR_ID, NUM_ENTRY_ITEMS};

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -25,7 +25,7 @@
 #include "fw_trx.h"
 #include "fw_settings.h"
 #include <math.h>
-#include "fw_ticks.h"
+#include <functions/fw_ticks.h>
 
 void updateLastHeardList(int id,int talkGroup);
 
@@ -42,7 +42,7 @@ LinkItem_t *LinkHead = callsList;
 int numLastHeard=0;
 int menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 int qsodata_timer;
-const uint32_t RSSI_UPDATE_COUNTER_RELOAD = 500;
+const uint32_t RSSI_UPDATE_COUNTER_RELOAD = 100;
 
 uint32_t menuUtilityReceivedPcId 	= 0;// No current Private call awaiting acceptance
 uint32_t menuUtilityTgBeforePcMode 	= 0;// No TG saved, prior to a Private call being accepted.
@@ -56,7 +56,7 @@ uint32_t lastTG=0;
 /*
  * Remove space at the end of the array, and return pointer to first non space character
  */
-static char *chomp(char *str)
+char *chomp(char *str)
 {
 	char *sp = str, *ep = str;
 
@@ -83,7 +83,7 @@ static char *chomp(char *str)
 	return sp;
 }
 
-static int32_t getCallsignEndingPos(char *str)
+int32_t getCallsignEndingPos(char *str)
 {
 	char *p = str;
 
@@ -591,7 +591,7 @@ static void displayChannelNameOrRxFrequency(char *buffer, size_t maxLen)
 	ucPrintCentered(52, buffer, FONT_6x8);
 }
 
-void printSplitOrSpanText(uint8_t y, char *text)
+void printSplitOrSpanText(uint8_t y, char *text, bool smallFont)
 {
 	uint8_t len = strlen(text);
 
@@ -600,7 +600,7 @@ void printSplitOrSpanText(uint8_t y, char *text)
 
 	if (len <= 16)
 	{
-		ucPrintCentered(y, text, FONT_8x16);
+		ucPrintCentered(y, text, smallFont ? FONT_6x8 : FONT_8x16);
 	}
 	else
 	{
@@ -681,7 +681,7 @@ static void displayContactTextInfos(char *text, size_t maxLen, bool isFromTalker
 			pbuf = chomp(buffer);
 
 			if (strlen(pbuf))
-				printSplitOrSpanText(48, pbuf);
+				printSplitOrSpanText(48, pbuf, false);
 			else
 				displayChannelNameOrRxFrequency(buffer, (sizeof(buffer) / sizeof(buffer[0])));
 		}
@@ -699,7 +699,7 @@ static void displayContactTextInfos(char *text, size_t maxLen, bool isFromTalker
 			pbuf = chomp(buffer);
 
 			if (strlen(pbuf))
-				printSplitOrSpanText(48, pbuf);
+				printSplitOrSpanText(48, pbuf, false);
 			else
 				displayChannelNameOrRxFrequency(buffer, (sizeof(buffer) / sizeof(buffer[0])));
 		}
@@ -783,11 +783,11 @@ void menuUtilityRenderQSOData(void)
 			// first check if we have this ID in the DMR ID data
 			if (contactIDLookup(LinkHead->id, CONTACT_CALLTYPE_PC, buffer))
 			{
-				displayContactTextInfos(buffer, 16,false);
+				displayContactTextInfos(buffer, 16, false);
 			}
 			else if (dmrIDLookup((LinkHead->id & 0xFFFFFF), &currentRec))
 			{
-				displayContactTextInfos(currentRec.text, sizeof(currentRec.text),false);
+				displayContactTextInfos(currentRec.text, sizeof(currentRec.text), false);
 			}
 			else
 			{
@@ -803,7 +803,7 @@ void menuUtilityRenderQSOData(void)
 						displayContactTextInfos(bufferTA, sizeof(bufferTA), true);
 					}
 					else
-						displayContactTextInfos(LinkHead->talkerAlias, sizeof(LinkHead->talkerAlias),true);
+						displayContactTextInfos(LinkHead->talkerAlias, sizeof(LinkHead->talkerAlias), true);
 				}
 				else
 				{

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -27,8 +27,6 @@
 #include <math.h>
 #include <functions/fw_ticks.h>
 
-void updateLastHeardList(int id,int talkGroup);
-
 const int QSO_TIMER_TIMEOUT = 2400;
 const int TX_TIMER_Y_OFFSET = 8;
 const int CONTACT_Y_POS = 16;

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -558,7 +558,7 @@ static void displayChannelNameOrRxFrequency(char *buffer, size_t maxLen)
 	ucPrintCentered(52, buffer, FONT_6x8);
 }
 
-void printSplitOrSpanText(uint8_t y, char *text, bool smallFont)
+static void printSplitOrSpanText(uint8_t y, char *text)
 {
 	uint8_t len = strlen(text);
 
@@ -567,7 +567,7 @@ void printSplitOrSpanText(uint8_t y, char *text, bool smallFont)
 
 	if (len <= 16)
 	{
-		ucPrintCentered(y, text, smallFont ? FONT_6x8 : FONT_8x16);
+		ucPrintCentered(y, text, FONT_8x16);
 	}
 	else
 	{
@@ -648,7 +648,7 @@ static void displayContactTextInfos(char *text, size_t maxLen, bool isFromTalker
 			pbuf = chomp(buffer);
 
 			if (strlen(pbuf))
-				printSplitOrSpanText(48, pbuf, false);
+				printSplitOrSpanText(48, pbuf);
 			else
 				displayChannelNameOrRxFrequency(buffer, (sizeof(buffer) / sizeof(buffer[0])));
 		}
@@ -666,7 +666,7 @@ static void displayContactTextInfos(char *text, size_t maxLen, bool isFromTalker
 			pbuf = chomp(buffer);
 
 			if (strlen(pbuf))
-				printSplitOrSpanText(48, pbuf, false);
+				printSplitOrSpanText(48, pbuf);
 			else
 				displayChannelNameOrRxFrequency(buffer, (sizeof(buffer) / sizeof(buffer[0])));
 		}

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -147,7 +147,7 @@ int menuVFOMode(uiEvent_t *ev, bool isFirstRun)
 			else
 			{
 				// Clear squelch region
-				if (displaySquelch && ((ev->ticks - sqm) > 2000))
+				if (displaySquelch && ((ev->time - sqm) > 1000))
 				{
 					displaySquelch = false;
 
@@ -155,9 +155,9 @@ int menuVFOMode(uiEvent_t *ev, bool isFirstRun)
 					ucRenderRows(2,4);
 				}
 
-				if ((ev->ticks - m) > RSSI_UPDATE_COUNTER_RELOAD)
+				if ((ev->time - m) > RSSI_UPDATE_COUNTER_RELOAD)
 				{
-					m = ev->ticks;
+					m = ev->time;
 					drawRSSIBarGraph();
 					ucRenderRows(1,2);// Only render the second row which contains the bar graph, as there is no need to redraw the rest of the screen
 				}
@@ -179,7 +179,7 @@ int menuVFOMode(uiEvent_t *ev, bool isFirstRun)
 				if ((currentChannelData->chMode == RADIO_MODE_ANALOG) &&
 						(ev->events & KEY_EVENT) && ((ev->keys.key == KEY_LEFT) || (ev->keys.key == KEY_RIGHT)))
 				{
-					sqm = ev->ticks;
+					sqm = ev->time;
 				}
 
 				// Scanning barrier
@@ -273,7 +273,7 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 					printToneAndSquelch();
 				}
 
-				// Squelch will be cleared later, 2000 ticks after last change
+				// Squelch will be cleared later, 1s after last change
 				if(displaySquelch && !displayChannelSettings)
 				{
 					static const int xbar = 74; // 128 - (51 /* max squelch px */ + 3);
@@ -287,7 +287,7 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 					ucFillRect(xbar, 19, bargraph, 9, false);
 				}
 
-				// SK1 is pressed, we don't want to clear the first info row after 2000 ticks
+				// SK1 is pressed, we don't want to clear the first info row after 1s
 				if (displayChannelSettings && displaySquelch)
 				{
 					displaySquelch = false;


### PR DESCRIPTION
 If SK1 is pressed, extra infos + elapsed time are displayed, using 6x8* fonts.
TxScreen displays LH on SK1, but only centered callsign (just like normal LH screen).
Fix the damn fw_millis(): now it returns milliseconds. Rename uiEvent_t 'ticks' member to 'time'. Review all timediff checks (I hope I didn't missed one).

About LH (don't take care of elapsed time values)
![GD-77_screengrab-2020-01-10_09_57_50](https://user-images.githubusercontent.com/10473896/72152098-4bf49b00-33aa-11ea-9ec1-5ee1f5cc864b.png)
![GD-77_screengrab-2020-01-10_09_57_59](https://user-images.githubusercontent.com/10473896/72152101-4eef8b80-33aa-11ea-856c-bfca1daa5714.png)



