### PR TITLE
New new Last Heard menu.

### DIFF
--- a/firmware/include/io/fw_keyboard.h
+++ b/firmware/include/io/fw_keyboard.h
@@ -52,25 +52,25 @@
 #define GPIO_Key_Row4 	GPIOB
 #define Pin_Key_Row4	23
 
-#define SCAN_UP    0x00000100
-#define SCAN_DOWN  0x00002000
-#define SCAN_LEFT  0x00000200
-#define SCAN_RIGHT 0x00000010
-#define SCAN_GREEN 0x00000008
-#define SCAN_RED   0x00040000
-#define SCAN_0     0x00010000
-#define SCAN_1     0x00000001
-#define SCAN_2     0x00000002
-#define SCAN_3     0x00000004
-#define SCAN_4     0x00000020
-#define SCAN_5     0x00000040
-#define SCAN_6     0x00000080
-#define SCAN_7     0x00000400
-#define SCAN_8     0x00000800
-#define SCAN_9     0x00001000
-#define SCAN_STAR  0x00008000
-#define SCAN_HASH  0x00020000
-#define SCAN_SK1   0x00004000
+#define SCAN_UP     0x00000100
+#define SCAN_DOWN   0x00002000
+#define SCAN_LEFT   0x00000200
+#define SCAN_RIGHT  0x00000010
+#define SCAN_GREEN  0x00000008
+#define SCAN_RED    0x00040000
+#define SCAN_0      0x00010000
+#define SCAN_1      0x00000001
+#define SCAN_2      0x00000002
+#define SCAN_3      0x00000004
+#define SCAN_4      0x00000020
+#define SCAN_5      0x00000040
+#define SCAN_6      0x00000080
+#define SCAN_7      0x00000400
+#define SCAN_8      0x00000800
+#define SCAN_9      0x00001000
+#define SCAN_STAR   0x00008000
+#define SCAN_HASH   0x00020000
+#define SCAN_SK1    0x00004000
 #define SCAN_ORANGE 0x00080000
 
 #define KEY_GREENSTAR  '+'    // GREEN + STAR

--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -96,7 +96,7 @@ void menuBatteryPushBackVoltage(int32_t voltage);
 
 void menuLockScreenPop(void);
 
-void menuLastHeardUpdateScreen(bool showTitleOrHeader);
+void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool displayDetails);
 
 void menuClearPrivateCall(void);
 void menuAcceptPrivateCall(int id);

--- a/firmware/include/user_interface/uiUtilityQSOData.h
+++ b/firmware/include/user_interface/uiUtilityQSOData.h
@@ -64,7 +64,7 @@ extern uint32_t menuUtilityTgBeforePcMode;
 extern const uint32_t RSSI_UPDATE_COUNTER_RELOAD;
 
 char *chomp(char *str);
-int32_t getCallsignEndingPos(char *str);
+int32_t getFirstSpacePos(char *str);
 bool dmrIDLookup(int targetId, dmrIdDataStruct_t *foundRecord);
 bool contactIDLookup(uint32_t id, int calltype, char *buffer);
 void menuUtilityRenderQSOData(void);

--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -374,7 +374,7 @@ void fw_main_task(void *data)
         		}
 
     			// Toggle backlight
-        		if ((nonVolatileSettings.backlightMode == BACKLIGHT_MODE_MANUAL) && (KEYCHECK_DOWN(keys,KEY_SK1)))
+        		if ((nonVolatileSettings.backlightMode == BACKLIGHT_MODE_MANUAL) && (buttons & BUTTON_SK1))
         		{
         			fw_displayEnableBacklight(! fw_displayIsBacklightLit());
         		}

--- a/firmware/source/io/fw_keyboard.c
+++ b/firmware/source/io/fw_keyboard.c
@@ -142,10 +142,12 @@ uint32_t fw_read_keyboard(void)
 		GPIO_PinWrite(GPIOC, col, 1);
 		GPIO_PinInit(GPIOC, col, &pin_config_input);
 	}
