### PR TITLE
Require long-press to change DMR Filter to None

### DIFF
--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -1166,6 +1166,26 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 				break;
 		}
 	}
+	else if (KEYCHECK_LONGDOWN(ev->keys, KEY_LEFT))
+	{
+		switch(gMenusCurrentItemIndex)
+		{
+			case CH_SCREEN_QUICK_MENU_FILTER:
+				if (trxGetMode() == RADIO_MODE_DIGITAL)
+				{
+					// Require long-press to change the DMR Filter to None
+					//
+					//  This feature is not intended for normal operation. Its only intended
+					//  as a way to listen to stations using an unknown CC.
+					if (tmpQuickMenuDmrFilterLevel == DMR_FILTER_NONE + 1)
+					{
+						tmpQuickMenuDmrFilterLevel--;
+					}
+				}
+				break;
+		}
+
+	}
 	else if (KEYCHECK_PRESS(ev->keys, KEY_LEFT))
 	{
 		switch(gMenusCurrentItemIndex)
@@ -1173,7 +1193,9 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 			case CH_SCREEN_QUICK_MENU_FILTER:
 				if (trxGetMode() == RADIO_MODE_DIGITAL)
 				{
-					if (tmpQuickMenuDmrFilterLevel > DMR_FILTER_NONE)
+					// Note that long-press is required to change DMR filter to None
+					// See KEYCHECK_LONGDOWN section above.
+					if (tmpQuickMenuDmrFilterLevel > DMR_FILTER_NONE + 1)
 					{
 						tmpQuickMenuDmrFilterLevel--;
 					}

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -1304,6 +1304,24 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 #endif
 			}
 	}
+	else if (KEYCHECK_LONGDOWN(ev->keys, KEY_LEFT))
+	{
+		switch(gMenusCurrentItemIndex)
+		{
+			case VFO_SCREEN_QUICK_MENU_FILTER:
+				if (trxGetMode() == RADIO_MODE_DIGITAL)
+				{
+					// Require long-press to change the DMR Filter to None
+					//
+					//  This feature is not intended for normal operation. Its only intended
+					//  as a way to listen to stations using an unknown CC.
+					if (tmpQuickMenuDmrFilterLevel == DMR_FILTER_NONE + 1)
+					{
+						tmpQuickMenuDmrFilterLevel--;
+					}
+				}
+		}
+	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 	{
 		switch(gMenusCurrentItemIndex)
@@ -1311,7 +1329,9 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 			case VFO_SCREEN_QUICK_MENU_FILTER:
 				if (trxGetMode() == RADIO_MODE_DIGITAL)
 				{
-					if (tmpQuickMenuDmrFilterLevel > DMR_FILTER_NONE)
+					// Note that long-press is required to change DMR filter to None
+					// See KEYCHECK_LONGDOWN section above.
+					if (tmpQuickMenuDmrFilterLevel > DMR_FILTER_NONE + 1)
 					{
 						tmpQuickMenuDmrFilterLevel--;
 					}


### PR DESCRIPTION
With the CC filter off I had some channels get messed up while scanning
in Channel mode. Changing the interface this way is a gentle reminder
that the feature is experimental, and will effectively hide it from
novice users who don't know what it's for, while being still easily
reachable by advanced users who do.

Since the "5W++" feature used this same long-press interaction it seemed
like an intuitive way to make the feature slightly harder to reach.