### PR TITLE
Add simple VOX support, see "Sounds options".

### DIFF
--- a/firmware/include/functions/settings.h
+++ b/firmware/include/functions/settings.h
@@ -88,6 +88,9 @@ typedef struct settingsStruct
 	uint8_t			contactDisplayPriority;
 	uint8_t			splitContact;
 	uint8_t			beepOptions;
+	uint8_t			voxThreshold; // 0: disabled
+	uint8_t			voxTailUnits; // 500ms units
+
 
 } settingsStruct_t;
 

--- a/firmware/include/functions/vox.h
+++ b/firmware/include/functions/vox.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C)2020	Kai Ludwig, DG4KLU
+ *               and	Roger Clark, VK3KYY / G4KYF
+ *               and	Daniel Caujolle-Bert, F1RMB
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef _VOX_H_
+#define _VOX_H_
+
+#include <common.h>
+
+
+void voxInit(void);
+void voxSetParameters(uint8_t threshold, uint8_t tailHalfSecond);
+bool voxIsEnabled(void);
+bool voxIsTriggered(void);
+void voxReset(void);
+void voxTick(void);
+
+#endif /* _VOX_H_ */

--- a/firmware/include/main.h
+++ b/firmware/include/main.h
@@ -39,6 +39,7 @@
 #include "rotary_switch.h"
 #include "speech_synthesis.h"
 #include "display.h"
+#include "vox.h"
 
 #include "UC1701.h"
 

--- a/firmware/include/user_interface/uiLocalisation.h
+++ b/firmware/include/user_interface/uiLocalisation.h
@@ -144,6 +144,8 @@ typedef struct stringsTable
    const char *dmr_beep;
    const char *start;
    const char *both;
+   const char *vox_threshold;
+   const char *vox_tail;
 } stringsTable_t;
 
 extern const stringsTable_t languages[];

--- a/firmware/source/functions/settings.c
+++ b/firmware/source/functions/settings.c
@@ -27,7 +27,7 @@
 
 static const int STORAGE_BASE_ADDRESS 		= 0x6000;
 
-static const int STORAGE_MAGIC_NUMBER 		= 0x4747;
+static const int STORAGE_MAGIC_NUMBER 		= 0x4748;
 
 // Bit patterns for DMR Beep
 const uint8_t BEEP_TX_NONE  = 0x00;
@@ -204,6 +204,9 @@ void settingsRestoreDefaultSettings(void)
 			BEEP_TX_STOP |
 #endif
 			BEEP_TX_START;
+	// VOX related
+	nonVolatileSettings.voxThreshold = 0; // 0: VOX disabled
+	nonVolatileSettings.voxTailUnits = 4; // 2 seconds tail
 
 	currentChannelData = &settingsVFOChannel[nonVolatileSettings.currentVFONumber];// Set the current channel data to point to the VFO data since the default screen will be the VFO
 

