### PR TITLE
VOX: take care of the hotspot running status.

### DIFF
--- a/firmware/source/functions/vox.c
+++ b/firmware/source/functions/vox.c
@@ -67,9 +67,7 @@ void voxSetParameters(uint8_t threshold, uint8_t tailHalfSecond)
 
 bool voxIsEnabled(void)
 {
-	return ((currentChannelData->flag4 & 0x40) &&
-			((nonVolatileSettings.hotspotType == HOTSPOT_TYPE_OFF) ||
-					((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) && (settingsUsbMode != USB_MODE_HOTSPOT))));
+	return ((currentChannelData->flag4 & 0x40) && (settingsUsbMode != USB_MODE_HOTSPOT));
 }
 
 bool voxIsTriggered(void)
@@ -135,7 +133,7 @@ void voxTick(void)
 		}
 	}
 
-	if (vox.triggered && ((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) && (settingsUsbMode == USB_MODE_HOTSPOT)))
+	if (vox.triggered && (settingsUsbMode == USB_MODE_HOTSPOT))
 	{
 		voxReset();
 	}

--- a/firmware/source/functions/vox.c
+++ b/firmware/source/functions/vox.c
@@ -67,7 +67,9 @@ void voxSetParameters(uint8_t threshold, uint8_t tailHalfSecond)
 
 bool voxIsEnabled(void)
 {
-	return (currentChannelData->flag4 & 0x40);//return (vox.threshold > 0);
+	return ((currentChannelData->flag4 & 0x40) &&
+			((nonVolatileSettings.hotspotType == HOTSPOT_TYPE_OFF) ||
+					((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) && (settingsUsbMode != USB_MODE_HOTSPOT))));
 }
 
 bool voxIsTriggered(void)
@@ -88,7 +90,9 @@ void voxReset(void)
 
 void voxTick(void)
 {
-	if (currentChannelData->flag4 & 0x40)
+	if ((currentChannelData->flag4 & 0x40) &&
+			((nonVolatileSettings.hotspotType == HOTSPOT_TYPE_OFF) ||
+					((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) && (settingsUsbMode != USB_MODE_HOTSPOT))))
 	{
 		if (PITCounter >= vox.nextTimeSampling)
 		{
@@ -132,4 +136,10 @@ void voxTick(void)
 			vox.shots = 0;
 		}
 	}
+
+	if (vox.triggered && ((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) && (settingsUsbMode == USB_MODE_HOTSPOT)))
+	{
+		voxReset();
+	}
+
 }

--- a/firmware/source/hotspot/uiHotspot.c
+++ b/firmware/source/hotspot/uiHotspot.c
@@ -125,7 +125,7 @@ M: 2020-01-07 09:52:15.246 DMR Slot 2, received network end of voice transmissio
 
 #define MMDVM_HEADER_LENGTH 4U
 
-#define HOTSPOT_VERSION_STRING "OpenGD77_HS v0.1.4"
+#define HOTSPOT_VERSION_STRING "OpenGD77_HS v0.1.3"
 #define concat(a, b) a " GitID #" b ""
 static const char HARDWARE[] = concat(HOTSPOT_VERSION_STRING, GITVERSION);
 
@@ -338,9 +338,6 @@ int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
-		// Disable VOX
-		voxSetParameters(0, nonVolatileSettings.voxTailUnits);
-
 		// DMR filter level isn't saved yet (cycling power OFF/ON quickly can corrupt
 		// this value otherwise, as menuHotspotMode(true) could be called twice.
 		if (savedDMRFilterLevel == 0xFF)
@@ -755,9 +752,6 @@ static void hotspotExit(void)
 	trxDMRID = codeplugGetUserDMRID();
 	settingsUsbMode = USB_MODE_CPS;
 	mmdvmHostIsConnected = false;
-
-	// Re-enable VOX
-	voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
 
 	menuHotspotRestoreSettings();
 	menuSystemPopAllAndDisplayRootMenu();

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1204,7 +1204,7 @@ void menuUtilityRenderHeader(void)
 			{
 				strcat(buffer,"N");
 			}
-			ucPrintCore(0, Y_OFFSET, buffer, FONT_SIZE_1, TEXT_ALIGN_LEFT, scanBlinkPhase);
+			ucPrintCore(0, Y_OFFSET, buffer, ((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) ? FONT_SIZE_1_BOLD : FONT_SIZE_1), TEXT_ALIGN_LEFT, scanBlinkPhase);
 
 			if (codeplugChannelToneIsCTCSS(currentChannelData->txTone) || codeplugChannelToneIsCTCSS(currentChannelData->rxTone))
 			{


### PR DESCRIPTION
HS: revert to previous version, removing vox enable/disable code.
HS Mode: write mode in bold even on analog mode.