### PR TITLE
Change: keep CC in hotspot mode (new version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 /ComTool/.vs
 /ComTool/ComTool/bin
 /ComTool/ComTool/obj
-/font_tools/font_converter/font_*
+/tools/font_tools/font_converter/font_*

--- a/firmware/include/main.h
+++ b/firmware/include/main.h
@@ -60,5 +60,6 @@ extern bool Display_light_Touched;
 extern const char *FIRMWARE_VERSION_STRING;
 
 void fw_init(void);
+void fw_powerOffFinalStage(void);
 
 #endif /* _FW_MAIN_H_ */

--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -99,6 +99,9 @@ void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool displayDetails);
 void menuClearPrivateCall(void);
 void menuAcceptPrivateCall(int id);
 
+void menuHotspotRestoreSettings(void);
+
+
 /*
  * ---------------------- IMPORTANT ----------------------------
  *

--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -99,8 +99,6 @@ void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool displayDetails);
 void menuClearPrivateCall(void);
 void menuAcceptPrivateCall(int id);
 
-bool menuHotspotModeIsRunning(void);
-
 /*
  * ---------------------- IMPORTANT ----------------------------
  *

--- a/firmware/source/hardware/HR-C6000.c
+++ b/firmware/source/hardware/HR-C6000.c
@@ -776,14 +776,13 @@ inline static void HRC6000SysInterruptHandler(void)
 
 	if (!trxIsTransmitting) // ignore the LC data when we are transmitting
 	{
-		if ((menuHotspotModeIsRunning() == false) && (ccHold == false) && (nonVolatileSettings.dmrFilterLevel < DMR_FILTER_CC))
+		if ((!ccHold) && (nonVolatileSettings.dmrFilterLevel < DMR_FILTER_CC) )
 		{
 			if(rxColorCode==lastRxColorCode)
 			{
 				trxSetDMRColourCode(rxColorCode);
 			}
-
-			lastRxColorCode=rxColorCode;
+		lastRxColorCode=rxColorCode;
 		}
 
 		uint8_t LCBuf[12];

--- a/firmware/source/hotspot/uiHotspot.c
+++ b/firmware/source/hotspot/uiHotspot.c
@@ -309,7 +309,6 @@ static uint8_t cwBuffer[64U];
 static uint16_t cwpoLen;
 static uint16_t cwpoPtr;
 static bool cwKeying = false;
-static bool hotspotModeRunning = false;
 // End of CWID related
 
 
@@ -336,7 +335,6 @@ int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
-		hotspotModeRunning = true;
 		hotspotState = HOTSPOT_STATE_NOT_CONNECTED;
 
 		savedTGorPC = trxTalkGroupOrPcId;// Save the current TG or PC
@@ -420,11 +418,6 @@ int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 	}
 
 	return 0;
-}
-
-bool menuHotspotModeIsRunning(void)
-{
-	return hotspotModeRunning;
 }
 
 static void displayContactInfo(uint8_t y, char *text, size_t maxLen)
@@ -716,7 +709,6 @@ static void hotspotExit(void)
 	trxDMRID = codeplugGetUserDMRID();
 	settingsUsbMode = USB_MODE_CPS;
 	mmdvmHostIsConnected = false;
-	hotspotModeRunning = false;
 	menuSystemPopAllAndDisplayRootMenu();
 }
 

--- a/firmware/source/hotspot/uiHotspot.c
+++ b/firmware/source/hotspot/uiHotspot.c
@@ -123,9 +123,9 @@ M: 2020-01-07 09:52:15.246 DMR Slot 2, received network end of voice transmissio
 
 #define PROTOCOL_VERSION    1U
 
-#define MMDVM_HEADER_LENGTH  4U
+#define MMDVM_HEADER_LENGTH 4U
 
-#define HOTSPOT_VERSION_STRING "OpenGD77 Hotspot v0.1.0"
+#define HOTSPOT_VERSION_STRING "OpenGD77 Hotspot v0.1.1"
 #define concat(a, b) a " GitID #" b ""
 static const char HARDWARE[] = concat(HOTSPOT_VERSION_STRING, GITVERSION);
 
@@ -309,6 +309,8 @@ static uint8_t cwBuffer[64U];
 static uint16_t cwpoLen;
 static uint16_t cwpoPtr;
 static bool cwKeying = false;
+static uint8_t savedDMRFilterLevel = 0xFF; // 0xFF value means unset
+
 // End of CWID related
 
 
@@ -335,6 +337,15 @@ int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
+		// DMR filter level isn't saved yet (cycling power OFF/ON quickly can corrupt
+		// this value otherwise, as menuHotspotMode(true) could be called twice.
+		if (savedDMRFilterLevel == 0xFF)
+		{
+			// Override DMR filtering
+			savedDMRFilterLevel = nonVolatileSettings.dmrFilterLevel;
+			nonVolatileSettings.dmrFilterLevel = DMR_FILTER_CC_TS;
+		}
+
 		hotspotState = HOTSPOT_STATE_NOT_CONNECTED;
 
 		savedTGorPC = trxTalkGroupOrPcId;// Save the current TG or PC
@@ -418,6 +429,15 @@ int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 	}
 
 	return 0;
+}
+
+void menuHotspotRestoreSettings(void)
+{
+	if (savedDMRFilterLevel != 0xFF)
+	{
+		nonVolatileSettings.dmrFilterLevel = savedDMRFilterLevel;
+		savedDMRFilterLevel = 0xFF; // Unset saved DMR filter level
+	}
 }
 
 static void displayContactInfo(uint8_t y, char *text, size_t maxLen)
@@ -709,6 +729,7 @@ static void hotspotExit(void)
 	trxDMRID = codeplugGetUserDMRID();
 	settingsUsbMode = USB_MODE_CPS;
 	mmdvmHostIsConnected = false;
+	menuHotspotRestoreSettings();
 	menuSystemPopAllAndDisplayRootMenu();
 }
 

--- a/firmware/source/user_interface/uiPowerOff.c
+++ b/firmware/source/user_interface/uiPowerOff.c
@@ -48,7 +48,7 @@ static void handleEvent(uiEvent_t *ev)
 {
 	static uint32_t m = 0;
 
-	if ((GPIO_PinRead(GPIO_Power_Switch, Pin_Power_Switch)==0) && (battery_voltage>CUTOFF_VOLTAGE_LOWER_HYST))
+	if ((GPIO_PinRead(GPIO_Power_Switch, Pin_Power_Switch) == 0) && (battery_voltage > CUTOFF_VOLTAGE_LOWER_HYST))
 	{
 		// I think this is to handle if the power button is turned back on during shutdown
 		menuSystemPopPreviousMenu();
@@ -64,7 +64,6 @@ static void handleEvent(uiEvent_t *ev)
 
 	if ((ev->time - m) > 500)
 	{
-		// This turns the power off to the CPU.
-		GPIO_PinWrite(GPIO_Keep_Power_On, Pin_Keep_Power_On, 0);
+		fw_powerOffFinalStage();
 	}
 }


### PR DESCRIPTION
Hi Roger,

 Hotspot overrides the DMR filter level (to CC+TS).
Implement fw_powerOffFinalStage() which restore latest overriden TG and restore DMR filter overriden by Hotspot mode (if modified), save the settings, then power off the MCU.

This is used in case of low battery and normal power off cycling.

Cheers.
...
Daniel