### PR TITLE
Allow disabling Analog CTCSS filtering

### DIFF
--- a/firmware/include/functions/fw_settings.h
+++ b/firmware/include/functions/fw_settings.h
@@ -68,6 +68,7 @@ typedef struct settingsStruct
 	uint8_t			currentVFONumber;
 	uint8_t			dmrFilterLevel;
 	uint8_t			dmrCaptureTimeout;
+	uint8_t			analogFilterLevel;
 	uint8_t			languageIndex;
 	uint8_t			scanDelay;
 	uint8_t			squelchDefaults[RADIO_BANDS_TOTAL_NUM];// VHF,200Mhz and UHF
@@ -84,6 +85,7 @@ typedef struct settingsStruct
 
 typedef enum DMR_FILTER_TYPE {DMR_FILTER_NONE = 0, DMR_FILTER_CC, DMR_FILTER_CC_TS, DMR_FILTER_CC_TS_TG, DMR_FILTER_CC_TS_DC ,
 								NUM_DMR_FILTER_LEVELS} dmrFilter_t;
+typedef enum ANALOG_FILTER_TYPE {ANALOG_FILTER_NONE = 0, ANALOG_FILTER_CTCSS, NUM_ANALOG_FILTER_LEVELS} analogFilter_t;
 
 extern settingsStruct_t nonVolatileSettings;
 extern struct_codeplugChannel_t *currentChannelData;

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -71,6 +71,7 @@ enum QSO_DISPLAY_STATE
 extern const int MAX_POWER_SETTING_NUM;
 extern const char *POWER_LEVELS[];
 extern const char *DMR_FILTER_LEVELS[];
+extern const char *ANALOG_FILTER_LEVELS[];
 extern LinkItem_t *LinkHead;
 extern int menuDisplayQSODataState;
 extern int qsodata_timer;

--- a/firmware/source/functions/fw_settings.c
+++ b/firmware/source/functions/fw_settings.c
@@ -27,7 +27,7 @@
 
 static const int STORAGE_BASE_ADDRESS 		= 0x6000;
 
-static const int STORAGE_MAGIC_NUMBER 		= 0x4743;
+static const int STORAGE_MAGIC_NUMBER 		= 0x4744;
 
 
 settingsStruct_t nonVolatileSettings;
@@ -66,6 +66,10 @@ bool settingsLoadSettings(void)
 	trxDMRID = codeplugGetUserDMRID();
 
 	HRC6000SetCCFilterMode(nonVolatileSettings.dmrFilterLevel==DMR_FILTER_NONE);
+	if (nonVolatileSettings.analogFilterLevel == ANALOG_FILTER_NONE)
+	{
+		trxSetRxCTCSS(TRX_CTCSS_TONE_NONE);
+	}
 
 	currentLanguage = &languages[nonVolatileSettings.languageIndex];
 
@@ -154,6 +158,7 @@ void settingsRestoreDefaultSettings(void)
 	nonVolatileSettings.currentVFONumber = 0;
 	nonVolatileSettings.dmrFilterLevel = DMR_FILTER_CC_TS;
 	nonVolatileSettings.dmrCaptureTimeout=10;// Default to holding 10 seconds after a call ends
+	nonVolatileSettings.analogFilterLevel = ANALOG_FILTER_CTCSS;
 	nonVolatileSettings.languageIndex=0;
 	nonVolatileSettings.scanDelay=5;// 5 seconds
 	nonVolatileSettings.scanModePause = SCAN_MODE_HOLD;

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -68,6 +68,7 @@ static int nuisanceDelete[MAX_ZONE_SCAN_NUISANCE_CHANNELS];
 static int nuisanceDeleteIndex = 0;
 
 static int tmpQuickMenuDmrFilterLevel;
+static int tmpQuickMenuAnalogFilterLevel;
 static bool displayChannelSettings;
 static int prevDisplayQSODataState;
 