--- a/firmware/source/functions/vox.c
+++ b/firmware/source/functions/vox.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C)2020	Kai Ludwig, DG4KLU
+ *               and	Roger Clark, VK3KYY / G4KYF
+ *               and	Daniel Caujolle-Bert, F1RMB
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <vox.h>
+#include <interfaces/adc.h>
+#include <functions/sound.h>
+
+
+#define PIT_COUNTS_PER_MS  10U
+
+extern volatile uint32_t PITCounter;
+
+
+static const uint32_t VOX_TAIL_TIME_UNIT = (PIT_COUNTS_PER_MS * 500); // 500ms tail unit
+static const uint16_t VOX_SETTLE_TIME = 4000; // Countdown before doing first real sampling;
+
+typedef struct
+{
+	bool     triggered;
+	uint8_t  threshold; // threshold is a super low value, 8 bits are enough
+	uint16_t sampled;
+	uint16_t averaged;
+	uint32_t nextTimeSampling;
+	uint8_t  tailUnits;
+	uint32_t tailTime;
+	uint16_t settleCount;
+	uint8_t  shots;
+} voxData_t;
+
+static voxData_t vox;
+
+void voxInit(void)
+{
+	vox.triggered = false;
+	vox.threshold = 0;
+	vox.sampled = 0;
+	vox.averaged = 0;
+	vox.nextTimeSampling = 0;
+	vox.tailUnits = 1;
+	vox.tailTime = 0;
+	vox.settleCount = VOX_SETTLE_TIME;
+	vox.shots = 0;
+}
+
+void voxSetParameters(uint8_t threshold, uint8_t tailHalfSecond)
+{
+	vox.triggered = false;
+	vox.threshold = ((threshold > 0) ? threshold + 1 : threshold); // threshold 1 is too low, add 1 to value.
+
+	if (vox.threshold > 0)
+	{
+		voxReset();
+		vox.tailUnits = tailHalfSecond;
+		vox.settleCount = VOX_SETTLE_TIME;
+	}
+}
+
+bool voxIsEnabled(void)
+{
+	return (vox.threshold > 0);
+}
+
+bool voxIsTriggered(void)
+{
+	return vox.triggered;
+}
+
+void voxReset(void)
+{
+	vox.triggered = false;
+	vox.sampled = 0;
+	vox.averaged = 0;
+	vox.nextTimeSampling = PITCounter + PIT_COUNTS_PER_MS; // now + 1ms
+	vox.tailTime = 0;
+	vox.settleCount = VOX_SETTLE_TIME >> 1;
+	//vox.settleCount = VOX_SETTLE_TIME;
+	vox.shots = 0;
+
+}
+
+void voxTick(void)
+{
+	if (vox.threshold > 0)
+	{
+		if (PITCounter >= vox.nextTimeSampling)
+		{
+			if ((getAudioAmpStatus() & (AUDIO_AMP_MODE_RF | AUDIO_AMP_MODE_BEEP)))
+			{
+				voxReset();
+			}
+			else
+			{
+				uint16_t sample = getVOX();
+
+				if (vox.settleCount > 0)
+				{
+					vox.settleCount--;
+					return;
+				}
+
+				vox.sampled += sample;
+				vox.averaged = (vox.sampled + (1 << (2 - 1))) >> 2;
+				vox.sampled -= vox.averaged;
+
+				if (vox.averaged >= vox.threshold)
+				{
+					vox.shots = MIN((vox.shots + 1), 20);
+
+					if (vox.shots >= 20)
+					{
+						vox.triggered = true;
+						vox.tailTime = PITCounter + (vox.tailUnits * VOX_TAIL_TIME_UNIT);
+					}
+				}
+			}
+
+			vox.nextTimeSampling = PITCounter + PIT_COUNTS_PER_MS; // now + 1ms
+		}
+
+		if ((vox.tailTime != 0) && (PITCounter >= vox.tailTime))
+		{
+			vox.triggered = false;
+			vox.tailTime = 0;
+			vox.shots = 0;
+		}
+	}
+}

--- a/firmware/source/functions/vox.c
+++ b/firmware/source/functions/vox.c
@@ -48,15 +48,10 @@ static voxData_t vox;
 
 void voxInit(void)
 {
-	vox.triggered = false;
+	voxReset();
 	vox.threshold = 0;
-	vox.sampled = 0;
-	vox.averaged = 0;
-	vox.nextTimeSampling = 0;
 	vox.tailUnits = 1;
-	vox.tailTime = 0;
 	vox.settleCount = VOX_SETTLE_TIME;
-	vox.shots = 0;
 }
 
 void voxSetParameters(uint8_t threshold, uint8_t tailHalfSecond)
@@ -90,9 +85,7 @@ void voxReset(void)
 	vox.nextTimeSampling = PITCounter + PIT_COUNTS_PER_MS; // now + 1ms
 	vox.tailTime = 0;
 	vox.settleCount = VOX_SETTLE_TIME >> 1;
-	//vox.settleCount = VOX_SETTLE_TIME;
 	vox.shots = 0;
-
 }
 
 void voxTick(void)

--- a/firmware/source/hotspot/uiHotspot.c
+++ b/firmware/source/hotspot/uiHotspot.c
@@ -125,7 +125,7 @@ M: 2020-01-07 09:52:15.246 DMR Slot 2, received network end of voice transmissio
 
 #define MMDVM_HEADER_LENGTH 4U
 
-#define HOTSPOT_VERSION_STRING "OpenGD77_HS v0.1.3"
+#define HOTSPOT_VERSION_STRING "OpenGD77_HS v0.1.4"
 #define concat(a, b) a " GitID #" b ""
 static const char HARDWARE[] = concat(HOTSPOT_VERSION_STRING, GITVERSION);
 
