### PR TITLE
Ignore DCS

### DIFF
--- a/firmware/include/functions/codeplug.h
+++ b/firmware/include/functions/codeplug.h
@@ -24,6 +24,7 @@ extern const int CODEPLUG_MAX_VARIABLE_SQUELCH;
 extern const int CODEPLUG_MIN_VARIABLE_SQUELCH;
 extern const int CODEPLUG_ZONE_DATA_SIZE;
 extern const int VFO_FREQ_STEP_TABLE[8];
+extern const uint16_t CODEPLUG_DCS_FLAGS_MASK;
 
 extern int codeplugChannelsPerZone;
 
@@ -132,6 +133,7 @@ void codeplugSetVFO_ChannelData(struct_codeplugChannel_t *vfoBuf,int VFONumber);
 bool codeplugChannelIndexIsValid(int index);
 void codeplugChannelIndexSetValid(int index);
 bool codeplugChannelSaveDataForIndex(int index, struct_codeplugChannel_t *channelBuf);
+bool codeplugChannelToneIsCTCSS(uint16_t tone);
 
 int codeplugContactsGetCount(int callType);
 int codeplugContactGetDataForNumber(int number, int callType, struct_codeplugContact_t *contact);

--- a/firmware/source/functions/codeplug.c
+++ b/firmware/source/functions/codeplug.c
@@ -66,6 +66,8 @@ const int VFO_FREQ_STEP_TABLE[8] = {250,500,625,1000,1250,2500,3000,5000};
 const int CODEPLUG_MAX_VARIABLE_SQUELCH = 21;
 const int CODEPLUG_MIN_VARIABLE_SQUELCH = 1;
 
+const uint16_t CODEPLUG_DCS_FLAGS_MASK = 0xC000;
+
 typedef struct
 {
 	uint32_t tgOrPCNum;
@@ -115,6 +117,11 @@ int int2bcd(int i)
         shift += 4;
     }
     return result;
+}
+
+bool codeplugChannelToneIsCTCSS(uint16_t tone)
+{
+	return ((tone != TRX_CTCSS_TONE_NONE) && !(tone & CODEPLUG_DCS_FLAGS_MASK));
 }
 
 void codeplugUtilConvertBufToString(char *inBuf,char *outBuf,int len)
