### PR TITLE
FM Mic gain: add more gain from 18 to 31 (2 .. 15 on option screen).

### DIFF
--- a/firmware/include/functions/trx.h
+++ b/firmware/include/functions/trx.h
@@ -97,6 +97,7 @@ bool trxCheckFrequencyInAmateurBand(int tmp_frequency);
 int trxGetBandFromFrequency(int frequency);
 int trxGetNextOrPrevBandFromFrequency(int frequency, bool nextBand);
 void trxReadRSSIAndNoise(void);
+uint8_t trxGetCalibrationVoiceGainTx(void);
 void trxSelectVoiceChannel(uint8_t channel);
 void trxSetTone1(int toneFreq);
 void trxSetTone2(int toneFreq);

--- a/firmware/source/functions/trx.c
+++ b/firmware/source/functions/trx.c
@@ -95,6 +95,7 @@ volatile uint8_t trxRxNoise;
 
 static uint8_t trxSaveVoiceGainTx = 0xff;
 static uint16_t trxSaveDeviation = 0xff;
+static uint8_t voice_gain_tx = 0x31; // default voice_gain_tx fro calibration, needs to be declared here in case calibration:OFF
 
 int trxDMRMode = DMR_MODE_ACTIVE;// Active is for simplex
 static volatile bool txPAEnabled=false;
@@ -734,7 +735,6 @@ void trxUpdateAT1846SCalibration(void)
 	trxCalcBandAndFrequencyOffset(&band_offset, &freq_offset);
 
 	uint8_t val_pga_gain;
-	uint8_t voice_gain_tx;
 	uint8_t gain_tx;
 	uint8_t padrv_ibit;
 
@@ -953,6 +953,11 @@ void trxUpdateDeviation(int channel)
 		break;
 	}
 	taskEXIT_CRITICAL();
+}
+
+uint8_t trxGetCalibrationVoiceGainTx(void)
+{
+	return voice_gain_tx;
 }
 
 void trxSelectVoiceChannel(uint8_t channel) {

--- a/firmware/source/hardware/AT1846S.c
+++ b/firmware/source/hardware/AT1846S.c
@@ -225,5 +225,15 @@ void I2C_AT1846_SetMode(void)
 
 void setMicGainFM(uint8_t gain)
 {
+	uint8_t voice_gain_tx = trxGetCalibrationVoiceGainTx();
+
+	// Apply extra gain 17 (the calibration default value, not the datasheet one)
+	if (gain > 17)
+	{
+		//voice_gain_tx += (((gain - 16) * 3) >> 1); // Get some Larsen starting at gain:11
+		voice_gain_tx += (gain - 16); // Seems to be enough
+	}
+
 	I2C_AT1846_set_register_with_mask(0x0A, 0xF83F, gain, 6);
+	I2C_AT1846_set_register_with_mask(0x41, 0xFF80, voice_gain_tx, 0);
 }

--- a/firmware/source/user_interface/menuSoundOptions.c
+++ b/firmware/source/user_interface/menuSoundOptions.c
@@ -183,7 +183,7 @@ static void handleEvent(uiEvent_t *ev)
 					if (nonVolatileSettings.micGainFM > 1) // Limit to min 1, as 0: no audio
 					{
 						nonVolatileSettings.micGainFM--;
-						setMicGainDMR(nonVolatileSettings.micGainFM);
+						setMicGainFM(nonVolatileSettings.micGainFM);
 					}
 					break;
 			}


### PR DESCRIPTION
Please note: adding more gain just trigger Larsen effect.
Fix a bug I've made in Sound Options, calling setMicGainDMR() instead of setMicGainFM()...