### PR TITLE
Instant display contact info when getting out of a menu while RXing.

### DIFF
--- a/firmware/include/hardware/fw_HR-C6000.h
+++ b/firmware/include/hardware/fw_HR-C6000.h
@@ -91,6 +91,7 @@ void clearIsWakingState(void);
 int getIsWakingState(void);
 void clearActiveDMRID(void);
 void setMicGainDMR(uint8_t gain);
+bool checkTalkGroupFilter(void);
 
 int HRC6000GetReceivedTgOrPcId(void);
 int HRC6000GetReceivedSrcId(void);

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -92,7 +92,7 @@ int menuChannelMode(uiEvent_t *ev, bool isFirstRun)
 		// We're in digital mode, RXing, and current talker is already at the top of last heard list,
 		// hence immediately display complete contact/TG info on screen
 		// This mostly happens when getting out of a menu.
-		if ((trxIsTransmitting == false) && ((trxGetMode() == RADIO_MODE_DIGITAL) && (rxID != 0)) &&
+		if ((trxIsTransmitting == false) && ((trxGetMode() == RADIO_MODE_DIGITAL) && (rxID != 0) && (HRC6000GetReceivedTgOrPcId() != 0)) &&
 				(GPIO_PinRead(GPIO_audio_amp_enable, Pin_audio_amp_enable) == 1) && checkTalkGroupFilter() &&
 				(((item = lastheardFindInList(rxID)) != NULL) && (item == LinkHead)))
 		{

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -75,18 +75,37 @@ static struct_codeplugChannel_t channelNextChannelData={.rxFreq=0};
 static bool nextChannelReady = false;
 static uint16_t nextChannelIndex = 0;
 
+
 int menuChannelMode(uiEvent_t *ev, bool isFirstRun)
 {
 	static uint32_t m = 0, sqm = 0;
 
 	if (isFirstRun)
 	{
+		LinkItem_t *item = NULL;
+		uint32_t rxID = HRC6000GetReceivedSrcId();
+
 		nonVolatileSettings.initialMenuNumber = MENU_CHANNEL_MODE;// This menu.
 		displayChannelSettings = false;
 		nextChannelReady = false;
+
+		// We're in digital mode, RXing, and current talker is already at the top of last heard list,
+		// hence immediately display complete contact/TG info on screen
+		// This mostly happens when getting out of a menu.
+		if ((trxIsTransmitting == false) && ((trxGetMode() == RADIO_MODE_DIGITAL) && (rxID != 0)) &&
+				(GPIO_PinRead(GPIO_audio_amp_enable, Pin_audio_amp_enable) == 1) &&
+				(((item = lastheardFindInList(rxID)) != NULL) && (item == LinkHead)))
+		{
+			menuDisplayQSODataState = QSO_DISPLAY_CALLER_DATA;
+		}
+		else
+		{
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+		}
+
+		lastHeardClearLastID();
 		prevDisplayQSODataState = QSO_DISPLAY_IDLE;
 		currentChannelData = &channelScreenChannelData;// Need to set this as currentChannelData is used by functions called by loadChannelData()
-		lastHeardClearLastID();
 
 		if (channelScreenChannelData.rxFreq != 0)
 		{
@@ -100,8 +119,8 @@ int menuChannelMode(uiEvent_t *ev, bool isFirstRun)
 			loadChannelData(false);
 		}
 
-		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		menuChannelModeUpdateScreen(0);
+
 		if (uiChannelModeScanActive==false)
 		{
 			scanState = SCAN_SCANNING;

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -93,7 +93,7 @@ int menuChannelMode(uiEvent_t *ev, bool isFirstRun)
 		// hence immediately display complete contact/TG info on screen
 		// This mostly happens when getting out of a menu.
 		if ((trxIsTransmitting == false) && ((trxGetMode() == RADIO_MODE_DIGITAL) && (rxID != 0)) &&
-				(GPIO_PinRead(GPIO_audio_amp_enable, Pin_audio_amp_enable) == 1) &&
+				(GPIO_PinRead(GPIO_audio_amp_enable, Pin_audio_amp_enable) == 1) && checkTalkGroupFilter() &&
 				(((item = lastheardFindInList(rxID)) != NULL) && (item == LinkHead)))
 		{
 			menuDisplayQSODataState = QSO_DISPLAY_CALLER_DATA;

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -172,7 +172,7 @@ int menuVFOMode(uiEvent_t *ev, bool isFirstRun)
 		// hence immediately display complete contact/TG info on screen
 		// This mostly happens when getting out of a menu.
 		if ((trxIsTransmitting == false) && ((trxGetMode() == RADIO_MODE_DIGITAL) && (rxID != 0)) &&
-				(GPIO_PinRead(GPIO_audio_amp_enable, Pin_audio_amp_enable) == 1) &&
+				(GPIO_PinRead(GPIO_audio_amp_enable, Pin_audio_amp_enable) == 1) && checkTalkGroupFilter() &&
 				(((item = lastheardFindInList(rxID)) != NULL) && (item == LinkHead)))
 		{
 			menuDisplayQSODataState = QSO_DISPLAY_CALLER_DATA;

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -171,7 +171,7 @@ int menuVFOMode(uiEvent_t *ev, bool isFirstRun)
 		// We're in digital mode, RXing, and current talker is already at the top of last heard list,
 		// hence immediately display complete contact/TG info on screen
 		// This mostly happens when getting out of a menu.
-		if ((trxIsTransmitting == false) && ((trxGetMode() == RADIO_MODE_DIGITAL) && (rxID != 0)) &&
+		if ((trxIsTransmitting == false) && ((trxGetMode() == RADIO_MODE_DIGITAL) && (rxID != 0) && (HRC6000GetReceivedTgOrPcId() != 0)) &&
 				(GPIO_PinRead(GPIO_audio_amp_enable, Pin_audio_amp_enable) == 1) && checkTalkGroupFilter() &&
 				(((item = lastheardFindInList(rxID)) != NULL) && (item == LinkHead)))
 		{


### PR DESCRIPTION
This fixes latency about contact informations rendering, when getting in and out of any menu when RXing (DIGITAL mode only).