@@ -307,11 +314,11 @@ void codeplugChannelGetDataForIndex(int index, struct_codeplugChannel_t *channel
 	// Convert the the legacy codeplug tx and rx freq values into normal integers
 	channelBuf->txFreq = bcd2int(channelBuf->txFreq);
 	channelBuf->rxFreq = bcd2int(channelBuf->rxFreq);
-	if (channelBuf->rxTone != 0xffff)
+	if (codeplugChannelToneIsCTCSS(channelBuf->rxTone))
 	{
 		channelBuf->rxTone = bcd2int(channelBuf->rxTone);
 	}
-	if (channelBuf->txTone != 0xffff)
+	if (codeplugChannelToneIsCTCSS(channelBuf->txTone))
 	{
 		channelBuf->txTone = bcd2int(channelBuf->txTone);
 	}
@@ -338,12 +345,12 @@ bool codeplugChannelSaveDataForIndex(int index, struct_codeplugChannel_t *channe
 	// Convert the the legacy codeplug tx and rx freq values into normal integers
 	channelBuf->txFreq = int2bcd(channelBuf->txFreq);
 	channelBuf->rxFreq = int2bcd(channelBuf->rxFreq);
-	if (channelBuf->rxTone != 0xffff)
+	if (codeplugChannelToneIsCTCSS(channelBuf->rxTone))
 	{
 		channelBuf->rxTone = int2bcd(channelBuf->rxTone);
 	}
 
-	if (channelBuf->txTone != 0xffff)
+	if (codeplugChannelToneIsCTCSS(channelBuf->txTone))
 	{
 		channelBuf->txTone = int2bcd(channelBuf->txTone);
 	}
@@ -431,11 +438,11 @@ bool codeplugChannelSaveDataForIndex(int index, struct_codeplugChannel_t *channe
 	// Convert the the legacy codeplug tx and rx freq values into normal integers
 	channelBuf->txFreq = bcd2int(channelBuf->txFreq);
 	channelBuf->rxFreq = bcd2int(channelBuf->rxFreq);
-	if (channelBuf->rxTone != 0xffff)
+	if (codeplugChannelToneIsCTCSS(channelBuf->rxTone))
 	{
 		channelBuf->rxTone = bcd2int(channelBuf->rxTone);
 	}
-	if (channelBuf->txTone != 0xffff)
+	if (codeplugChannelToneIsCTCSS(channelBuf->txTone))
 	{
 		channelBuf->txTone = bcd2int(channelBuf->txTone);
 	}

--- a/firmware/source/functions/trx.c
+++ b/firmware/source/functions/trx.c
@@ -840,7 +840,7 @@ void trxUpdateTsForCurrentChannelWithSpecifiedContact(struct_codeplugContact_t *
 void trxSetTxCTCSS(int toneFreqX10)
 {
 	taskENTER_CRITICAL();
-	if (toneFreqX10 == 0xFFFF)
+	if (!codeplugChannelToneIsCTCSS(toneFreqX10))
 	{
 		// tone value of 0xffff in the codeplug seem to be a flag that no tone has been selected
         write_I2C_reg_2byte(I2C_MASTER_SLAVE_ADDR_7BIT, 0x4a, 0x00,0x00); //Zero the CTCSS1 Register
@@ -860,7 +860,7 @@ void trxSetTxCTCSS(int toneFreqX10)
 void trxSetRxCTCSS(int toneFreqX10)
 {
 	taskENTER_CRITICAL();
-	if (toneFreqX10 == 0xFFFF)
+	if (!codeplugChannelToneIsCTCSS(toneFreqX10))
 	{
 		// tone value of 0xffff in the codeplug seem to be a flag that no tone has been selected
         write_I2C_reg_2byte(I2C_MASTER_SLAVE_ADDR_7BIT, 0x4d, 0x00,0x00); //Zero the CTCSS2 Register

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -169,7 +169,7 @@ static void updateScreen(void)
 				case CH_DETAILS_RXCTCSS:
 					if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 					{
-						if (tmpChannel.txTone == TRX_CTCSS_TONE_NONE)
+						if (!codeplugChannelToneIsCTCSS(tmpChannel.txTone))
 						{
 							snprintf(buf, bufferLen, "Tx CTCSS:%s", currentLanguage->none);
 						}
@@ -186,7 +186,7 @@ static void updateScreen(void)
 				case CH_DETAILS_TXCTCSS:
 					if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 					{
-						if (tmpChannel.rxTone == TRX_CTCSS_TONE_NONE)
+						if (!codeplugChannelToneIsCTCSS(tmpChannel.rxTone))
 						{
 							snprintf(buf, bufferLen, "Rx CTCSS:%s", currentLanguage->none);
 						}

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -1045,8 +1045,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		else if (KEYCHECK_SHORTUP(ev->keys, KEY_STAR))
 		{
-			// Toggle TimeSlot
-			if (ev->buttons & BUTTON_SK2 )
+			if (ev->buttons & BUTTON_SK2 )  // Toggle Channel Mode
 			{
 				if (trxGetMode() == RADIO_MODE_ANALOG)
 				{
@@ -1057,7 +1056,15 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					channelScreenChannelData.chMode = RADIO_MODE_ANALOG;
 					trxSetModeAndBandwidth(channelScreenChannelData.chMode, ((channelScreenChannelData.flag4 & 0x02) == 0x02));
-					trxSetTxCTCSS(currentChannelData->rxTone);
+					trxSetTxCTCSS(currentChannelData->txTone);
+					if (nonVolatileSettings.analogFilterLevel == ANALOG_FILTER_NONE)
+					{
+						trxSetRxCTCSS(TRX_CTCSS_TONE_NONE);
+					}
+					else
+					{
+						trxSetRxCTCSS(currentChannelData->rxTone);
+					}
 				}
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 				menuChannelModeUpdateScreen(0);

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1145,16 +1145,16 @@ void menuUtilityRenderHeader(void)
 			}
 			ucPrintCore(0, Y_OFFSET, buffer, FONT_6x8, TEXT_ALIGN_LEFT, scanBlinkPhase);
 
-			if ((currentChannelData->txTone!=65535)||(currentChannelData->rxTone!=65535))
+			if (codeplugChannelToneIsCTCSS(currentChannelData->txTone) || codeplugChannelToneIsCTCSS(currentChannelData->rxTone))
 			{
 				int rectWidth = 7;
 				strcpy(buffer, "C");
-				if (currentChannelData->txTone!=65535)
+				if (codeplugChannelToneIsCTCSS(currentChannelData->txTone))
 				{
 					rectWidth += 6;
 					strcat(buffer, "T");
 				}
-				if (currentChannelData->rxTone!=65535)
+				if (codeplugChannelToneIsCTCSS(currentChannelData->rxTone))
 				{
 					rectWidth += 6;
 					strcat(buffer, "R");
@@ -1317,7 +1317,7 @@ void printToneAndSquelch(void)
 	char buf[24];
 	if (trxGetMode() == RADIO_MODE_ANALOG)
 	{
-		if (currentChannelData->rxTone == TRX_CTCSS_TONE_NONE)
+		if (!codeplugChannelToneIsCTCSS(currentChannelData->rxTone))
 		{
 			snprintf(buf, 24, "CTCSS:%s|", currentLanguage->none);
 			buf[23] = 0;
@@ -1327,7 +1327,7 @@ void printToneAndSquelch(void)
 			snprintf(buf, 24, "CTCSS:%d.%dHz|", currentChannelData->rxTone / 10 , currentChannelData->rxTone % 10);
 		}
 
-		if (currentChannelData->txTone == TRX_CTCSS_TONE_NONE)
+		if (!codeplugChannelToneIsCTCSS(currentChannelData->txTone))
 		{
 			snprintf(buf, 24, "%s%s", buf, currentLanguage->none);
 			buf[23] = 0;


### PR DESCRIPTION
DCS values in the codeplug have the high bit set, which is something
that never happens with valid CTCSS codes. Since the DCS feature is not
yet ready to merge, ignore DCS values in the codeplug.

See [bug confirmed on the forum](https://opengd77.com/viewtopic.php?f=15&t=425&p=7249#p7249).

Also fixed a quasi-related bug where CTCSS wasn't configured correctly when switching radio modes from digital to analog using Blue+Star.