+#if 0
 	if (GPIO_PinRead(GPIO_SK1, Pin_SK1)==0)
 	{
 		result |= SCAN_SK1;
 	}
+#endif
 	if (GPIO_PinRead(GPIO_Orange, Pin_Orange)==0)
 	{
 		result |= SCAN_ORANGE;

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -56,7 +56,7 @@ int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 		}
 		else
 		{
-			// Just refresh the list while displaying extra infos, it's all about elapsed time
+			// Just refresh the list while displaying details, it's all about elapsed time
 			if (displayLHDetails && ((ev->time - m) > (1000U * 60U)))
 			{
 				m = ev->time;

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -18,42 +18,62 @@
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiUtilityQSOData.h>
 #include <user_interface/uiLocalisation.h>
-const int LAST_HEARD_NUM_LINES_ON_DISPLAY = 3;
+#include <functions/fw_ticks.h>
+
+static const int LAST_HEARD_NUM_LINES_ON_DISPLAY = 3;
+static bool displayLHDetails = false;
 
 static void handleEvent(uiEvent_t *ev);
+static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_t now, uint32_t TGorPC, size_t maxLen, bool displayDetails);
 
 int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 {
+	static uint32_t m = 0;
+
 	if (isFirstRun)
 	{
 		gMenusStartIndex = LinkHead->id;// reuse this global to store the ID of the first item in the list
-		gMenusEndIndex=0;
-		menuLastHeardUpdateScreen(true);
+		gMenusEndIndex = 0;
+		displayLHDetails = false;
+		menuLastHeardUpdateScreen(true, displayLHDetails);
+		m = ev->time;
 	}
 	else
 	{
 		// do live update by checking if the item at the top of the list has changed
-		if (gMenusStartIndex != LinkHead->id || menuDisplayQSODataState==QSO_DISPLAY_CALLER_DATA)
+		if ((gMenusStartIndex != LinkHead->id) || (menuDisplayQSODataState == QSO_DISPLAY_CALLER_DATA))
 		{
 			gMenusStartIndex = LinkHead->id;
-			gMenusCurrentItemIndex=0;
-			gMenusEndIndex=0;
-			menuLastHeardUpdateScreen(true);
+			gMenusCurrentItemIndex = 0;
+			gMenusEndIndex = 0;
+			menuLastHeardUpdateScreen(true, displayLHDetails);
 		}
 
 		if (ev->hasEvent)
+		{
+			m = ev->time;
 			handleEvent(ev);
+		}
+		else
+		{
+			// Just refresh the list while displaying extra infos, it's all about elapsed time
+			if (displayLHDetails && ((ev->time - m) > (1000U * 60U)))
+			{
+				m = ev->time;
+				menuLastHeardUpdateScreen(true, true);
+			}
+		}
+
 	}
 	return 0;
 }
 
-void menuLastHeardUpdateScreen(bool showTitleOrHeader)
+void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool displayDetails)
 {
-	static const int bufferLen = 17;
-	char buffer[bufferLen];
 	dmrIdDataStruct_t foundRecord;
-	int numDisplayed=0;
+	int numDisplayed = 0;
 	LinkItem_t *item = LinkHead;
+	uint32_t now = fw_millis();
 
 	ucClearBuf();
 	if (showTitleOrHeader)
@@ -66,75 +86,185 @@ void menuLastHeardUpdateScreen(bool showTitleOrHeader)
 	}
 
 	// skip over the first gMenusCurrentItemIndex in the listing
-	for(int i=0;i<gMenusCurrentItemIndex;i++)
+	for(int i = 0; i < gMenusCurrentItemIndex; i++)
 	{
-		item=item->next;
+		item = item->next;
 	}