@@ -338,6 +338,9 @@ int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
+		// Disable VOX
+		voxSetParameters(0, nonVolatileSettings.voxTailUnits);
+
 		// DMR filter level isn't saved yet (cycling power OFF/ON quickly can corrupt
 		// this value otherwise, as menuHotspotMode(true) could be called twice.
 		if (savedDMRFilterLevel == 0xFF)
@@ -752,6 +755,10 @@ static void hotspotExit(void)
 	trxDMRID = codeplugGetUserDMRID();
 	settingsUsbMode = USB_MODE_CPS;
 	mmdvmHostIsConnected = false;
+
+	// Re-enable VOX
+	voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
+
 	menuHotspotRestoreSettings();
 	menuSystemPopAllAndDisplayRootMenu();
 }

--- a/firmware/source/user_interface/languages/catalan.h
+++ b/firmware/source/user_interface/languages/catalan.h
@@ -151,7 +151,9 @@ const stringsTable_t catalanLanguage=
 .priority_order			= "Prio.", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "DMR Beep", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Inici", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Tots" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Tots", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/czech.h
+++ b/firmware/source/user_interface/languages/czech.h
@@ -151,7 +151,9 @@ const stringsTable_t czechLanguage =
 .priority_order				= "íst ID", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "pípDMR", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "start", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "StartStop" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "StartStop", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/danish.h
+++ b/firmware/source/user_interface/languages/danish.h
@@ -151,7 +151,9 @@ const stringsTable_t danishLanguage =
 .priority_order				= "Order", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "DMR beep", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Start", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Both" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Both", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/english.h
+++ b/firmware/source/user_interface/languages/english.h
@@ -151,7 +151,9 @@ const stringsTable_t englishLanguage =
 .priority_order				= "Order", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "DMR beep", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Start", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Both" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Both", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/finnish.h
+++ b/firmware/source/user_interface/languages/finnish.h
@@ -151,7 +151,9 @@ const stringsTable_t finnishLanguage =
 .priority_order		= "Järjest", 		// MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep		= "DMR piippi", 	// MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start			= "Alku", 		// MaxLen 16 (with ':' + .dmr_beep)
-.both			= "Molemm" 		// MaxLen 16 (with ':' + .dmr_beep)
+.both			= "Molemm",		// MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold          = "VOX Thres.",         // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail               = "VOX Tail"            // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/french.h
+++ b/firmware/source/user_interface/languages/french.h
@@ -151,7 +151,9 @@ const stringsTable_t frenchLanguage =
 .priority_order				= "Ordre", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "Bip TX", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Début", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Les Deux" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Les Deux", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "Seuil VOX", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "Queue VOX" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/german.h
+++ b/firmware/source/user_interface/languages/german.h
@@ -151,7 +151,9 @@ const stringsTable_t germanLanguage =
 .priority_order				= "ID-Prio", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "DMR TX Ton", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Start", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Beide" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Beide", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/italian.h
+++ b/firmware/source/user_interface/languages/italian.h
@@ -151,7 +151,9 @@ const stringsTable_t italianLanguage =
 .priority_order			= "Prio.", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "DMR bip", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Inizio", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Ambedue" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Ambedue", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/polish.h
+++ b/firmware/source/user_interface/languages/polish.h
@@ -151,7 +151,9 @@ const stringsTable_t polishLanguage =
 .priority_order				= "Wybór", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "Wybór bipa", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Start", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Oba" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Oba", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/portuguese.h
+++ b/firmware/source/user_interface/languages/portuguese.h
@@ -151,7 +151,9 @@ const stringsTable_t portuguesLanguage =
 .priority_order				= "Order", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "DMR beep", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Start", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Both" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Both", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/spanish.h
+++ b/firmware/source/user_interface/languages/spanish.h
@@ -151,7 +151,9 @@ const stringsTable_t spanishLanguage =
 .priority_order				= "Orden", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "DMR beep", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Inicio", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Ambos" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Ambos", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/languages/turkish.h
+++ b/firmware/source/user_interface/languages/turkish.h
@@ -151,7 +151,9 @@ const stringsTable_t turkishLanguage =
 .priority_order				= "Öncelik", // MaxLen 16 (with ':' + 'Cc/DB/TA')
 .dmr_beep				= "DMR beep", // MaxLen 16 (with ':' + .star/.stop/.both/.none)
 .start					= "Start", // MaxLen 16 (with ':' + .dmr_beep)
