### PR TITLE
Fixes to Catalan

### DIFF
--- a/firmware/source/user_interface/languages/catalan.h
+++ b/firmware/source/user_interface/languages/catalan.h
@@ -20,7 +20,7 @@
  * Translators: EA3IGM, EA5SW, EB3AM, EA3BIL
  *
  *
- * Rev: 4
+ * Rev: 5
  */
 #ifndef USER_INTERFACE_LANGUAGES_CATALAN_H_
 #define USER_INTERFACE_LANGUAGES_CATALAN_H_
@@ -46,6 +46,7 @@ const stringsTable_t catalanLanguage=
 .last_heard				= "Escoltats",
 .options				= "Opcions",
 .display_options		= "Opcions pantalla",
+.sound_options			= "Opcions de só", // MaxLen: 16
 .channel_details		= "Detalls Canal",
 .new_contact			= "Nou contacte",
 .new_channel			= "Nou canal", // MaxLen: 16, leave room for a space and four channel digits after
@@ -90,7 +91,7 @@ const stringsTable_t catalanLanguage=
 .duplicate				= "Duplicat",
 .tg						= "TG",
 .pc						= "ID",
-.ts						= "TimeSlot",
+.ts						= "TS",
 .mode					= "Mode",
 .colour_code			= "Codi Color",
 .n_a					= "N/D",
@@ -104,7 +105,7 @@ const stringsTable_t catalanLanguage=
 .no						= "No",
 .rx_group				= "Llista TG/ID",
 .on						= "Sí",
-.timeout_beep			= "Avís de temps",
+.timeout_beep			= "Avís T.O.T.",
 .factory_reset			= "Reinici fabr.",
 .calibration			= "Calibració",
 .band_limits			= "Límit bandes",
@@ -145,8 +146,11 @@ const stringsTable_t catalanLanguage=
 .private_call_handling	= "Gestió PC", // MaxLen 16 (with ':' + .on ot .off)
 .stop					= "Stop", // Maxlen 16 (with ':' + .scan_mode)
 .one_line				= "1 línia", // MaxLen 16 (with ':' + .contact)
-.two_lines				= "2 linies", // MaxLen 16 (with ':' + .contact)
+.two_lines				= "2 línies", // MaxLen 16 (with ':' + .contact)
 .priority_order			= "Prio.", // MaxLen 16 (with ':' + 'Cc/DB/TA')
+.dmr_beep				= "DMR Beep", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
+.start					= "Inici", // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Tots" // MaxLen 16 (with ':' + .dmr_beep)
 };
 /********************************************************************
  *


### PR DESCRIPTION
#23, version number updated
#108, used T.O.T., it's higly specific. Also "de temps" + ":" + .both = 18 !!!
#149, placed missing tilde
#151, Capitals to beep

73'Rafa.
EA3BIL.