-	while((item != NULL) && item->id != 0)
+
+	while((item != NULL) && (item->id != 0))
 	{
-		if (dmrIDLookup(item->id,&foundRecord))
+		if (dmrIDLookup(item->id, &foundRecord))
 		{
-			ucPrintCentered(16+(numDisplayed*16), foundRecord.text, FONT_8x16);
+			menuLastHeardDisplayTA(16 + (numDisplayed * 16), foundRecord.text, item->time, now, item->talkGroupOrPcId, 20, displayDetails);
 		}
 		else
 		{
 			if (item->talkerAlias[0] != 0x00)
 			{
-				memcpy(buffer, item->talkerAlias, bufferLen - 1);// limit to 1 line of the display which is 16 chars at the normal font size
+				menuLastHeardDisplayTA(16 + (numDisplayed * 16), item->talkerAlias, item->time, now, item->talkGroupOrPcId, 32, displayDetails);
 			}
 			else
 			{
-				snprintf(buffer, bufferLen, "ID:%d", item->id);
+				char buffer[17];
+
+				snprintf(buffer, 17, "ID:%d", item->id);
+				buffer[16] = 0;
+				menuLastHeardDisplayTA(16 + (numDisplayed * 16), buffer, item->time, now, item->talkGroupOrPcId, 17, displayDetails);
 			}
-			buffer[bufferLen - 1] = 0;
-			ucPrintCentered(16+(numDisplayed*16), buffer, FONT_8x16);
 		}
 
 		numDisplayed++;
 
-		item=item->next;
-		if (numDisplayed > (LAST_HEARD_NUM_LINES_ON_DISPLAY -1))
+		item = item->next;
+		if (numDisplayed > (LAST_HEARD_NUM_LINES_ON_DISPLAY - 1))
 		{
-			if (item!=NULL && item->id != 0)
+			if ((item != NULL) && (item->id != 0))
 			{
-				gMenusEndIndex=0x01;
+				gMenusEndIndex = 0x01;
 			}
 			else
 			{
-				gMenusEndIndex=0;
+				gMenusEndIndex = 0;
 			}
 			break;
 		}
 	}
 	ucRender();
-	displayLightTrigger();
 	menuDisplayQSODataState = QSO_DISPLAY_IDLE;
 }
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
 
-	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
+	if (KEYCHECK_PRESS(ev->keys, KEY_DOWN) && (gMenusEndIndex != 0))
 	{
 		gMenusCurrentItemIndex++;
 	}
-	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
+	else if (KEYCHECK_PRESS(ev->keys, KEY_UP))
 	{
-		gMenusCurrentItemIndex--;
-		if (gMenusCurrentItemIndex<0)
+		if (gMenusCurrentItemIndex > 0)
 		{
-			gMenusCurrentItemIndex=0;
+			gMenusCurrentItemIndex--;
 		}
 	}
-	else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
+	else if (KEYCHECK_SHORTUP(ev->keys, KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}
-	menuLastHeardUpdateScreen(true);
+
+	// Toggles LH simple/details view on SK1 press
+	if (ev->buttons & BUTTON_SK1)
+	{
+		displayLHDetails = !displayLHDetails;
+	}
+
+	menuLastHeardUpdateScreen(true, displayLHDetails);
 }
