### PR TITLE
Fix RD-5R custom content erase

### DIFF
--- a/firmware/include/io/buttons.h
+++ b/firmware/include/io/buttons.h
@@ -82,8 +82,8 @@
 
 extern volatile bool PTTLocked;
 
-void fw_init_buttons(void);
-uint32_t fw_read_buttons(void);
-void fw_check_button_event(uint32_t *buttons, int *event);
+void buttonsInit(void);
+uint32_t buttonsRead(void);
+void buttonsCheckButtonsEvent(uint32_t *buttons, int *event);
 
 #endif /* _FW_BUTTONS_H_ */

--- a/firmware/include/io/keyboard.h
+++ b/firmware/include/io/keyboard.h
@@ -206,11 +206,10 @@ typedef struct keyboardCode {
 
 #define NO_KEYCODE  { .event = 0, .key = 0 }
 
-void fw_init_keyboard(void);
-void fw_reset_keyboard(void);
-uint8_t fw_read_keyboard_col(void);
-uint32_t fw_read_keyboard(void);
-void fw_check_key_event(keyboardCode_t *keys, int *event);
-bool fw_scan_key(uint32_t scancode, char *keycode);
+void keyboardInit(void);
+void keyboardReset(void);
+uint32_t keyboardRead(void);
+void keyboardCheckKeyEvent(keyboardCode_t *keys, int *event);
+bool heyboardScanKey(uint32_t scancode, char *keycode);
 
 #endif /* _FW_KEYBOARD_H_ */

--- a/firmware/include/io/rotary_switch.h
+++ b/firmware/include/io/rotary_switch.h
@@ -41,9 +41,9 @@
 #endif // PLATFORM_GD77S
 
 
-void init_rotary_switch(void);
-uint8_t get_rotary_switch_position(void);
-void check_rotary_switch_event(uint32_t *position, int *event);
+void rotarySwitchInit(void);
+uint8_t rotarySwitchGetPosition(void);
+void rotarySwitchCheckRotaryEvent(uint32_t *position, int *event);
 
 #define EVENT_ROTARY_NONE   0
 #define EVENT_ROTARY_CHANGE 1

--- a/firmware/source/io/buttons.c
+++ b/firmware/source/io/buttons.c
@@ -30,7 +30,7 @@ static bool orangeButtonPressed;
 static bool orangeButtonReleased;
 #endif
 
-void fw_init_buttons(void)
+void buttonsInit(void)
 {
     PORT_SetPinMux(Port_PTT, Pin_PTT, kPORT_MuxAsGpio);
     PORT_SetPinMux(Port_SK1, Pin_SK1, kPORT_MuxAsGpio);
@@ -58,7 +58,7 @@ void fw_init_buttons(void)
     old_button_state = 0;
 }
 
-uint32_t fw_read_buttons(void)
+uint32_t buttonsRead(void)
 {
 	uint32_t result = BUTTON_NONE;
 
@@ -101,9 +101,9 @@ uint32_t fw_read_buttons(void)
 	return result;
 }
 
-void fw_check_button_event(uint32_t *buttons, int *event)
+void buttonsCheckButtonsEvent(uint32_t *buttons, int *event)
 {
-	*buttons = fw_read_buttons();
+	*buttons = buttonsRead();
 
 #if defined(PLATFORM_GD77S)
 	taskENTER_CRITICAL();

--- a/firmware/source/io/keyboard.c
+++ b/firmware/source/io/keyboard.c
@@ -94,7 +94,7 @@ static const char keypadAlphaMap[11][31] = {
 		"*"
 };
 
-void fw_init_keyboard(void)
+void keyboardInit(void)
 {
 #if ! defined(PLATFORM_GD77S)
 	port_pin_config_t config = {
@@ -144,7 +144,7 @@ void fw_init_keyboard(void)
 	keypadLocked = false;
 }
 
-void fw_reset_keyboard(void)
+void keyboardReset(void)
 {
 	oldKeyboardCode = 0;
 	keypadAlphaEnable = false;
@@ -153,7 +153,7 @@ void fw_reset_keyboard(void)
 	keyState = KEY_WAIT_RELEASED;
 }
 
-inline uint8_t fw_read_keyboard_col(void)
+static inline uint8_t keyboardReadCol(void)
 {
 #if defined(PLATFORM_GD77S)
 	return 0;
@@ -162,7 +162,7 @@ inline uint8_t fw_read_keyboard_col(void)
 #endif
 }
 
-uint32_t fw_read_keyboard(void)
+uint32_t keyboardRead(void)
 {
 	uint32_t result = 0;
 
@@ -174,7 +174,7 @@ uint32_t fw_read_keyboard(void)
 		for (volatile int i = 0; i < 100; i++)
 			; // small delay to allow voltages to settle. The delay value of 100 is arbitrary.
 
-		result=(result<<5) | fw_read_keyboard_col();
+		result=(result<<5) | keyboardReadCol();
 
 		GPIO_PinWrite(GPIOC, col, 1);
 		GPIO_PinInit(GPIOC, col, &pin_config_input);
@@ -184,7 +184,7 @@ uint32_t fw_read_keyboard(void)
     return result;
 }
 
-bool fw_scan_key(uint32_t scancode, char *keycode)
+bool keyboardScanKey(uint32_t scancode, char *keycode)
 {
 	int col;
 	int row = 0;
@@ -221,9 +221,9 @@ bool fw_scan_key(uint32_t scancode, char *keycode)
 	return (numKeys == 1);
 }
 
-void fw_check_key_event(keyboardCode_t *keys, int *event)
+void keyboardCheckKeyEvent(keyboardCode_t *keys, int *event)
 {
-	uint32_t scancode = fw_read_keyboard();
+	uint32_t scancode = keyboardRead();
 	char keycode;
 	bool validKey;
 	int newAlphaKey;
@@ -235,7 +235,7 @@ void fw_check_key_event(keyboardCode_t *keys, int *event)
 	keys->event = 0;
 	keys->key = 0;
 
-	validKey = fw_scan_key(scancode, &keycode);
+	validKey = keyboardScanKey(scancode, &keycode);
 
 	if (keyState > KEY_DEBOUNCE && !validKey)
 	{

--- a/firmware/source/io/rotary_switch.c
+++ b/firmware/source/io/rotary_switch.c
@@ -26,7 +26,7 @@
 static uint8_t prevPosition;
 #endif
 
-void init_rotary_switch(void)
+void rotarySwitchInit(void)
 {
 #if defined(PLATFORM_GD77S)
 	PORT_SetPinMux(Port_RotarySW_Line0, Pin_RotarySW_Line0, kPORT_MuxAsGpio);
@@ -43,7 +43,7 @@ void init_rotary_switch(void)
 #endif
 }
 
-uint8_t get_rotary_switch_position(void)
+uint8_t rotarySwitchGetPosition(void)
 {
 #if defined(PLATFORM_GD77S)
 	static const uint8_t rsPositions[] = { 1, 8, 2, 7, 4, 5, 3, 6, 16, 9, 15, 10, 13, 12, 14, 11 };
@@ -53,13 +53,13 @@ uint8_t get_rotary_switch_position(void)
 #endif
 }
 
-void check_rotary_switch_event(uint32_t *position, int *event)
+void rotarySwitchCheckRotaryEvent(uint32_t *position, int *event)
 {
 #if ! defined(PLATFORM_GD77S)
 	*position = 0;
 	*event = EVENT_ROTARY_NONE;
 #else
-	uint8_t value = get_rotary_switch_position();
+	uint8_t value = rotarySwitchGetPosition();
 
 	*position = value; // set it anyway, as it could be checked even on no event
 

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -128,12 +128,12 @@ void fw_main_task(void *data)
     init_I2C0a();
     setup_I2C0();
 	fw_init_common();
-	fw_init_buttons();
+	buttonsInit();
 	fw_init_LEDs();
 	keyboardInit();
 	init_rotary_switch();
 
-	fw_check_button_event(&buttons, &button_event);// Read button state and event
+	buttonsCheckButtonsEvent(&buttons, &button_event);// Read button state and event
 	if (buttons & BUTTON_SK2)
 	{
 		settingsRestoreDefaultSettings();
@@ -264,7 +264,7 @@ void fw_main_task(void *data)
 
 			tick_com_request();
 
-			fw_check_button_event(&buttons, &button_event); // Read button state and event
+			buttonsCheckButtonsEvent(&buttons, &button_event); // Read button state and event
 
 			keyboardCheckKeyEvent(&keys, &key_event); // Read keyboard state and event
 

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -130,7 +130,7 @@ void fw_main_task(void *data)
 	fw_init_common();
 	fw_init_buttons();
 	fw_init_LEDs();
-	fw_init_keyboard();
+	keyboardInit();
 	init_rotary_switch();
 
 	fw_check_button_event(&buttons, &button_event);// Read button state and event
@@ -220,7 +220,7 @@ void fw_main_task(void *data)
 #if defined(PLATFORM_GD77S)
     if ((buttons & (BUTTON_SK2 | BUTTON_ORANGE)) == ((BUTTON_SK2 | BUTTON_ORANGE)))
 #else
-    if ((buttons & BUTTON_SK2) && ((fw_read_keyboard() & (SCAN_UP | SCAN_DOWN)) == (SCAN_UP | SCAN_DOWN)))
+    if ((buttons & BUTTON_SK2) && ((keyboardRead() & (SCAN_UP | SCAN_DOWN)) == (SCAN_UP | SCAN_DOWN)))
 #endif
 	{
 		settingsEraseCustomContent();
@@ -266,7 +266,7 @@ void fw_main_task(void *data)
 
 			fw_check_button_event(&buttons, &button_event); // Read button state and event
 
-			fw_check_key_event(&keys, &key_event); // Read keyboard state and event
+			keyboardCheckKeyEvent(&keys, &key_event); // Read keyboard state and event
 
 			check_rotary_switch_event(&rotary, &rotary_event); // Rotary switch state and event (GD-77S only)
 
@@ -642,7 +642,7 @@ void fw_main_task(void *data)
 					keys.key = 0;
 					keys.event = 0;
 					function_event = FUNCTION_EVENT;
-					fw_reset_keyboard();
+					keyboardReset();
 				}
 			}
     		ev.buttons = buttons;

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -216,11 +216,13 @@ void fw_main_task(void *data)
     SEGGER_RTT_printf(0,"Segger RTT initialised\n");
 #endif
 
+#if ! defined(PLATFORM_RD5R)
 	// Clear boot melody and image
 	if ((buttons & (BUTTON_SK2 | BUTTON_ORANGE)) == ((BUTTON_SK2 | BUTTON_ORANGE)))
 	{
 		settingsEraseCustomContent();
 	}
+#endif
 
     lastheardInitList();
     codeplugInitContactsCache();

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -131,7 +131,7 @@ void fw_main_task(void *data)
 	buttonsInit();
 	fw_init_LEDs();
 	keyboardInit();
-	init_rotary_switch();
+	rotarySwitchInit();
 
 	buttonsCheckButtonsEvent(&buttons, &button_event);// Read button state and event
 	if (buttons & BUTTON_SK2)
@@ -268,7 +268,7 @@ void fw_main_task(void *data)
 
 			keyboardCheckKeyEvent(&keys, &key_event); // Read keyboard state and event
 
-			check_rotary_switch_event(&rotary, &rotary_event); // Rotary switch state and event (GD-77S only)
+			rotarySwitchCheckRotaryEvent(&rotary, &rotary_event); // Rotary switch state and event (GD-77S only)
 
 			// VOX Checking
 			if (voxIsEnabled())

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -216,8 +216,13 @@ void fw_main_task(void *data)
     SEGGER_RTT_printf(0,"Segger RTT initialised\n");
 #endif
 
-#if ! defined(PLATFORM_RD5R)
 	// Clear boot melody and image
+#if defined(PLATFORM_RD5R)
+	if ((buttons & (BUTTON_SK1 | BUTTON_SK2 | BUTTON_PTT)) == ((BUTTON_SK1 | BUTTON_SK2 | BUTTON_PTT)))
+	{
+		settingsEraseCustomContent();
+	}
+#else
 	if ((buttons & (BUTTON_SK2 | BUTTON_ORANGE)) == ((BUTTON_SK2 | BUTTON_ORANGE)))
 	{
 		settingsEraseCustomContent();

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -217,17 +217,14 @@ void fw_main_task(void *data)
 #endif
 
 	// Clear boot melody and image
-#if defined(PLATFORM_RD5R)
-	if ((buttons & (BUTTON_SK1 | BUTTON_SK2 | BUTTON_PTT)) == ((BUTTON_SK1 | BUTTON_SK2 | BUTTON_PTT)))
-	{
-		settingsEraseCustomContent();
-	}
+#if defined(PLATFORM_GD77S)
+    if ((buttons & (BUTTON_SK2 | BUTTON_ORANGE)) == ((BUTTON_SK2 | BUTTON_ORANGE)))
 #else
-	if ((buttons & (BUTTON_SK2 | BUTTON_ORANGE)) == ((BUTTON_SK2 | BUTTON_ORANGE)))
+    if ((buttons & BUTTON_SK2) && ((fw_read_keyboard() & (SCAN_UP | SCAN_DOWN)) == (SCAN_UP | SCAN_DOWN)))
+#endif
 	{
 		settingsEraseCustomContent();
 	}
-#endif
 
     lastheardInitList();
     codeplugInitContactsCache();
@@ -245,6 +242,13 @@ void fw_main_task(void *data)
 		nonVolatileSettings.hotspotType = (buttons & BUTTON_PTT) ? HOTSPOT_TYPE_BLUEDV : HOTSPOT_TYPE_MMDVM;
 	}
 #endif
+
+	// Reset buttons/key states in case some where pressed while booting.
+	button_event = EVENT_BUTTON_NONE;
+	buttons = BUTTON_NONE;
+	key_event = EVENT_KEY_NONE;
+	keys.event = 0;
+	keys.key = 0;
 
     while (1U)
     {

--- a/firmware/source/user_interface/menuContactList.c
+++ b/firmware/source/user_interface/menuContactList.c
@@ -324,7 +324,7 @@ int menuContactListSubMenu(uiEvent_t *ev, bool isFirstRun)
 	if (isFirstRun)
 	{
 		updateSubMenuScreen();
-		fw_init_keyboard();
+		keyboardInit();
 	}
 	else
 	{

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -110,7 +110,7 @@ void menuSystemPushNewMenu(int menuNumber)
 	{
 		uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .rotary = 0, .function = 0, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
-		fw_reset_keyboard();
+		keyboardReset();
 		menuControlData.itemIndex[menuControlData.stackPosition] = gMenusCurrentItemIndex;
 		menuControlData.stackPosition++;
 		menuControlData.stack[menuControlData.stackPosition] = menuNumber;
@@ -125,7 +125,7 @@ void menuSystemPushNewMenuWithQuickFunction(int menuNumber, int quickFunction)
 	{
 		uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .rotary = 0, .function = quickFunction, .events = FUNCTION_EVENT, .hasEvent = false, .time = fw_millis() };
 
-		fw_reset_keyboard();
+		keyboardReset();
 		menuControlData.itemIndex[menuControlData.stackPosition] = gMenusCurrentItemIndex;
 		menuControlData.stackPosition++;
 		menuControlData.stack[menuControlData.stackPosition] = menuNumber;
@@ -138,7 +138,7 @@ void menuSystemPopPreviousMenu(void)
 {
 	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .rotary = 0, .function = 0, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
-	fw_reset_keyboard();
+	keyboardReset();
 	menuControlData.itemIndex[menuControlData.stackPosition] = 0;
 	menuControlData.stackPosition -= (menuControlData.stackPosition > 0) ? 1 : 0; // Avoid crashing if something goes wrong.
 	gMenusCurrentItemIndex = menuControlData.itemIndex[menuControlData.stackPosition];
@@ -149,7 +149,7 @@ void menuSystemPopAllAndDisplayRootMenu(void)
 {
 	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .rotary = 0, .function = 0, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
-	fw_reset_keyboard();
+	keyboardReset();
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
 	menuControlData.stackPosition = 0;
 	gMenusCurrentItemIndex = 0;
@@ -160,7 +160,7 @@ void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu)
 {
 	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .rotary = 0, .function = 0, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
-	fw_reset_keyboard();
+	keyboardReset();
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
 	menuControlData.stack[0]  = newRootMenu;
 	menuControlData.stackPosition = 0;
@@ -172,7 +172,7 @@ void menuSystemSetCurrentMenu(int menuNumber)
 {
 	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .rotary = 0, .function = 0, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
-	fw_reset_keyboard();
+	keyboardReset();
 	menuControlData.stack[menuControlData.stackPosition] = menuNumber;
 	gMenusCurrentItemIndex = menuControlData.itemIndex[menuControlData.stackPosition];
 	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev,true);

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -1043,7 +1043,7 @@ static void handleEvent(uiEvent_t *ev)
 				}
 				scanTimer = SCAN_SKIP_CHANNEL_INTERVAL;	//force scan to continue;
 				scanState=SCAN_SCANNING;
-				fw_reset_keyboard();
+				keyboardReset();
 				return;
 			}
 
@@ -1051,7 +1051,7 @@ static void handleEvent(uiEvent_t *ev)
 			if (scanState == SCAN_SCANNING && ev->keys.key == KEY_LEFT)
 			{
 				scanDirection *= -1;
-				fw_reset_keyboard();
+				keyboardReset();
 				return;
 			}
 		}
@@ -1060,7 +1060,7 @@ static void handleEvent(uiEvent_t *ev)
 		if (((ev->keys.key == KEY_UP) && (ev->buttons & BUTTON_SK2) == 0) == false)
 		{
 			uiChannelModeStopScanning();
-			fw_reset_keyboard();
+			keyboardReset();
 			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 			uiChannelModeUpdateScreen(0);
 			return;

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -111,7 +111,7 @@ int uiChannelMode(uiEvent_t *ev, bool isFirstRun)
 		if (firstRunGD77S)
 		{
 			firstRunGD77S = false;
-			checkAndUpdateSelectedChannelForGD77S(get_rotary_switch_position(), true);
+			checkAndUpdateSelectedChannelForGD77S(rotarySwitchGetPosition(), true);
 		}
 #endif
 		displayLightTrigger();
@@ -136,9 +136,9 @@ int uiChannelMode(uiEvent_t *ev, bool isFirstRun)
 #if defined(PLATFORM_GD77S)
 			// Just ensure rotary's selected channel is matching the already loaded one
 			// as rotary selector could be turned while the GD is OFF, or in hotspot mode.
-			if (get_rotary_switch_position() != getCurrentChannelInCurrentZoneForGD77S())
+			if (rotarySwitchGetPosition() != getCurrentChannelInCurrentZoneForGD77S())
 			{
-				checkAndUpdateSelectedChannelForGD77S(get_rotary_switch_position(), false);
+				checkAndUpdateSelectedChannelForGD77S(rotarySwitchGetPosition(), false);
 			}
 #endif
 

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -635,7 +635,7 @@ static void handleEvent(uiEvent_t *ev)
 				}
 				scanTimer = SCAN_SKIP_CHANNEL_INTERVAL;//force scan to continue;
 				scanState=SCAN_SCANNING;
-				fw_reset_keyboard();
+				keyboardReset();
 				return;
 			}
 
@@ -643,7 +643,7 @@ static void handleEvent(uiEvent_t *ev)
 			if (scanState == SCAN_SCANNING && ev->keys.key == KEY_LEFT)
 			{
 				scanDirection *= -1;
-				fw_reset_keyboard();
+				keyboardReset();
 				return;
 			}
 		}
@@ -653,7 +653,7 @@ static void handleEvent(uiEvent_t *ev)
 		if (ev->keys.key != KEY_UP)
 		{
 			uiVFOModeStopScanning();
-			fw_reset_keyboard();
+			keyboardReset();
 			return;
 		}
 	}


### PR DESCRIPTION
Yes, it can bootup txing, but at least the feature is usable on that platform.
Maybe later we can use keypad too (without longpress/repeat).

**EDIT**: I changed the default shortcut to SK2 + UP + DOWN, as it works on all platform exceot the GD-77S.
On this one, I left SK2 + ORANGE, as the choice is quite limited.