@@ -299,7 +300,14 @@ static void loadChannelData(bool useChannelDataInMemory)
 	{
 		trxSetModeAndBandwidth(channelScreenChannelData.chMode, ((channelScreenChannelData.flag4 & 0x02) == 0x02));
 		trxSetTxCTCSS(channelScreenChannelData.txTone);
-		trxSetRxCTCSS(channelScreenChannelData.rxTone);
+		if (nonVolatileSettings.analogFilterLevel == ANALOG_FILTER_NONE)
+		{
+			trxSetRxCTCSS(TRX_CTCSS_TONE_NONE);
+		}
+		else
+		{
+			trxSetRxCTCSS(channelScreenChannelData.rxTone);
+		}
 	}
 	else
 	{
@@ -1014,7 +1022,7 @@ static void handleUpKey(uiEvent_t *ev)
 // Quick Menu functions
 
 enum CHANNEL_SCREEN_QUICK_MENU_ITEMS { CH_SCREEN_QUICK_MENU_SCAN=0, CH_SCREEN_QUICK_MENU_COPY2VFO, CH_SCREEN_QUICK_MENU_COPY_FROM_VFO,
-	CH_SCREEN_QUICK_MENU_DMR_FILTER,
+	CH_SCREEN_QUICK_MENU_FILTER,
 	NUM_CH_SCREEN_QUICK_MENU_ITEMS };// The last item in the list is used so that we automatically get a total number of items in the list
 
 static void updateQuickMenuScreen(void)
@@ -1042,8 +1050,15 @@ static void updateQuickMenuScreen(void)
 			case CH_SCREEN_QUICK_MENU_COPY_FROM_VFO:
 				strncpy(buf, currentLanguage->vfoToChannel, bufferLen);
 				break;
-			case CH_SCREEN_QUICK_MENU_DMR_FILTER:
-				snprintf(buf, bufferLen, "%s:%s", currentLanguage->filter, (tmpQuickMenuDmrFilterLevel == 0) ? currentLanguage->none : DMR_FILTER_LEVELS[tmpQuickMenuDmrFilterLevel]);
+			case CH_SCREEN_QUICK_MENU_FILTER:
+				if (trxGetMode() == RADIO_MODE_DIGITAL)
+				{
+					snprintf(buf, bufferLen, "%s:%s", currentLanguage->filter, (tmpQuickMenuDmrFilterLevel == 0) ? currentLanguage->none : DMR_FILTER_LEVELS[tmpQuickMenuDmrFilterLevel]);
+				}
+				else
+				{
+					snprintf(buf, bufferLen, "%s:%s", currentLanguage->filter, (tmpQuickMenuAnalogFilterLevel == 0) ? currentLanguage->none : ANALOG_FILTER_LEVELS[tmpQuickMenuAnalogFilterLevel]);
+				}
 				break;
 			default:
 				strcpy(buf, "");
@@ -1083,10 +1098,17 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 				codeplugChannelSaveDataForIndex(settingsCurrentChannelNumber,&channelScreenChannelData);
 				menuSystemPopAllAndDisplaySpecificRootMenu(MENU_CHANNEL_MODE);
 				break;
-			case CH_SCREEN_QUICK_MENU_DMR_FILTER:
-				nonVolatileSettings.dmrFilterLevel = tmpQuickMenuDmrFilterLevel;
-				HRC6000SetCCFilterMode(nonVolatileSettings.dmrFilterLevel==DMR_FILTER_NONE);
-				init_digital_DMR_RX();
+			case CH_SCREEN_QUICK_MENU_FILTER:
+				if (trxGetMode() == RADIO_MODE_DIGITAL)
+				{
+					nonVolatileSettings.dmrFilterLevel = tmpQuickMenuDmrFilterLevel;
+					HRC6000SetCCFilterMode(nonVolatileSettings.dmrFilterLevel==DMR_FILTER_NONE);
+					init_digital_DMR_RX();
+				}
+				else
+				{
+					nonVolatileSettings.analogFilterLevel = tmpQuickMenuAnalogFilterLevel;
+				}
 				menuSystemPopAllAndDisplaySpecificRootMenu(MENU_CHANNEL_MODE);
 				break;
 		}