+
+static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_t now, uint32_t TGorPC, size_t maxLen, bool displayDetails)
+{
+	char buffer[37]; // Max: TA 27 (in 7bit format) + ' [' + 6 (Maidenhead)  + ']' + NULL
+
+	if (displayDetails)
+	{
+		uint32_t diffTimeInMins = (((now - time) / 1000U) / 60U);
+		uint32_t tg = TGorPC & 0xFFFFFF;
+
+		// PC or TG
+		sprintf(buffer, "%s %u", (((TGorPC >> 24) == PC_CALL_FLAG) ? "PC" : "TG"), tg);
+		ucPrintAt(0, y, buffer, FONT_8x16);
+
+		// Time
+		snprintf(buffer, 5, "%d", diffTimeInMins);
+		buffer[5] = 0;
+
+		ucPrintAt((128 - (3 * 6)), (y + 6), "min", FONT_6x8);
+		ucPrintAt((128 - (strlen(buffer) * 8) - (3 * 6) - 1), y, buffer, FONT_8x16);
+
+	}
+	else // search for callsign + first name
+	{
+		if (strlen(text) >= 5)
+		{
+			int32_t  cpos;
+
+			if ((cpos = getFirstSpacePos(text)) != -1) // Callsign found
+			{
+				// Check if second part is 'DMR ID:'
+				// In this case, don't go further
+				if (strncmp((text + cpos + 1), "DMR ID:", 7) == 0)
+				{
+					if (cpos > 15)
+						cpos = 16;
+
+					memcpy(buffer, text, cpos);
+					buffer[cpos] = 0;
+
+					ucPrintCentered(y, chomp(buffer), FONT_8x16);
+				}
+				else // Nope, look for first name
+				{
+					uint32_t npos;
+					char nameBuf[17];
+					char outputBuf[17];
+
+					memset(nameBuf, 0, sizeof(nameBuf));
+
+					// Look for the second part, aka first name
+					if ((npos = getFirstSpacePos(text + cpos + 1)) != -1)
+					{
+						// Store callsign
+						memcpy(buffer, text, cpos);
+						buffer[cpos] = 0;
+
+						// Store 'first name'
+						memcpy(nameBuf, (text + cpos + 1), npos);
+						nameBuf[npos] = 0;
+
+						snprintf(outputBuf, 16, "%s %s", chomp(buffer), chomp(nameBuf));
+						outputBuf[16] = 0;
+
+						ucPrintCentered(y, chomp(outputBuf), FONT_8x16);
+					}
+					else
+					{
+						// Store callsign
+						memcpy(buffer, text, cpos);
+						buffer[cpos] = 0;
+
+						memcpy(nameBuf, (text + cpos + 1), strlen(text) - cpos - 1);
+						nameBuf[16] = 0;
+
+						snprintf(outputBuf, 16, "%s %s", chomp(buffer), chomp(nameBuf));
+						outputBuf[16] = 0;
+
+						ucPrintCentered(y, chomp(outputBuf), FONT_8x16);
+					}
+				}
+			}
+			else
+			{
+				// No space found, use a chainsaw
+				memcpy(buffer, text, 16);
+				buffer[16] = 0;
+
+				ucPrintCentered(y, chomp(buffer), FONT_8x16);
+			}
+		}
+		else // short callsign
+		{
+			memcpy(buffer, text, strlen(text));
+			buffer[strlen(text)] = 0;
+
+			ucPrintCentered(y, chomp(buffer), FONT_8x16);
+		}
+	}
+}
+

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -455,25 +455,25 @@ static void handleEvent(uiEvent_t *ev)
 			return;
 		}
 
-	}
+		// Display channel settings (RX/TX/etc) while SK1 is pressed
+		if ((displayChannelSettings == false) && (ev->buttons & BUTTON_SK1))
+		{
+			int prevQSODisp = prevDisplayQSODataState;
 
-	// Display channel settings (RX/TX/etc) while SK1 is pressed
-	if ((displayChannelSettings == false) && (KEYCHECK_LONGDOWN(ev->keys, KEY_SK1)))
-	{
-		int prevQSODisp = prevDisplayQSODataState;
+			displayChannelSettings = true;
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+			menuChannelModeUpdateScreen(0);
+			prevDisplayQSODataState = prevQSODisp;
+			return;
+		}
+		else if ((displayChannelSettings==true) && (ev->buttons & BUTTON_SK1))
+		{
+			displayChannelSettings = false;
+			menuDisplayQSODataState = prevDisplayQSODataState;
+			menuChannelModeUpdateScreen(0);
+			return;
+		}
 
-		displayChannelSettings = true;
-		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
-		menuChannelModeUpdateScreen(0);
-		prevDisplayQSODataState = prevQSODisp;
-		return;
-	}
-	else if ((displayChannelSettings==true) && (KEYCHECK_UP(ev->keys, KEY_SK1)))
-	{
-		displayChannelSettings = false;
-		menuDisplayQSODataState = prevDisplayQSODataState;
-		menuChannelModeUpdateScreen(0);
-		return;
 	}
 
 	if (ev->events & KEY_EVENT)

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -257,14 +257,14 @@ static void handleEvent(uiEvent_t *ev)
 		GPIO_PinWrite(GPIO_audio_amp_enable, Pin_audio_amp_enable, 0);
 	}
 
