### PR TITLE
Wait 50ms before rebooting after the CPS has finished to write (related to EEPROM slowliness)

### DIFF
--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -85,6 +85,7 @@ void fw_powerOffFinalStage(void)
 		}
 	}
 
+	nonVolatileSettings.displayBacklightPercentageOff = 0;
 	displayEnableBacklight(false);
 
 #if !defined(PLATFORM_RD5R)

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -85,6 +85,8 @@ void fw_powerOffFinalStage(void)
 		}
 	}
 
+	displayEnableBacklight(false);
+
 #if !defined(PLATFORM_RD5R)
 	// This turns the power off to the CPU.
 	GPIO_PinWrite(GPIO_Keep_Power_On, Pin_Keep_Power_On, 0);


### PR DESCRIPTION
Turn off the backlight while powering off, mostly related when low battery is triggered, as backlight will remains on until user action.