@@ -1096,10 +1118,19 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 	{
 		switch(gMenusCurrentItemIndex)
 		{
-			case CH_SCREEN_QUICK_MENU_DMR_FILTER:
-				if (tmpQuickMenuDmrFilterLevel < DMR_FILTER_CC_TS_DC)
+			case CH_SCREEN_QUICK_MENU_FILTER:
+				if (trxGetMode() == RADIO_MODE_DIGITAL) {
+					if (tmpQuickMenuDmrFilterLevel < NUM_DMR_FILTER_LEVELS - 1)
+					{
+						tmpQuickMenuDmrFilterLevel++;
+					}
+				}
+				else
 				{
-					tmpQuickMenuDmrFilterLevel++;
+					if (tmpQuickMenuAnalogFilterLevel < NUM_ANALOG_FILTER_LEVELS - 1)
+					{
+						tmpQuickMenuAnalogFilterLevel++;
+					}
 				}
 				break;
 		}
@@ -1108,10 +1139,20 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 	{
 		switch(gMenusCurrentItemIndex)
 		{
-			case CH_SCREEN_QUICK_MENU_DMR_FILTER:
-				if (tmpQuickMenuDmrFilterLevel > DMR_FILTER_NONE)
+			case CH_SCREEN_QUICK_MENU_FILTER:
+				if (trxGetMode() == RADIO_MODE_DIGITAL)
 				{
-					tmpQuickMenuDmrFilterLevel--;
+					if (tmpQuickMenuDmrFilterLevel > DMR_FILTER_NONE)
+					{
+						tmpQuickMenuDmrFilterLevel--;
+					}
+				}
+				else
+				{
+					if (tmpQuickMenuAnalogFilterLevel > ANALOG_FILTER_NONE)
+					{
+						tmpQuickMenuAnalogFilterLevel--;
+					}
 				}
 				break;
 		}
@@ -1141,6 +1182,7 @@ int menuChannelModeQuickMenu(uiEvent_t *ev, bool isFirstRun)
 	{
 		menuChannelModeStopScanning();
 		tmpQuickMenuDmrFilterLevel = nonVolatileSettings.dmrFilterLevel;
+		tmpQuickMenuAnalogFilterLevel = nonVolatileSettings.analogFilterLevel;
 		updateQuickMenuScreen();
 	}
 	else

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -50,6 +50,7 @@ uint32_t menuUtilityTgBeforePcMode 	= 0;// No TG saved, prior to a Private call 
 
 const char *POWER_LEVELS[]={ "50mW","250mW","500mW","750mW","1W","2W","3W","4W","5W","5W++"};
 const char *DMR_FILTER_LEVELS[]={"None","CC","CC,TS","CC,TS,TG","CC,TS,Ct"};
+const char *ANALOG_FILTER_LEVELS[]={"None","CTCSS"};
 
 volatile uint32_t lastID=0;// This needs to be volatile as lastHeardClearLastID() is called from an ISR
 uint32_t lastTG=0;
@@ -1106,19 +1107,29 @@ void menuUtilityRenderHeader(void)
 			{
 				strcat(buffer,"N");
 			}
+			ucPrintCore(0, Y_OFFSET, buffer, FONT_6x8, TEXT_ALIGN_LEFT, scanBlinkPhase);
+
 			if ((currentChannelData->txTone!=65535)||(currentChannelData->rxTone!=65535))
 			{
-				strcat(buffer," C");
+				int rectWidth = 7;
+				strcpy(buffer, "C");
+				if (currentChannelData->txTone!=65535)
+				{
+					rectWidth += 6;
+					strcat(buffer, "T");
+				}
+				if (currentChannelData->rxTone!=65535)
+				{
+					rectWidth += 6;
+					strcat(buffer, "R");
+				}
+				bool isInverted = (nonVolatileSettings.analogFilterLevel == ANALOG_FILTER_NONE);
+				if (isInverted)
+				{
+					ucFillRect(23, Y_OFFSET - 1, rectWidth, 9, false);
+				}
+				ucPrintCore(24, Y_OFFSET, buffer, FONT_6x8, TEXT_ALIGN_LEFT, isInverted);
 			}
-			if (currentChannelData->txTone!=65535)
-			{
-				strcat(buffer,"T");
-			}
-			if (currentChannelData->rxTone!=65535)
-			{
-				strcat(buffer,"R");
-			}
-			ucPrintCore(0, Y_OFFSET, buffer, FONT_6x8, TEXT_ALIGN_LEFT, scanBlinkPhase);
 			break;
 
 		case RADIO_MODE_DIGITAL:


### PR DESCRIPTION
This patch makes it so that in Analog mode, both in VFO and Channel modes, the quick menu Filter setting allows selecting `CTCSS` (default) or `None`. When the filter is set to `None` the Rx CTCSS filter is disabled.

`STORAGE_MAGIC_NUMBER` is also bumped because the setting is added to the `nonVolatileSettings` struct.

I tested every scenario I could think of against another radio sending and not sending the access tone. I also cleaned up the code just a bit but only where I was touching it anyway and not in any dramatic way.

The feature looks like this:
![analog-filter-none](https://user-images.githubusercontent.com/260569/75210346-a87f0000-5735-11ea-8db8-0d01ba52bd1b.png)
![analog-filter-ctcss](https://user-images.githubusercontent.com/260569/75210350-ac128700-5735-11ea-9a0b-bf2e82d11447.png)

I've also attached a test firmware based on 893c04f246dbaa5a3c7264fc07ff01bed560df02 (master when I rebased).

[OpenGD77-KC7RBW-analog-filter-setting-b0477f8.zip](https://github.com/rogerclarkmelbourne/OpenGD77/files/4247839/OpenGD77-KC7RBW-analog-filter-setting-b0477f8.zip)

Feature is under discussion at https://opengd77.com/viewtopic.php?f=16&t=669