### PR TITLE
May prevent the blank screen when TG and PC are zero.

### DIFF
--- a/firmware/include/hardware/UC1701.h
+++ b/firmware/include/hardware/UC1701.h
@@ -57,7 +57,7 @@ extern uint8_t screenBuf[];
 
 void ucBegin(bool isInverted);
 void ucClearBuf(void);
-void ucClearRows(int16_t startRow, int16_t endRow);
+void ucClearRows(int16_t startRow, int16_t endRow, bool isInverted);
 void ucRender(void);
 void ucRenderRows(int16_t startRow, int16_t endRow);
 void ucPrintCentered(uint8_t y,const  char *text, ucFont_t fontSize);

--- a/firmware/include/hardware/UC1701.h
+++ b/firmware/include/hardware/UC1701.h
@@ -57,6 +57,7 @@ extern uint8_t screenBuf[];
 
 void ucBegin(bool isInverted);
 void ucClearBuf(void);
+void ucClearRows(int16_t startRow, int16_t endRow);
 void ucRender(void);
 void ucRenderRows(int16_t startRow, int16_t endRow);
 void ucPrintCentered(uint8_t y,const  char *text, ucFont_t fontSize);

--- a/firmware/source/fw_main.c
+++ b/firmware/source/fw_main.c
@@ -175,7 +175,7 @@ void fw_main_task(void *data)
 
 				if ((currentMenu == MENU_CHANNEL_MODE) || (currentMenu == MENU_VFO_MODE))
 				{
-					ucFillRect(0, 0, 128, 16, true);
+					ucClearRows(0, 2, false);
 					menuUtilityRenderHeader();
 					ucRenderRows(0, 2);
 				}

--- a/firmware/source/hardware/UC1701.c
+++ b/firmware/source/hardware/UC1701.c
@@ -365,7 +365,7 @@ void ucClearBuf(void)
 	memset(screenBuf,0x00,1024);
 }
 
-void ucClearRows(int16_t startRow, int16_t endRow)
+void ucClearRows(int16_t startRow, int16_t endRow, bool isInverted)
 {
 	// Boundaries
 	if (((startRow < 0) || (endRow < 0)) || ((startRow > 8) || (endRow > 8)) || (startRow == endRow))
@@ -378,7 +378,7 @@ void ucClearRows(int16_t startRow, int16_t endRow)
 
 	// memset would be faster than ucFillRect
 	//ucFillRect(0, (startRow * 8), 128, (8 * (endRow - startRow)), true);
-    memset(screenBuf + (128 * startRow), 0, (128 * (endRow - startRow)));
+    memset(screenBuf + (128 * startRow), (isInverted ? 0xFF : 0x00), (128 * (endRow - startRow)));
 }
 
 

--- a/firmware/source/hardware/UC1701.c
+++ b/firmware/source/hardware/UC1701.c
@@ -376,7 +376,7 @@ void ucClearRows(int16_t startRow, int16_t endRow)
 		swap(startRow, endRow);
 	}
 
-	// memset would be faster then ucFillRect
+	// memset would be faster than ucFillRect
 	//ucFillRect(0, (startRow * 8), 128, (8 * (endRow - startRow)), true);
     memset(screenBuf + (128 * startRow), 0, (128 * (endRow - startRow)));
 }

--- a/firmware/source/hardware/UC1701.c
+++ b/firmware/source/hardware/UC1701.c
@@ -141,6 +141,15 @@ void ucRender(void)
 	ucRenderRows(0,8);
 }
 
+/*
+
+     clear(0, 1); 0, 8
+     clear(2, 4); 16, 32
+
+     clear(6, 8); 48, 64
+
+ */
+
 //#define DISPLAY_CHECK_BOUNDS
 #ifdef DISPLAY_CHECK_BOUNDS
 static inline bool checkWritePos(uint8_t * writePos)
@@ -364,6 +373,23 @@ void ucClearBuf(void)
 {
 	memset(screenBuf,0x00,1024);
 }
+
+void ucClearRows(int16_t startRow, int16_t endRow)
+{
+	// Boundaries
+	if (((startRow < 0) || (endRow < 0)) || ((startRow > 8) || (endRow > 8)) || (startRow == endRow))
+		return;
+
+	if (endRow < startRow)
+	{
+		swap(startRow, endRow);
+	}
+
+	// memset would be faster then ucFillRect()
+	//ucFillRect(0, (startRow * 8), 128, (8 * (endRow - startRow)), true);
+    memset(screenBuf + (128 * startRow), 0, (128 * (endRow - startRow)));
+}
+
 
 void ucPrintCentered(uint8_t y,const char *text, ucFont_t fontSize)
 {

--- a/firmware/source/hardware/UC1701.c
+++ b/firmware/source/hardware/UC1701.c
@@ -141,15 +141,6 @@ void ucRender(void)
 	ucRenderRows(0,8);
 }
 
-/*
-
-     clear(0, 1); 0, 8
-     clear(2, 4); 16, 32
-
-     clear(6, 8); 48, 64
-
- */
-
 //#define DISPLAY_CHECK_BOUNDS
 #ifdef DISPLAY_CHECK_BOUNDS
 static inline bool checkWritePos(uint8_t * writePos)
