### PR TITLE
Complete remove buttons from keypad code, removes long press ORANGE

### DIFF
--- a/firmware/include/io/fw_keyboard.h
+++ b/firmware/include/io/fw_keyboard.h
@@ -70,8 +70,6 @@
 #define SCAN_9      0x00001000
 #define SCAN_STAR   0x00008000
 #define SCAN_HASH   0x00020000
-#define SCAN_SK1    0x00004000
-#define SCAN_ORANGE 0x00080000
 
 #define KEY_GREENSTAR  '+'    // GREEN + STAR
 
@@ -93,8 +91,6 @@
 #define KEY_9     '9'
 #define KEY_STAR  '*'
 #define KEY_HASH  '#'
-#define KEY_SK1    5
-#define KEY_ORANGE 6
 
 
 #define KEY_MOD_DOWN    0x01

--- a/firmware/source/io/fw_keyboard.c
+++ b/firmware/source/io/fw_keyboard.c
@@ -47,8 +47,8 @@ volatile bool keypadLocked = false;
 static const uint32_t keyMap[] = {
 		KEY_1, KEY_2, KEY_3, KEY_GREEN, KEY_RIGHT,
 		KEY_4, KEY_5, KEY_6, KEY_UP, KEY_LEFT,
-		KEY_7, KEY_8, KEY_9, KEY_DOWN, KEY_SK1,
-		KEY_STAR, KEY_0, KEY_HASH, KEY_RED, KEY_ORANGE
+		KEY_7, KEY_8, KEY_9, KEY_DOWN, NULL,
+		KEY_STAR, KEY_0, KEY_HASH, KEY_RED, NULL
 };
 static const char keypadAlphaMap[11][31] = {
 		"0 ",
@@ -141,16 +141,6 @@ uint32_t fw_read_keyboard(void)
 
 		GPIO_PinWrite(GPIOC, col, 1);
 		GPIO_PinInit(GPIOC, col, &pin_config_input);
-	}
-#if 0
-	if (GPIO_PinRead(GPIO_SK1, Pin_SK1)==0)
-	{
-		result |= SCAN_SK1;
-	}
-#endif
-	if (GPIO_PinRead(GPIO_Orange, Pin_Orange)==0)
-	{
-		result |= SCAN_ORANGE;
 	}
 
     return result;

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -473,12 +473,7 @@ static void handleEvent(uiEvent_t *ev)
 			menuChannelModeUpdateScreen(0);
 			return;
 		}
-
-	}
-
-	if (ev->events & KEY_EVENT)
-	{
-		if (KEYCHECK_SHORTUP(ev->keys, KEY_ORANGE))
+		if (ev->buttons & BUTTON_ORANGE)
 		{
 			if (ev->buttons & BUTTON_SK2)
 			{
@@ -494,12 +489,11 @@ static void handleEvent(uiEvent_t *ev)
 
 			return;
 		}
-		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_ORANGE))
-		{
-			directChannelNumber = 0;
-			startScan();
-		}
-		else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
+	}
+
+	if (ev->events & KEY_EVENT)
+	{
+		if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 		{
 			if (directChannelNumber>0)
 			{
@@ -987,7 +981,7 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 	{
 		MENU_DEC(gMenusCurrentItemIndex, NUM_CH_SCREEN_QUICK_MENU_ITEMS);
 	}
-	else if ((KEYCHECK_SHORTUP(ev->keys, KEY_ORANGE)) && (gMenusCurrentItemIndex==CH_SCREEN_QUICK_MENU_SCAN))
+	else if (((ev->events & BUTTON_EVENT) && (ev->buttons & BUTTON_ORANGE)) && (gMenusCurrentItemIndex==CH_SCREEN_QUICK_MENU_SCAN))
 	{
 		startScan();
 	}

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -586,11 +586,7 @@ static void handleEvent(uiEvent_t *ev)
 			menuVFOModeUpdateScreen(0);
 			return;
 		}
-	}
-
-	if (ev->events & KEY_EVENT)
-	{
-		if (KEYCHECK_SHORTUP(ev->keys, KEY_ORANGE))
+		if (ev->buttons & BUTTON_ORANGE)
 		{
 			if (ev->buttons & BUTTON_SK2)
 			{
@@ -605,10 +601,10 @@ static void handleEvent(uiEvent_t *ev)
 
 			return;
 		}
-		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_ORANGE))
-		{
-			startScan();
-		}
+	}
+
+	if (ev->events & KEY_EVENT)
+	{
 		if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 		{
 			if (ev->buttons & BUTTON_SK2 )
@@ -1124,7 +1120,7 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if ((KEYCHECK_SHORTUP(ev->keys, KEY_ORANGE)) && (gMenusCurrentItemIndex==VFO_SCREEN_QUICK_MENU_VFO_A_B))
+	else if (((ev->events & BUTTON_EVENT) && (ev->buttons & BUTTON_ORANGE)) && (gMenusCurrentItemIndex==VFO_SCREEN_QUICK_MENU_VFO_A_B))
 	{
 		nonVolatileSettings.currentVFONumber = 1 - nonVolatileSettings.currentVFONumber;// Switch to other VFO
 		currentChannelData = &settingsVFOChannel[nonVolatileSettings.currentVFONumber];


### PR DESCRIPTION
I removed all traces of including the handling of SK1 and ORANGE inside the keypad code.
This also removes the detection of long press buttons. If this is needed it has to be implemented inside fw_buttons.c