### PR TITLE
Fix VFO CTCSS

### DIFF
--- a/firmware/source/functions/codeplug.c
+++ b/firmware/source/functions/codeplug.c
@@ -868,6 +868,10 @@ void codeplugGetVFO_ChannelData(struct_codeplugChannel_t *vfoBuf,int VFONumber)
 	vfoBuf->chMode = (vfoBuf->chMode==0)?RADIO_MODE_ANALOG:RADIO_MODE_DIGITAL;
 	vfoBuf->txFreq = bcd2int(vfoBuf->txFreq);
 	vfoBuf->rxFreq = bcd2int(vfoBuf->rxFreq);
+	if (codeplugChannelToneIsCTCSS(vfoBuf->rxTone))
+		vfoBuf->rxTone = bcd2int(vfoBuf->rxTone);
+	if (codeplugChannelToneIsCTCSS(vfoBuf->txTone))
+		vfoBuf->txTone = bcd2int(vfoBuf->txTone);
 }
 
 void codeplugSetVFO_ChannelData(struct_codeplugChannel_t *vfoBuf,int VFONumber)
@@ -877,6 +881,10 @@ void codeplugSetVFO_ChannelData(struct_codeplugChannel_t *vfoBuf,int VFONumber)
 	tmpChannel.chMode = (vfoBuf->chMode==RADIO_MODE_ANALOG)?0:1;
 	tmpChannel.txFreq = int2bcd(vfoBuf->txFreq);
 	tmpChannel.rxFreq = int2bcd(vfoBuf->rxFreq);
+	if (codeplugChannelToneIsCTCSS(vfoBuf->rxTone))
+		tmpChannel.rxTone = int2bcd(vfoBuf->rxTone);
+	if (codeplugChannelToneIsCTCSS(vfoBuf->txTone))
+		tmpChannel.txTone = int2bcd(vfoBuf->txTone);
 	EEPROM_Write(CODEPLUG_ADDR_VFO_A_CHANNEL+(sizeof(struct_codeplugChannel_t)*VFONumber),(uint8_t *)&tmpChannel,sizeof(struct_codeplugChannel_t));
 }
 

--- a/firmware/source/functions/codeplug.c
+++ b/firmware/source/functions/codeplug.c
@@ -869,9 +869,13 @@ void codeplugGetVFO_ChannelData(struct_codeplugChannel_t *vfoBuf,int VFONumber)
 	vfoBuf->txFreq = bcd2int(vfoBuf->txFreq);
 	vfoBuf->rxFreq = bcd2int(vfoBuf->rxFreq);
 	if (codeplugChannelToneIsCTCSS(vfoBuf->rxTone))
+	{
 		vfoBuf->rxTone = bcd2int(vfoBuf->rxTone);
+	}
 	if (codeplugChannelToneIsCTCSS(vfoBuf->txTone))
+	{
 		vfoBuf->txTone = bcd2int(vfoBuf->txTone);
+	}
 }
 
 void codeplugSetVFO_ChannelData(struct_codeplugChannel_t *vfoBuf,int VFONumber)
@@ -882,9 +886,13 @@ void codeplugSetVFO_ChannelData(struct_codeplugChannel_t *vfoBuf,int VFONumber)
 	tmpChannel.txFreq = int2bcd(vfoBuf->txFreq);
 	tmpChannel.rxFreq = int2bcd(vfoBuf->rxFreq);
 	if (codeplugChannelToneIsCTCSS(vfoBuf->rxTone))
+	{
 		tmpChannel.rxTone = int2bcd(vfoBuf->rxTone);
+	}
 	if (codeplugChannelToneIsCTCSS(vfoBuf->txTone))
+	{
 		tmpChannel.txTone = int2bcd(vfoBuf->txTone);
+	}
 	EEPROM_Write(CODEPLUG_ADDR_VFO_A_CHANNEL+(sizeof(struct_codeplugChannel_t)*VFONumber),(uint8_t *)&tmpChannel,sizeof(struct_codeplugChannel_t));
 }
 


### PR DESCRIPTION
Found this bug while working on the DCS feature. The firmware wasn't decoding (or encoding) the CTCSS tones for VFO (only for channels). So for example if the VFO was configured for a 77Hz tone, the radio would think it was configured for 190.4Hz.

![vfo-ctcss-bug](https://user-images.githubusercontent.com/260569/79530865-78612880-8025-11ea-9a6d-adae914eab18.png)

A similar bug existed when saving the VFO to the EEPROM.

This commit fixes both.