@@ -385,7 +376,7 @@ void ucClearRows(int16_t startRow, int16_t endRow)
 		swap(startRow, endRow);
 	}
 
-	// memset would be faster then ucFillRect()
+	// memset would be faster then ucFillRect
 	//ucFillRect(0, (startRow * 8), 128, (8 * (endRow - startRow)), true);
     memset(screenBuf + (128 * startRow), 0, (128 * (endRow - startRow)));
 }

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -115,7 +115,7 @@ int menuChannelMode(uiEvent_t *ev, bool isFirstRun)
 				{
 					displaySquelch = false;
 
-					ucFillRect(0, 16, 128, 16, true);
+					ucClearRows(2, 4, false);
 					ucRenderRows(2,4);
 				}
 
@@ -243,7 +243,7 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 	// since menuDisplayQSODataState won't be set to QSO_DISPLAY_IDLE
 	if ((trxGetMode() == RADIO_MODE_DIGITAL) && (HRC6000GetReceivedTgOrPcId() == 0))
 	{
-		ucClearRows(0,  2);
+		ucClearRows(0,  2, false);
 		menuUtilityRenderHeader();
 		ucRenderRows(0,  2);
 	}
@@ -264,7 +264,7 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 				if (displaySquelch)
 				{
 					displaySquelch = false;
-					ucFillRect(0, 16, 128, 16, true);
+					ucClearRows(2, 4, false);
 				}
 
 				snprintf(buffer, bufferLen, " %d ", txTimeSecs);

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -238,6 +238,16 @@ void menuChannelModeUpdateScreen(int txTimeSecs)
 	struct_codeplugContact_t contact;
 	int contactIndex;
 
+	// Only render the header, then wait for the next run
+	// Otherwise the screen could remain blank if TG and PC are == 0
+	// since menuDisplayQSODataState won't be set to QSO_DISPLAY_IDLE
+	if ((trxGetMode() == RADIO_MODE_DIGITAL) && (HRC6000GetReceivedTgOrPcId() == 0))
+	{
+		ucClearRows(0,  2);
+		menuUtilityRenderHeader();
+		ucRenderRows(0,  2);
+	}
+
 	ucClearBuf();
 	menuUtilityRenderHeader();
 

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -775,7 +775,7 @@ void menuUtilityRenderQSOData(void)
 			}
 			if (tg != trxTalkGroupOrPcId || (dmrMonitorCapturedTS!=-1 && dmrMonitorCapturedTS != trxGetDMRTimeSlot()))
 			{
-				ucFillRect(0,16,128,16,false);// fill background with black
+				ucClearRows(2, 4, true);
 				ucPrintCore(0, CONTACT_Y_POS, buffer, FONT_8x16, TEXT_ALIGN_CENTER, true);// draw the text in inverse video
 			}
 			else

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -243,8 +243,17 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 	struct_codeplugContact_t contact;
 	int contactIndex;
 
-	ucClearBuf();
+	// Only render the header, then wait for the next run
+	// Otherwise the screen could remain blank if TG and PC are == 0
+	// since menuDisplayQSODataState won't be set to QSO_DISPLAY_IDLE
+	if ((trxGetMode() == RADIO_MODE_DIGITAL) && (HRC6000GetReceivedTgOrPcId() == 0))
+	{
+		ucClearRows(0,  2);
+		menuUtilityRenderHeader();
+		ucRenderRows(0,  2);
+	}
 
+	ucClearBuf();
 	menuUtilityRenderHeader();
 
 	switch(menuDisplayQSODataState)

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -181,7 +181,7 @@ int menuVFOMode(uiEvent_t *ev, bool isFirstRun)
 				{
 					displaySquelch = false;
 
-					ucFillRect(0, 16, 128, 16, true);
+					ucClearRows(2, 4, false);
 					ucRenderRows(2,4);
 				}
 
@@ -248,7 +248,7 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 	// since menuDisplayQSODataState won't be set to QSO_DISPLAY_IDLE
 	if ((trxGetMode() == RADIO_MODE_DIGITAL) && (HRC6000GetReceivedTgOrPcId() == 0))
 	{
-		ucClearRows(0,  2);
+		ucClearRows(0,  2, false);
 		menuUtilityRenderHeader();
 		ucRenderRows(0,  2);
 	}
@@ -286,9 +286,13 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 							codeplugUtilConvertBufToString(contact.name, buffer, 16);
 						}
 					}
-					if (trxIsTransmitting) {
+
+					if (trxIsTransmitting)
+					{
 						ucDrawRect(0, 34, 128, 16, true);
-					} else {
+					}
+					else
+					{
 						ucDrawRect(0, (CCScanActive ? 32 : CONTACT_Y_POS), 128, 16, true);
 					}
 				}
@@ -367,7 +371,7 @@ void menuVFOModeUpdateScreen(int txTimeSecs)
 					if (displaySquelch)
 					{
 						displaySquelch = false;
-						ucFillRect(0, 16, 128, 16, true);
+						ucClearRows(2, 4, false);
 					}
 
 					snprintf(buffer, bufferLen, " %d ", txTimeSecs);


### PR DESCRIPTION
Add ucClearRows(), I will replace all calls to ucFillRect() used to clear regions (memset is faster).