-	if (trxGetMode() == RADIO_MODE_DIGITAL && (KEYCHECK_DOWN(ev->keys, KEY_SK1)) && isShowingLastHeard==false && trxIsTransmitting==true)
+	if (trxGetMode() == RADIO_MODE_DIGITAL && (ev->buttons & BUTTON_SK1) && isShowingLastHeard==false && trxIsTransmitting==true)
 	{
 		isShowingLastHeard=true;
-		menuLastHeardUpdateScreen(false);
+		menuLastHeardUpdateScreen(false, false);
 	}
 	else
 	{
-		if (isShowingLastHeard && KEYCHECK_UP(ev->keys, KEY_SK1))
+		if (isShowingLastHeard && (ev->buttons & BUTTON_SK1))
 		{
 			isShowingLastHeard=false;
 			updateScreen();

--- a/firmware/source/user_interface/uiUtilityQSOData.c
+++ b/firmware/source/user_interface/uiUtilityQSOData.c
@@ -81,7 +81,7 @@ char *chomp(char *str)
 	return sp;
 }
 
-int32_t getCallsignEndingPos(char *str)
+int32_t getFirstSpacePos(char *str)
 {
 	char *p = str;
 
@@ -641,7 +641,7 @@ static void displayContactTextInfos(char *text, size_t maxLen, bool isFromTalker
 		char    *pbuf;
 		int32_t  cpos;
 
-		if ((cpos = getCallsignEndingPos(text)) != -1)
+		if ((cpos = getFirstSpacePos(text)) != -1)
 		{
 			// Callsign found
 			memcpy(buffer, text, cpos);

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -504,12 +504,8 @@ static void handleEvent(uiEvent_t *ev)
 			return;
 		}
 
-	}
-
-	if (ev->events & KEY_EVENT)
-	{
 		// Display channel settings (CTCSS, Squelch) while SK1 is pressed
-		if ((displayChannelSettings == false) && (KEYCHECK_LONGDOWN(ev->keys, KEY_SK1)))
+		if ((displayChannelSettings == false) && (ev->buttons & BUTTON_SK1))
 		{
 			int prevQSODisp = prevDisplayQSODataState;
 
@@ -519,14 +515,17 @@ static void handleEvent(uiEvent_t *ev)
 			prevDisplayQSODataState = prevQSODisp;
 			return;
 		}
-		else if ((displayChannelSettings==true) && (KEYCHECK_UP(ev->keys, KEY_SK1)))
+		else if ((displayChannelSettings == true) && (ev->buttons & BUTTON_SK1))
 		{
 			displayChannelSettings = false;
 			menuDisplayQSODataState = prevDisplayQSODataState;
 			menuVFOModeUpdateScreen(0);
 			return;
 		}
+	}
 
+	if (ev->events & KEY_EVENT)
+	{
 		if (KEYCHECK_SHORTUP(ev->keys, KEY_ORANGE))
 		{
 			if (ev->buttons & BUTTON_SK2)


### PR DESCRIPTION
**BEWARE**: this revert the handling of SK1, as a button only. It've just disabled the button state checking statement in keyboard code, and replace all KEY_*(SK1) with old bitwise checking.

SK1 toggles the display view between normal  and details views (as in the other screen, ChannelMode, VFOMode).

![GD-77_screengrab-2020-01-13_15_49_02](https://user-images.githubusercontent.com/10473896/72284361-15847d80-3641-11ea-8f7c-10741aced9b8.png)
![GD-77_screengrab-2020-01-13_15_49_17](https://user-images.githubusercontent.com/10473896/72284365-1a493180-3641-11ea-9094-780718d374ef.png)

