### PR TITLE
Reduce min contrast value from 12 to 5 (still slightly visible).

### DIFF
--- a/firmware/source/functions/settings.c
+++ b/firmware/source/functions/settings.c
@@ -123,7 +123,12 @@ void settingsRestoreDefaultSettings(void)
 	nonVolatileSettings.currentZone = 0;
 	nonVolatileSettings.backlightMode = BACKLIGHT_MODE_AUTO;
 	nonVolatileSettings.backLightTimeout = 0;//0 = never timeout. 1 - 255 time in seconds
-	nonVolatileSettings.displayContrast = 0x12;
+	nonVolatileSettings.displayContrast =
+#if defined(PLATFORM_DM1801)
+			0x0e; // 14
+#else
+			0x12; // 18
+#endif
 	nonVolatileSettings.initialMenuNumber=MENU_VFO_MODE;
 	nonVolatileSettings.displayBacklightPercentage=100U;// 100% brightness
 	nonVolatileSettings.displayBacklightPercentageOff=0U;// 0% brightness

--- a/firmware/source/user_interface/menuDisplayOptions.c
+++ b/firmware/source/user_interface/menuDisplayOptions.c
@@ -27,7 +27,7 @@ static void updateBacklightMode(uint8_t mode);
 
 static const int BACKLIGHT_MAX_TIMEOUT = 30;
 static const int CONTRAST_MAX_VALUE = 30;// Maximum value which still seems to be readable
-static const int CONTRAST_MIN_VALUE = 12;// Minimum value which still seems to be readable
+static const int CONTRAST_MIN_VALUE = 5;// Minimum value which still seems to be readable
 static const int BACKLIGHT_TIMEOUT_STEP = 5;
 static const int BACKLIGHT_MAX_PERCENTAGE = 100;
 static const int BACKLIGHT_PERCENTAGE_STEP = 10;


### PR DESCRIPTION
Make 14 default contrast value for the DM-1801. I tried to use the same value for both model, but it doesn't look similar here.