### PR TITLE
Avoid updateScreen()s when not needed.

### DIFF
--- a/firmware/include/functions/settings.h
+++ b/firmware/include/functions/settings.h
@@ -25,7 +25,7 @@
 #include "trx.h"
 
 #if defined(PLATFORM_RD5R)
-#define SETTINGS_PLATFORM_SPECIFIC_SAVE_SETTINGS(includeVFOs) settingsSaveSettings(includeVFOs)
+#define SETTINGS_PLATFORM_SPECIFIC_SAVE_SETTINGS(includeVFOs) do { settingsSaveSettings(includeVFOs); } while(0)
 #else
 #define SETTINGS_PLATFORM_SPECIFIC_SAVE_SETTINGS(includeVFOs)
 #endif

--- a/firmware/source/user_interface/menuBattery.c
+++ b/firmware/source/user_interface/menuBattery.c
@@ -275,6 +275,8 @@ static void updateScreen(bool forceRedraw)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
@@ -324,8 +326,6 @@ static void handleEvent(uiEvent_t *ev)
 			}
 		}
 	}
-
-	displayLightTrigger();
 }
 
 void menuBatteryInit(void)

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -28,8 +28,8 @@ static void updateScreen(void);
 static void updateCursor(bool moved);
 static void handleEvent(uiEvent_t *ev);
 
-static int CTCSSRxIndex=0;
-static int CTCSSTxIndex=0;
+static int CTCSSRxIndex = 0;
+static int CTCSSTxIndex = 0;
 static struct_codeplugChannel_t tmpChannel;// update a temporary copy of the channel and only write back if green menu is pressed
 static char channelName[17];
 static int namePos;