-.both					= "Both" // MaxLen 16 (with ':' + .dmr_beep)
+.both					= "Both", // MaxLen 16 (with ':' + .dmr_beep)
+.vox_threshold                          = "VOX Thres.", // MaxLen 16 (with ':' + .off or 1..30)
+.vox_tail                               = "VOX Tail" // MaxLen 16 (with ':' + .n_a or '0.0s')
 };
 /********************************************************************
  *

--- a/firmware/source/user_interface/menuSoundOptions.c
+++ b/firmware/source/user_interface/menuSoundOptions.c
@@ -93,11 +93,11 @@ static void updateScreen(void)
 			case OPTIONS_VOX_THRESHOLD:
 				if (nonVolatileSettings.voxThreshold != 0)
 				{
-					snprintf(buf, bufferLen, "%s:%d", "VOX Thres.", nonVolatileSettings.voxThreshold);
+					snprintf(buf, bufferLen, "%s:%d", currentLanguage->vox_threshold, nonVolatileSettings.voxThreshold);
 				}
 				else
 				{
-					snprintf(buf, bufferLen, "%s:%s", "VOX Thres.", currentLanguage->off);
+					snprintf(buf, bufferLen, "%s:%s", currentLanguage->vox_threshold, currentLanguage->off);
 				}
 				break;
 			case OPTIONS_VOX_TAIL:
@@ -107,11 +107,11 @@ static void updateScreen(void)
 					uint8_t secs = (uint8_t)tail;
 					uint8_t fracSec = (tail - secs) * 10;
 
-					snprintf(buf, bufferLen, "%s:%d.%ds", "VOX Tail", secs, fracSec);
+					snprintf(buf, bufferLen, "%s:%d.%ds", currentLanguage->vox_tail, secs, fracSec);
 				}
 				else
 				{
-					snprintf(buf, bufferLen, "%s:%s", "VOX Tail", currentLanguage->n_a);
+					snprintf(buf, bufferLen, "%s:%s", currentLanguage->vox_tail, currentLanguage->n_a);
 				}
 				break;
 		}

--- a/firmware/source/user_interface/menuSoundOptions.c
+++ b/firmware/source/user_interface/menuSoundOptions.c
@@ -25,7 +25,9 @@ static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
 enum SOUND_MENU_LIST { OPTIONS_MENU_TIMEOUT_BEEP = 0, OPTIONS_MENU_BEEP_VOLUME, OPTIONS_MENU_DMR_BEEP,
-						OPTIONS_MIC_GAIN_DMR, OPTIONS_MIC_GAIN_FM, NUM_SOUND_MENU_ITEMS};
+						OPTIONS_MIC_GAIN_DMR, OPTIONS_MIC_GAIN_FM,
+						OPTIONS_VOX_THRESHOLD, OPTIONS_VOX_TAIL,
+						NUM_SOUND_MENU_ITEMS};
 
 
 int menuSoundOptions(uiEvent_t *ev, bool isFirstRun)
@@ -88,6 +90,30 @@ static void updateScreen(void)
 			case OPTIONS_MIC_GAIN_FM: // FM Mic gain
 				snprintf(buf, bufferLen, "%s:%d", currentLanguage->fm_mic_gain, (nonVolatileSettings.micGainFM - 16));
 				break;
+			case OPTIONS_VOX_THRESHOLD:
+				if (nonVolatileSettings.voxThreshold != 0)
+				{
+					snprintf(buf, bufferLen, "%s:%d", "VOX Thres.", nonVolatileSettings.voxThreshold);
+				}
+				else
+				{
+					snprintf(buf, bufferLen, "%s:%s", "VOX Thres.", currentLanguage->off);
+				}
+				break;
+			case OPTIONS_VOX_TAIL:
+				if (nonVolatileSettings.voxThreshold != 0)
+				{
+					float tail = (nonVolatileSettings.voxTailUnits * 0.5);
+					uint8_t secs = (uint8_t)tail;
+					uint8_t fracSec = (tail - secs) * 10;
+
+					snprintf(buf, bufferLen, "%s:%d.%ds", "VOX Tail", secs, fracSec);
+				}
+				else
+				{
+					snprintf(buf, bufferLen, "%s:%s", "VOX Tail", currentLanguage->n_a);
+				}
+				break;
 		}
 
 		buf[bufferLen - 1] = 0;
@@ -148,6 +174,20 @@ static void handleEvent(uiEvent_t *ev)
 						setMicGainFM(nonVolatileSettings.micGainFM);
 					}
 					break;
+				case OPTIONS_VOX_THRESHOLD:
+					if (nonVolatileSettings.voxThreshold < 30)
+					{
+						nonVolatileSettings.voxThreshold++;
+						voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
+					}
+					break;
+				case OPTIONS_VOX_TAIL:
+					if (nonVolatileSettings.voxTailUnits < 10) // 5 seconds max
+					{
+						nonVolatileSettings.voxTailUnits++;
+						voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
+					}
+					break;
 			}
 		}
 		else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
@@ -186,6 +226,20 @@ static void handleEvent(uiEvent_t *ev)
 						setMicGainFM(nonVolatileSettings.micGainFM);
 					}
 					break;
+				case OPTIONS_VOX_THRESHOLD:
+					if (nonVolatileSettings.voxThreshold > 0)
+					{
+						nonVolatileSettings.voxThreshold--;
+						voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
+					}
+					break;
+				case OPTIONS_VOX_TAIL:
+					if (nonVolatileSettings.voxTailUnits > 1) // .5 minimum
+					{
+						nonVolatileSettings.voxTailUnits--;
+						voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
+					}
+					break;
 			}
 		}
 		else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
@@ -203,6 +257,7 @@ static void handleEvent(uiEvent_t *ev)
 			soundBeepVolumeDivider = nonVolatileSettings.beepVolumeDivider;
 			setMicGainDMR(nonVolatileSettings.micGainDMR);
 			setMicGainFM(nonVolatileSettings.micGainFM);
+			voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
 			menuSystemPopPreviousMenu();
 			return;
 		}

--- a/firmware/source/user_interface/uiSplashScreen.c
+++ b/firmware/source/user_interface/uiSplashScreen.c
@@ -28,8 +28,8 @@ int uiSplashScreen(uiEvent_t *ev, bool isFirstRun)
 	{
 		if (codeplugGetOpenGD77CustomData(CODEPLUG_CUSTOM_DATA_TYPE_BEEP, melodyBuf))
 		{
-		   create_song(melodyBuf);
-		   set_melody(melody_generic);
+			create_song(melodyBuf);
+			set_melody(melody_generic);
 		}
 		else
 		{

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -117,6 +117,7 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 				if ((currentChannelData->tot != 0) && (timeInSeconds == 0))
 				{
 					set_melody(melody_tx_timeout_beep);
+
 					ucClearBuf();
 					ucPrintCentered(20, currentLanguage->timeout, FONT_SIZE_4);
 					ucRender();

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -123,6 +123,7 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 					ucRender();
 					PTTToggledDown = false;
 					mto = ev->time;
+					voxReset();
 				}
 				else
 				{

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -563,6 +563,7 @@ static void update_frequency(int frequency)
 		{
 			currentChannelData->txFreq = frequency;
 			trxSetFrequency(currentChannelData->rxFreq,currentChannelData->txFreq,DMR_MODE_AUTO);
+
 			set_melody(melody_ACK_beep);
 		}
 	}
@@ -1113,11 +1114,12 @@ static void handleEvent(uiEvent_t *ev)
 					{
 						set_melody(melody_ERROR_beep);
 					}
+
 					menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 				}
 				else
 				{
-					if (freq_enter_idx!=0)
+					if (freq_enter_idx != 0)
 					{
 						set_melody(melody_ERROR_beep);
 					}
@@ -1430,6 +1432,7 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 					menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE);
 
 					set_melody(melody_ACK_beep);
+
 					return;
 				}
 				else


### PR DESCRIPTION
I didn't try on the 1801 yet.

Here, a Threshold of 3..4 looks fine.
The code avoid using 1, as it's way too low, and just trigger the vox all the time.
So, except for threshold value of zero (which turn the vox feature off), all other values are what is on option screen + 1, internally.
I set a default tail value of 2 seconds, as it looks fine. The tail values are units of 0.5 seconds.
