### PR TITLE
Longer last heard list length (16->32 entries).

### DIFF
--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -21,7 +21,7 @@
 #include <functions/fw_settings.h>
 #include "fw_common.h"
 
-#define NUM_LASTHEARD_STORED 16
+#define NUM_LASTHEARD_STORED 32
 extern const int QSO_TIMER_TIMEOUT;
 extern const int TX_TIMER_Y_OFFSET;
 extern const int CONTACT_Y_POS;


### PR DESCRIPTION
it will use more ram (already remapped to data.$RAM2), from 1792 to 3584 bytes.
16 entries could be a bit small if you're listening very active TG, and keeping contacts infos into the LH list a bit longer prevents lookups/TA processing.

Cheers.