### PR TITLE
Cut GITVERSION at 7th char, not the bracket.

### DIFF
--- a/firmware/source/user_interface/menuFirmwareInfoScreen.c
+++ b/firmware/source/user_interface/menuFirmwareInfoScreen.c
@@ -39,8 +39,9 @@ static void updateScreen(void)
 {
 	char buf[17];
 
-	snprintf(buf, 16, "[ %s ]", GITVERSION);
-	buf[11] = 0; // git hash id 7 char long;
+	snprintf(buf, 16, "[ %s", GITVERSION);
+	buf[9] = 0; // git hash id 7 char long;
+	strcat(buf, " ]");
 
 	ucClearBuf();
 

--- a/firmware/source/user_interface/menuFirmwareInfoScreen.c
+++ b/firmware/source/user_interface/menuFirmwareInfoScreen.c
@@ -30,7 +30,9 @@ int menuFirmwareInfoScreen(uiEvent_t *ev, bool isFirstRun)
 	else
 	{
 		if (ev->hasEvent)
+		{
 			handleEvent(ev);
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
Just saw that on the public FB page (I don't have FB account, I couldn't ask how it was compiled, but the code is wrong anyway).
![image](https://user-images.githubusercontent.com/10473896/79678924-c2523600-8200-11ea-829e-075b1f22bb41.png)
