### PR TITLE
Add Carrier Squelch to CTCSS Logic

### DIFF
--- a/firmware/source/functions/trx.c
+++ b/firmware/source/functions/trx.c
@@ -312,7 +312,7 @@ void trx_check_analog_squelch(void)
 
 
 
-		if(((!rxCTCSSactive) && (trxRxNoise < squelch)) || ((rxCTCSSactive) && (trxCheckCTCSSFlag())))
+		if((trxRxNoise < squelch) && (((rxCTCSSactive) && (trxCheckCTCSSFlag())) || (!rxCTCSSactive)))
 		{
 			GPIO_PinWrite(GPIO_RX_audio_mux, Pin_RX_audio_mux, 1);// Set the audio path to AT1846 -> audio amp.
 			enableAudioAmp(AUDIO_AMP_MODE_RF);


### PR DESCRIPTION
Fix problem where spurious CTCSS decodes were causing audio to briefly unmute.
Now needs Carrier Squelch AND CTCSS before audio Unmutes.