@@ -49,17 +49,18 @@ int menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
 	if (isFirstRun)
 	{
 		freq_enter_idx = 0;
-		memcpy(&tmpChannel,currentChannelData,sizeof(struct_codeplugChannel_t));
+		memcpy(&tmpChannel, currentChannelData,sizeof(struct_codeplugChannel_t));
 
-		for(int i=0;i<TRX_NUM_CTCSS;i++)
+		for(int i = 0; i < TRX_NUM_CTCSS; i++)
 		{
-			if (tmpChannel.txTone==TRX_CTCSSTones[i])
+			if (tmpChannel.txTone == TRX_CTCSSTones[i])
 			{
-				CTCSSTxIndex=i;
+				CTCSSTxIndex = i;
 			}
-			if (tmpChannel.rxTone==TRX_CTCSSTones[i])
+
+			if (tmpChannel.rxTone == TRX_CTCSSTones[i])
 			{
-				CTCSSRxIndex=i;
+				CTCSSRxIndex = i;
 			}
 		}
 
@@ -114,7 +115,7 @@ static void updateScreen(void)
 	ucClearBuf();
 	menuDisplayTitle(currentLanguage->channel_details);
 
-	if (freq_enter_idx!=0)
+	if (freq_enter_idx != 0)
 	{
 		snprintf(buf, bufferLen, "%c%c%c.%c%c%c%c%c MHz", freq_enter_digits[0], freq_enter_digits[1], freq_enter_digits[2],
 				freq_enter_digits[3], freq_enter_digits[4], freq_enter_digits[5], freq_enter_digits[6], freq_enter_digits[7]);
@@ -259,17 +260,18 @@ static void updateScreen(void)
 
 static void updateFrequency(void)
 {
-	int tmp_frequency=read_freq_enter_digits(0,8);
-	if (trxGetBandFromFrequency(tmp_frequency)!=-1)
+	int tmp_frequency = read_freq_enter_digits(0,8);
+
+	if (trxGetBandFromFrequency(tmp_frequency) != -1)
 	{
-		switch(gMenusCurrentItemIndex)
+		switch (gMenusCurrentItemIndex)
 		{
-		case CH_DETAILS_RXFREQ:
-			tmpChannel.rxFreq = tmp_frequency;
-			break;
-		case CH_DETAILS_TXFREQ:
-			tmpChannel.txFreq = tmp_frequency;
-			break;
+			case CH_DETAILS_RXFREQ:
+				tmpChannel.rxFreq = tmp_frequency;
+				break;
+			case CH_DETAILS_TXFREQ:
+				tmpChannel.txFreq = tmp_frequency;
+				break;
 		}
 		reset_freq_enter_digits();
 	}
@@ -289,11 +291,9 @@ static void handleEvent(uiEvent_t *ev)
 		gMenusCurrentItemIndex = ev->function;
 	}
 
-
 	if (gMenusCurrentItemIndex == CH_DETAILS_RXFREQ || gMenusCurrentItemIndex == CH_DETAILS_TXFREQ)
 	{
-
-		if (freq_enter_idx !=0 )
+		if (freq_enter_idx != 0)
 		{
 			if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 			{
@@ -309,7 +309,7 @@ static void handleEvent(uiEvent_t *ev)
 			if (KEYCHECK_SHORTUP(ev->keys,KEY_LEFT))
 			{
 				freq_enter_idx--;
-				freq_enter_digits[freq_enter_idx]='-';
+				freq_enter_digits[freq_enter_idx] = '-';
 				updateScreen();
 				return;
 			}
@@ -322,10 +322,10 @@ static void handleEvent(uiEvent_t *ev)
 			{
 				freq_enter_digits[freq_enter_idx] = (char) keyval+'0';
 				freq_enter_idx++;
-				if (freq_enter_idx==8)
+				if (freq_enter_idx == 8)
 				{
 					updateFrequency();
-					freq_enter_idx=0;
+					freq_enter_idx = 0;
 				}
 				updateScreen();
 				return;
@@ -338,23 +338,26 @@ static void handleEvent(uiEvent_t *ev)
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 	{
 		MENU_INC(gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
+		updateScreen();
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
+		updateScreen();
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 	{
 		switch(gMenusCurrentItemIndex)
 		{
 			case CH_DETAILS_NAME:
-				if (settingsCurrentChannelNumber != -1) {
+				if (settingsCurrentChannelNumber != -1)
+				{
 					moveCursorRightInString(channelName, &namePos, 16, (ev->buttons & BUTTON_SK2));
 					updateCursor(true);
 				}
 				break;
 			case CH_DETAILS_MODE:
-				if (tmpChannel.chMode ==RADIO_MODE_ANALOG)
+				if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 				{
 					tmpChannel.chMode = RADIO_MODE_DIGITAL;
 				}
@@ -364,7 +367,7 @@ static void handleEvent(uiEvent_t *ev)
 				}
 				break;
 			case CH_DETAILS_DMR_CC:
-				if (tmpChannel.rxColor<15)
+				if (tmpChannel.rxColor < 15)
 				{
 					tmpChannel.rxColor++;
 					trxSetDMRColourCode(tmpChannel.rxColor);
@@ -374,26 +377,26 @@ static void handleEvent(uiEvent_t *ev)
 				tmpChannel.flag2 |= 0x40;// set TS 2 bit
 				break;
 			case CH_DETAILS_RXCTCSS:
-				if (tmpChannel.chMode==RADIO_MODE_ANALOG)
+				if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 				{
 					CTCSSTxIndex++;
-					if (CTCSSTxIndex>=TRX_NUM_CTCSS)
+					if (CTCSSTxIndex >= TRX_NUM_CTCSS)
 					{
-						CTCSSTxIndex=TRX_NUM_CTCSS-1;
+						CTCSSTxIndex = TRX_NUM_CTCSS-1;
 					}
-					tmpChannel.txTone=TRX_CTCSSTones[CTCSSTxIndex];
+					tmpChannel.txTone = TRX_CTCSSTones[CTCSSTxIndex];
 					trxSetTxCTCSS(tmpChannel.txTone);
 				}
 				break;
 			case CH_DETAILS_TXCTCSS:
-				if (tmpChannel.chMode==RADIO_MODE_ANALOG)
+				if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 				{
 					CTCSSRxIndex++;
-					if (CTCSSRxIndex>=TRX_NUM_CTCSS)
+					if (CTCSSRxIndex >= TRX_NUM_CTCSS)
 					{
-						CTCSSRxIndex=TRX_NUM_CTCSS-1;
+						CTCSSRxIndex = TRX_NUM_CTCSS-1;
 					}
-					tmpChannel.rxTone=TRX_CTCSSTones[CTCSSRxIndex];
+					tmpChannel.rxTone = TRX_CTCSSTones[CTCSSRxIndex];
 					trxSetRxCTCSS(tmpChannel.rxTone);
 				}
 				break;
@@ -401,16 +404,16 @@ static void handleEvent(uiEvent_t *ev)
 				tmpChannel.flag4 |= 0x02;// set 25kHz bit
 				break;
 			case CH_DETAILS_FREQ_STEP:
-				tmpVal = (tmpChannel.VFOflag5>>4)+1;
-				if (tmpVal>7)
+				tmpVal = (tmpChannel.VFOflag5>>4) + 1;
+				if (tmpVal > 7)
 				{
-					tmpVal=7;
+					tmpVal = 7;
 				}
 				tmpChannel.VFOflag5 &= 0x0F;
 				tmpChannel.VFOflag5 |= tmpVal<<4;
 				break;
 			case CH_DETAILS_TOT:
-				if (tmpChannel.tot<255)
+				if (tmpChannel.tot < 255)
 				{
 					tmpChannel.tot++;
 				}
@@ -424,7 +427,8 @@ static void handleEvent(uiEvent_t *ev)
 			case CH_DETAILS_RXGROUP:
 				tmpVal = tmpChannel.rxGroupList;
 				tmpVal++;
-				while (tmpVal < 76) {
+				while (tmpVal < 76)
+				{
 					codeplugRxGroupGetDataForIndex(tmpVal, &rxGroupBuf);
 					if (rxGroupBuf.name[0] != 0) {
 						tmpChannel.rxGroupList = tmpVal;
@@ -434,19 +438,21 @@ static void handleEvent(uiEvent_t *ev)
 				}
 				break;
 		}
+		updateScreen();
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 	{
 		switch(gMenusCurrentItemIndex)
 		{
 			case CH_DETAILS_NAME:
-				if (settingsCurrentChannelNumber != -1) {
+				if (settingsCurrentChannelNumber != -1)
+				{
 					moveCursorLeftInString(channelName, &namePos, (ev->buttons & BUTTON_SK2));
 					updateCursor(true);
 				}
 				break;
 			case CH_DETAILS_MODE:
-				if (tmpChannel.chMode==RADIO_MODE_ANALOG)
+				if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 				{
 					tmpChannel.chMode = RADIO_MODE_DIGITAL;
 				}
@@ -456,7 +462,7 @@ static void handleEvent(uiEvent_t *ev)
 				}
 				break;
 			case CH_DETAILS_DMR_CC:
-				if (tmpChannel.rxColor>0)
+				if (tmpChannel.rxColor > 0)
 				{
 					tmpChannel.rxColor--;
 					trxSetDMRColourCode(tmpChannel.rxColor);
@@ -471,9 +477,9 @@ static void handleEvent(uiEvent_t *ev)
 					CTCSSTxIndex--;
 					if (CTCSSTxIndex < 0)
 					{
-						CTCSSTxIndex=0;
+						CTCSSTxIndex = 0;
 					}
-					tmpChannel.txTone=TRX_CTCSSTones[CTCSSTxIndex];
+					tmpChannel.txTone = TRX_CTCSSTones[CTCSSTxIndex];
 					trxSetTxCTCSS(tmpChannel.txTone);
 				}
 				break;
@@ -483,9 +489,9 @@ static void handleEvent(uiEvent_t *ev)
 					CTCSSRxIndex--;
 					if (CTCSSRxIndex < 0)
 					{
-						CTCSSRxIndex=0;
+						CTCSSRxIndex = 0;
 					}
-					tmpChannel.rxTone=TRX_CTCSSTones[CTCSSRxIndex];
+					tmpChannel.rxTone = TRX_CTCSSTones[CTCSSRxIndex];
 					trxSetRxCTCSS(tmpChannel.rxTone);
 				}
 				break;
@@ -493,16 +499,16 @@ static void handleEvent(uiEvent_t *ev)
 				tmpChannel.flag4 &= ~0x02;// clear 25kHz bit
 				break;
 			case CH_DETAILS_FREQ_STEP:
-				tmpVal = (tmpChannel.VFOflag5>>4)-1;
-				if (tmpVal<0)
+				tmpVal = (tmpChannel.VFOflag5>>4) - 1;
+				if (tmpVal < 0)
 				{
-					tmpVal=0;
+					tmpVal = 0;
 				}
 				tmpChannel.VFOflag5 &= 0x0F;
 				tmpChannel.VFOflag5 |= tmpVal<<4;
 				break;
 			case CH_DETAILS_TOT:
-				if (tmpChannel.tot>0)
+				if (tmpChannel.tot > 0)
 				{
 					tmpChannel.tot--;
 				}
@@ -516,7 +522,8 @@ static void handleEvent(uiEvent_t *ev)
 			case CH_DETAILS_RXGROUP:
 					tmpVal = tmpChannel.rxGroupList;
 					tmpVal--;
-					while (tmpVal > 0) {
+					while (tmpVal > 0)
+					{
 						codeplugRxGroupGetDataForIndex(tmpVal, &rxGroupBuf);
 						if (rxGroupBuf.name[0] != 0) {
 							tmpChannel.rxGroupList = tmpVal;
@@ -527,20 +534,22 @@ static void handleEvent(uiEvent_t *ev)
 				break;
 
 		}
+		updateScreen();
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
-		if (settingsCurrentChannelNumber != -1) {
+		if (settingsCurrentChannelNumber != -1)
+		{
 			codeplugUtilConvertStringToBuf(channelName, (char *)&tmpChannel.name, 16);
 		}
-		memcpy(currentChannelData,&tmpChannel,sizeof(struct_codeplugChannel_t));
+		memcpy(currentChannelData, &tmpChannel, sizeof(struct_codeplugChannel_t));
 
 		// settingsCurrentChannelNumber is -1 when in VFO mode
 		// But the VFO is stored in the nonVolatile settings, and not saved back to the codeplug
 		// Also don't store this back to the codeplug unless the Function key (Blue / SK2 ) is pressed at the same time.
-		if (settingsCurrentChannelNumber != -1 && (ev->buttons & BUTTON_SK2) )
+		if (settingsCurrentChannelNumber != -1 && (ev->buttons & BUTTON_SK2))
 		{
-			codeplugChannelSaveDataForIndex(settingsCurrentChannelNumber,currentChannelData);
+			codeplugChannelSaveDataForIndex(settingsCurrentChannelNumber, currentChannelData);
 		}
 		SETTINGS_PLATFORM_SPECIFIC_SAVE_SETTINGS(true);// For Baofeng RD-5R
 		menuSystemPopAllAndDisplayRootMenu();
@@ -553,18 +562,21 @@ static void handleEvent(uiEvent_t *ev)
 	}
 	else if (gMenusCurrentItemIndex == CH_DETAILS_NAME && settingsCurrentChannelNumber != -1)
 	{
-		if (ev->keys.event == KEY_MOD_PREVIEW && namePos<16) {
+		if (ev->keys.event == KEY_MOD_PREVIEW && namePos < 16)
+		{
 			channelName[namePos] = ev->keys.key;
 			updateCursor(true);
+			updateScreen();
 		}
-		if (ev->keys.event == KEY_MOD_PRESS && namePos < 16) {
+		if (ev->keys.event == KEY_MOD_PRESS && namePos < 16)
+		{
 			channelName[namePos] = ev->keys.key;
-			if (namePos < strlen(channelName) && namePos < 15) {
+			if (namePos < strlen(channelName) && namePos < 15)
+			{
 				namePos++;
 			}
 			updateCursor(true);
+			updateScreen();
 		}
 	}
-
-	updateScreen();
 }

--- a/firmware/source/user_interface/menuDisplayMenuList.c
+++ b/firmware/source/user_interface/menuDisplayMenuList.c
@@ -65,13 +65,17 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 	{
 		MENU_INC(gMenusCurrentItemIndex, gMenusEndIndex);
+		updateScreen();
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, gMenusEndIndex);
+		updateScreen();
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
@@ -100,6 +104,4 @@ static void handleEvent(uiEvent_t *ev)
 		menuSystemPushNewMenu(UI_LOCK_SCREEN);
 		return;
 	}
-
-	updateScreen();
 }

--- a/firmware/source/user_interface/menuDisplayOptions.c
+++ b/firmware/source/user_interface/menuDisplayOptions.c
@@ -138,6 +138,8 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (ev->events & FUNCTION_EVENT)
 	{
 		if (ev->function == DEC_BRIGHTNESS)

--- a/firmware/source/user_interface/menuFirmwareInfoScreen.c
+++ b/firmware/source/user_interface/menuFirmwareInfoScreen.c
@@ -72,6 +72,8 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_PRESS(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();

--- a/firmware/source/user_interface/menuLanguage.c
+++ b/firmware/source/user_interface/menuLanguage.c
@@ -58,13 +58,17 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
 		MENU_INC(gMenusCurrentItemIndex, NUM_LANGUAGES);
+		updateScreen();
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		MENU_DEC(gMenusCurrentItemIndex, NUM_LANGUAGES);
+		updateScreen();
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
@@ -80,5 +84,4 @@ static void handleEvent(uiEvent_t *ev)
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	updateScreen();
 }

--- a/firmware/source/user_interface/menuOptions.c
+++ b/firmware/source/user_interface/menuOptions.c
@@ -151,6 +151,8 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
 		MENU_INC(gMenusCurrentItemIndex, NUM_OPTIONS_MENU_ITEMS);

--- a/firmware/source/user_interface/menuRSSIScreen.c
+++ b/firmware/source/user_interface/menuRSSIScreen.c
@@ -97,6 +97,8 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
@@ -107,6 +109,4 @@ static void handleEvent(uiEvent_t *ev)
 		menuSystemPopAllAndDisplayRootMenu();
 		return;
 	}
-
-	displayLightTrigger();
 }

--- a/firmware/source/user_interface/menuSoundOptions.c
+++ b/firmware/source/user_interface/menuSoundOptions.c
@@ -97,6 +97,8 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (ev->events & KEY_EVENT)
 	{
 		if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)

--- a/firmware/source/user_interface/menuZoneList.c
+++ b/firmware/source/user_interface/menuZoneList.c
@@ -70,6 +70,8 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 	{
 		MENU_INC(gMenusCurrentItemIndex, gMenusEndIndex);

--- a/firmware/source/user_interface/uiLockScreen.c
+++ b/firmware/source/user_interface/uiLockScreen.c
@@ -177,6 +177,8 @@ static void updateScreen(bool updateOnly)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (KEYCHECK_DOWN(ev->keys, KEY_STAR) && (ev->buttons & BUTTON_SK2))
 	{
 		keypadLocked = false;
@@ -185,8 +187,6 @@ static void handleEvent(uiEvent_t *ev)
 		menuSystemPopAllAndDisplayRootMenu();
 		menuSystemPushNewMenu(UI_LOCK_SCREEN);
 	}
-
-	displayLightTrigger();
 }
 
 void menuLockScreenPop(void)

--- a/firmware/source/user_interface/uiPrivateCall.c
+++ b/firmware/source/user_interface/uiPrivateCall.c
@@ -70,6 +70,8 @@ static void updateScreen(void)
 
 static void handleEvent(uiEvent_t *ev)
 {
+	displayLightTrigger();
+
 	if (ev->events & KEY_EVENT)
 	{
 		if (KEYCHECK_SHORTUP(ev->keys, KEY_RED))
@@ -86,8 +88,6 @@ static void handleEvent(uiEvent_t *ev)
 			return;
 		}
 	}
-
-	displayLightTrigger();
 }
 
 void menuClearPrivateCall(void )

--- a/firmware/source/user_interface/uiTxTgPcContactOwnId.c
+++ b/firmware/source/user_interface/uiTxTgPcContactOwnId.c
@@ -154,6 +154,8 @@ static void handleEvent(uiEvent_t *ev)
 	size_t sLen;
 	uint32_t tmpID;
 
+	displayLightTrigger();
+
 	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();


### PR DESCRIPTION
Triggering light at the beginning of the event handler is way better than in the end (sometimes not reached).
setting.h: surround macro with do {} while(0).
Give some fresh air to menuChannelDetails: spaceless code won't run faster, but make it hard to read sometimes ;-)