### PR TITLE
Various keyboard fixes + 1 crash bug fix

### DIFF
--- a/firmware/include/io/keyboard.h
+++ b/firmware/include/io/keyboard.h
@@ -187,11 +187,11 @@
 //#define KEYCHECK_KEYMOD(keys, k, mask, mod) (((((keys) & 0xffffff) == (k)) && ((keys) & (mask)) == (mod)))
 //#define KEYCHECK_MOD(keys, mask, mod) (((keys) & (mask)) == (mod))
 
-#define KEYCHECK_UP(keys, k)       ((keys.key == k) && ((keys.event & KEY_MOD_UP) == KEY_MOD_UP))
-#define KEYCHECK_SHORTUP(keys, k)  ((keys.key == k) && ((keys.event & (KEY_MOD_UP | KEY_MOD_LONG)) == KEY_MOD_UP))
-#define KEYCHECK_DOWN(keys, k)     ((keys.key == k) && ((keys.event & KEY_MOD_DOWN) == KEY_MOD_DOWN))
-#define KEYCHECK_PRESS(keys, k)    ((keys.key == k) && ((keys.event & KEY_MOD_PRESS) == KEY_MOD_PRESS))
-#define KEYCHECK_LONGDOWN(keys, k) ((keys.key == k) && ((keys.event & (KEY_MOD_DOWN | KEY_MOD_LONG)) == (KEY_MOD_DOWN | KEY_MOD_LONG)))
+#define KEYCHECK_UP(keys, k)              ((keys.key == k) && ((keys.event & KEY_MOD_UP) == KEY_MOD_UP))
+#define KEYCHECK_SHORTUP(keys, k)         ((keys.key == k) && ((keys.event & (KEY_MOD_UP | KEY_MOD_LONG)) == KEY_MOD_UP))
+#define KEYCHECK_DOWN(keys, k)            ((keys.key == k) && ((keys.event & KEY_MOD_DOWN) == KEY_MOD_DOWN))
+#define KEYCHECK_PRESS(keys, k)           ((keys.key == k) && ((keys.event & KEY_MOD_PRESS) == KEY_MOD_PRESS))
+#define KEYCHECK_LONGDOWN(keys, k)        ((keys.key == k) && ((keys.event & (KEY_MOD_DOWN | KEY_MOD_LONG)) == (KEY_MOD_DOWN | KEY_MOD_LONG)))
 #define KEYCHECK_LONGDOWN_REPEAT(keys, k) ((keys.key == k) && ((keys.event & (KEY_MOD_PRESS | KEY_MOD_LONG)) == (KEY_MOD_PRESS | KEY_MOD_LONG)))
 
 

--- a/firmware/include/io/keyboard.h
+++ b/firmware/include/io/keyboard.h
@@ -192,6 +192,7 @@
 #define KEYCHECK_DOWN(keys, k)     ((keys.key == k) && ((keys.event & KEY_MOD_DOWN) == KEY_MOD_DOWN))
 #define KEYCHECK_PRESS(keys, k)    ((keys.key == k) && ((keys.event & KEY_MOD_PRESS) == KEY_MOD_PRESS))
 #define KEYCHECK_LONGDOWN(keys, k) ((keys.key == k) && ((keys.event & (KEY_MOD_DOWN | KEY_MOD_LONG)) == (KEY_MOD_DOWN | KEY_MOD_LONG)))
+#define KEYCHECK_LONGDOWN_REPEAT(keys, k) ((keys.key == k) && ((keys.event & (KEY_MOD_PRESS | KEY_MOD_LONG)) == (KEY_MOD_PRESS | KEY_MOD_LONG)))
 
 
 //#define KEYCHAR(keys)              ((char)(keys & 0xff))

--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -75,6 +75,7 @@ void uiVFOModeUpdateScreen(int txTimeSecs);
 void uiVFOModeStopScanning(void);
 bool uiVFOModeIsScanning(void);
 void uiChannelModeStopScanning(void);
+bool uiChannelModeIsScanning(void);
 void uiCPSUpdate(int command,int x, int y, ucFont_t fontSize, ucTextAlign_t alignment, bool isInverted,char *szMsg);
 
 void menuInitMenuSystem(void);
@@ -89,7 +90,7 @@ int menuSystemGetCurrentMenuNumber(void);
 
 void menuSystemPopPreviousMenu(void);
 void menuSystemPopAllAndDisplayRootMenu(void);
-void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu);
+void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu, bool resetKeyboard);
 
 void menuSystemCallCurrentMenuTick(uiEvent_t *ev);
 int menuGetKeypadKeyValue(uiEvent_t *ev, bool digitsOnly);

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -48,15 +48,15 @@ static const int LOW_BATTERY_INTERVAL_GD77S = ((1000 * 60) * 5); // 5 minutes;
 
 void fw_init(void)
 {
-	xTaskCreate(fw_main_task,                        /* pointer to the task */
-				"fw main task",                      /* task name for kernel awareness debugging */
-				5000L / sizeof(portSTACK_TYPE),      /* task stack size */
-				NULL,                      			 /* optional task startup argument */
-				6U,                                  /* initial priority */
-				fwMainTaskHandle					 /* optional task handle to create */
-				);
+	xTaskCreate(fw_main_task,                    /* pointer to the task */
+			"fw main task",                      /* task name for kernel awareness debugging */
+			5000L / sizeof(portSTACK_TYPE),      /* task stack size */
+			NULL,                      			 /* optional task startup argument */
+			6U,                                  /* initial priority */
+			fwMainTaskHandle					 /* optional task handle to create */
+	);
 
-    vTaskStartScheduler();
+	vTaskStartScheduler();
 }
 
 void fw_powerOffFinalStage(void)
@@ -125,11 +125,11 @@ void fw_main_task(void *data)
 	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .rotary = 0, .function = 0, .events = NO_EVENT, .hasEvent = false, .time = 0 };
 	bool keyOrButtonChanged = false;
 
-    USB_DeviceApplicationInit();
+	USB_DeviceApplicationInit();
 
-    // Init I2C
-    init_I2C0a();
-    setup_I2C0();
+	// Init I2C
+	init_I2C0a();
+	setup_I2C0();
 	fw_init_common();
 	buttonsInit();
 	fw_init_LEDs();
@@ -142,63 +142,63 @@ void fw_main_task(void *data)
 		settingsRestoreDefaultSettings();
 	}
 
-    settingsLoadSettings();
+	settingsLoadSettings();
 
 	displayInit(nonVolatileSettings.displayInverseVideo);
 
-    // Init SPI
-    init_SPI();
-    setup_SPI0();
-    setup_SPI1();
+	// Init SPI
+	init_SPI();
+	setup_SPI0();
+	setup_SPI1();
 
-    // Init I2S
-    init_I2S();
-    setup_I2S();
+	// Init I2S
+	init_I2S();
+	setup_I2S();
 
-    // Init ADC
-    adc_init();
+	// Init ADC
+	adc_init();
 
-    // Init DAC
-    dac_init();
+	// Init DAC
+	dac_init();
 
-    SPI_Flash_init();
+	SPI_Flash_init();
 
-    if (!checkAndCopyCalibrationToCommonLocation())
+	if (!checkAndCopyCalibrationToCommonLocation())
 	{
 		showErrorMessage("CAL DATA ERROR");
 		while(1U)
 		{
 			tick_com_request();
-		};
+		}
 	}
 
-    // Init AT1846S
-    I2C_AT1846S_init();
+	// Init AT1846S
+	I2C_AT1846S_init();
 
-    // Init HR-C6000
-    SPI_HR_C6000_init();
+	// Init HR-C6000
+	SPI_HR_C6000_init();
 
-    // Additional init stuff
-    SPI_C6000_postinit();
-    I2C_AT1846_Postinit();
+	// Additional init stuff
+	SPI_C6000_postinit();
+	I2C_AT1846_Postinit();
 
-    // Init HR-C6000 interrupts
-    init_HR_C6000_interrupts();
+	// Init HR-C6000 interrupts
+	init_HR_C6000_interrupts();
 
-    // Speech Synthesis (GD77S Only)
-    speechSynthesisInit();
+	// Speech Synthesis (GD77S Only)
+	speechSynthesisInit();
 
-    // VOX init
-    voxInit();
+	// VOX init
+	voxInit();
 
-    // Small startup delay after initialization to stabilize system
-  //  vTaskDelay(portTICK_PERIOD_MS * 500);
+	// Small startup delay after initialization to stabilize system
+	//  vTaskDelay(portTICK_PERIOD_MS * 500);
 
 	init_pit();
 
 	trx_measure_count = 0;
 
-	if (get_battery_voltage()<CUTOFF_VOLTAGE_UPPER_HYST)
+	if (get_battery_voltage() < CUTOFF_VOLTAGE_UPPER_HYST)
 	{
 		show_lowbattery();
 #if !defined(PLATFORM_RD5R)
@@ -212,34 +212,34 @@ void fw_main_task(void *data)
 	menuBatteryInit(); // Initialize circular buffer
 	init_watchdog(menuBatteryPushBackVoltage);
 
-    fw_init_beep_task();
+	fw_init_beep_task();
 
 #if defined(USE_SEGGER_RTT)
-    SEGGER_RTT_ConfigUpBuffer(0, NULL, NULL, 0, SEGGER_RTT_MODE_NO_BLOCK_TRIM);
-    SEGGER_RTT_printf(0,"Segger RTT initialised\n");
+	SEGGER_RTT_ConfigUpBuffer(0, NULL, NULL, 0, SEGGER_RTT_MODE_NO_BLOCK_TRIM);
+	SEGGER_RTT_printf(0,"Segger RTT initialised\n");
 #endif
 
 	// Clear boot melody and image
 #if defined(PLATFORM_GD77S)
-    if ((buttons & (BUTTON_SK2 | BUTTON_ORANGE)) == ((BUTTON_SK2 | BUTTON_ORANGE)))
+	if ((buttons & (BUTTON_SK2 | BUTTON_ORANGE)) == ((BUTTON_SK2 | BUTTON_ORANGE)))
 #else
-    if ((buttons & BUTTON_SK2) && ((keyboardRead() & (SCAN_UP | SCAN_DOWN)) == (SCAN_UP | SCAN_DOWN)))
+	if ((buttons & BUTTON_SK2) && ((keyboardRead() & (SCAN_UP | SCAN_DOWN)) == (SCAN_UP | SCAN_DOWN)))
 #endif
 	{
 		settingsEraseCustomContent();
 	}
 
-    lastheardInitList();
-    codeplugInitContactsCache();
-    dmrIDCacheInit();
+	lastheardInitList();
+	codeplugInitContactsCache();
+	dmrIDCacheInit();
 
-    // Should be initialized before the splash screen, as we don't want melodies when VOX is enabled
-    voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
+	// Should be initialized before the splash screen, as we don't want melodies when VOX is enabled
+	voxSetParameters(nonVolatileSettings.voxThreshold, nonVolatileSettings.voxTailUnits);
 
-    menuInitMenuSystem();
+	menuInitMenuSystem();
 
 #if defined(PLATFORM_GD77S)
-    // Change hotspot modem type setting
+	// Change hotspot modem type setting
 	if (buttons & BUTTON_SK1)
 	{
 		nonVolatileSettings.hotspotType = (buttons & BUTTON_PTT) ? HOTSPOT_TYPE_BLUEDV : HOTSPOT_TYPE_MMDVM;
@@ -253,17 +253,17 @@ void fw_main_task(void *data)
 	keys.event = 0;
 	keys.key = 0;
 
-    while (1U)
-    {
-    	taskENTER_CRITICAL();
-    	uint32_t tmp_timer_maintask=timer_maintask;
-    	taskEXIT_CRITICAL();
-    	if (tmp_timer_maintask==0)
-    	{
-        	taskENTER_CRITICAL();
-    		timer_maintask=10;
-    	    alive_maintask=true;
-        	taskEXIT_CRITICAL();
+	while (1U)
+	{
+		taskENTER_CRITICAL();
+		uint32_t tmp_timer_maintask=timer_maintask;
+		taskEXIT_CRITICAL();
+		if (tmp_timer_maintask==0)
+		{
+			taskENTER_CRITICAL();
+			timer_maintask=10;
+			alive_maintask=true;
+			taskEXIT_CRITICAL();
 
 			tick_com_request();
 
@@ -355,21 +355,21 @@ void fw_main_task(void *data)
 #if defined(PLATFORM_RD5R)
 					if (button_event == EVENT_BUTTON_CHANGE && (buttons & BUTTON_SK2))
 #else
-					if (button_event == EVENT_BUTTON_CHANGE && ((buttons & BUTTON_ORANGE) || (buttons & BUTTON_SK2)))
+						if (button_event == EVENT_BUTTON_CHANGE && ((buttons & BUTTON_ORANGE) || (buttons & BUTTON_SK2)))
 #endif
-					{
-						if ((PTTToggledDown == false) && (menuSystemGetCurrentMenuNumber() != UI_LOCK_SCREEN))
 						{
-							menuSystemPushNewMenu(UI_LOCK_SCREEN);
-						}
+							if ((PTTToggledDown == false) && (menuSystemGetCurrentMenuNumber() != UI_LOCK_SCREEN))
+							{
+								menuSystemPushNewMenu(UI_LOCK_SCREEN);
+							}
 
-						button_event = EVENT_BUTTON_NONE;
+							button_event = EVENT_BUTTON_NONE;
 
-						if (nonVolatileSettings.pttToggle && PTTToggledDown)
-						{
-							PTTToggledDown = false;
+							if (nonVolatileSettings.pttToggle && PTTToggledDown)
+							{
+								PTTToggledDown = false;
+							}
 						}
-					}
 				}
 				else if (PTTLocked)
 				{
@@ -397,36 +397,35 @@ void fw_main_task(void *data)
 			}
 
 #if ! defined(PLATFORM_GD77S)
-		if ((key_event == EVENT_KEY_CHANGE) && ((buttons & BUTTON_PTT) == 0) && (keys.key != 0))
+			if ((key_event == EVENT_KEY_CHANGE) && ((buttons & BUTTON_PTT) == 0) && (keys.key != 0))
 			{
 				// Do not send any beep while scanning, otherwise enabling the AMP will be handled as a valid signal detection.
 				if (keys.event & KEY_MOD_PRESS)
 				{
-					if ((PTTToggledDown == false) && (((menuSystemGetCurrentMenuNumber() == UI_VFO_MODE) && uiVFOModeIsScanning()) == false))
+					if ((PTTToggledDown == false) && (uiVFOModeIsScanning() == false) && (uiChannelModeIsScanning() == false))
 					{
 						set_melody(melody_key_beep);
 					}
 				}
 				else if ((keys.event & (KEY_MOD_LONG | KEY_MOD_DOWN)) == (KEY_MOD_LONG | KEY_MOD_DOWN))
 				{
-					if ((PTTToggledDown == false) && (((menuSystemGetCurrentMenuNumber() == UI_VFO_MODE) && uiVFOModeIsScanning()) == false))
+					if ((PTTToggledDown == false) && (uiVFOModeIsScanning() == false) && (uiChannelModeIsScanning() == false))
 					{
 						set_melody(melody_key_long_beep);
 					}
 				}
 
-				if (KEYCHECK_LONGDOWN(keys, KEY_RED) &&
-						(((menuSystemGetCurrentMenuNumber() == UI_VFO_MODE) && uiVFOModeIsScanning()) == false))
+				if (KEYCHECK_LONGDOWN(keys, KEY_RED) && (uiVFOModeIsScanning() == false) && (uiChannelModeIsScanning() == false))
 				{
 					contactListContactIndex = 0;
 					menuSystemPopAllAndDisplayRootMenu();
 				}
 			}
 
-/*
- * This code ignores the keypress if the display is not lit, however this functionality is proving to be a problem for things like entering a TG
- * I think it needs to be removed until a better solution can be found
- *
+			/*
+			 * This code ignores the keypress if the display is not lit, however this functionality is proving to be a problem for things like entering a TG
+			 * I think it needs to be removed until a better solution can be found
+			 *
 			if (menuDisplayLightTimer == 0
 					&& nonVolatileSettings.backLightTimeout != 0)
 			{
@@ -443,7 +442,7 @@ void fw_main_task(void *data)
 					displayLightTrigger();
 				}
 			}
-*/
+			 */
 
 			//
 			// PTT toggle feature
@@ -451,8 +450,8 @@ void fw_main_task(void *data)
 			// PTT is locked down, but any button but SK1 is pressed, virtually release PTT
 #if defined(PLATFORM_RD5R)
 			if ((nonVolatileSettings.pttToggle && PTTToggledDown) &&
-							(((buttons & BUTTON_SK2)) ||
-									((keys.key != 0) && (keys.event & KEY_MOD_UP))))
+					(((buttons & BUTTON_SK2)) ||
+							((keys.key != 0) && (keys.event & KEY_MOD_UP))))
 #else
 			if ((nonVolatileSettings.pttToggle && PTTToggledDown) &&
 					(((button_event & EVENT_BUTTON_CHANGE) && ((buttons & BUTTON_ORANGE) || (buttons & BUTTON_SK2))) ||
@@ -546,54 +545,54 @@ void fw_main_task(void *data)
 					}
 				}
 
-        		if (buttons & BUTTON_SK1 && buttons & BUTTON_SK2)
-        		{
-        			settingsSaveSettings(true);
-        		}
+				if (buttons & BUTTON_SK1 && buttons & BUTTON_SK2)
+				{
+					settingsSaveSettings(true);
+				}
 
-    			// Toggle backlight
-        		if ((nonVolatileSettings.backlightMode == BACKLIGHT_MODE_MANUAL) && (buttons & BUTTON_SK1))
-        		{
-        			displayEnableBacklight(! displayIsBacklightLit());
-        		}
-        	}
+				// Toggle backlight
+				if ((nonVolatileSettings.backlightMode == BACKLIGHT_MODE_MANUAL) && (buttons & BUTTON_SK1))
+				{
+					displayEnableBacklight(! displayIsBacklightLit());
+				}
+			}
 
-    		if (!trxIsTransmitting && updateLastHeard==true)
-    		{
-    			lastHeardListUpdate((uint8_t *)DMR_frame_buffer, false);
-    			updateLastHeard=false;
-    		}
+			if (!trxIsTransmitting && updateLastHeard==true)
+			{
+				lastHeardListUpdate((uint8_t *)DMR_frame_buffer, false);
+				updateLastHeard=false;
+			}
 
-    		if ((nonVolatileSettings.hotspotType == HOTSPOT_TYPE_OFF) ||
-    				((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) && (settingsUsbMode != USB_MODE_HOTSPOT))) // Do not filter anything in HS mode.
-    		{
+			if ((nonVolatileSettings.hotspotType == HOTSPOT_TYPE_OFF) ||
+					((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) && (settingsUsbMode != USB_MODE_HOTSPOT))) // Do not filter anything in HS mode.
+			{
 				if ((uiPrivateCallState == PRIVATE_CALL_DECLINED) &&
 						(slot_state == DMR_STATE_IDLE))
 				{
 					menuClearPrivateCall();
 				}
 				if (!trxIsTransmitting && menuDisplayQSODataState == QSO_DISPLAY_CALLER_DATA && nonVolatileSettings.privateCalls == true)
-    			{
-    				if (HRC6000GetReceivedTgOrPcId() == (trxDMRID | (PC_CALL_FLAG<<24)))
-    				{
-    					if ((uiPrivateCallState == NOT_IN_CALL) &&
-    							(trxTalkGroupOrPcId != (HRC6000GetReceivedSrcId() | (PC_CALL_FLAG<<24))) &&
+				{
+					if (HRC6000GetReceivedTgOrPcId() == (trxDMRID | (PC_CALL_FLAG<<24)))
+					{
+						if ((uiPrivateCallState == NOT_IN_CALL) &&
+								(trxTalkGroupOrPcId != (HRC6000GetReceivedSrcId() | (PC_CALL_FLAG<<24))) &&
 								(HRC6000GetReceivedSrcId() != uiPrivateCallLastID))
-    					{
-    						if ((HRC6000GetReceivedSrcId() & 0xFFFFFF) >= 1000000)
-    						{
-    							menuSystemPushNewMenu(UI_PRIVATE_CALL);
-    						}
-    					}
-    				}
-    			}
-    		}
+						{
+							if ((HRC6000GetReceivedSrcId() & 0xFFFFFF) >= 1000000)
+							{
+								menuSystemPushNewMenu(UI_PRIVATE_CALL);
+							}
+						}
+					}
+				}
+			}
 
 			ev.function = 0;
 			function_event = NO_EVENT;
 			if (buttons & BUTTON_SK2)
 			{
-//				keyFunction = codeplugGetQuickkeyFunctionID(keys.key);
+				//				keyFunction = codeplugGetQuickkeyFunctionID(keys.key);
 				switch (keys.key)
 				{
 				case '1':
@@ -648,77 +647,77 @@ void fw_main_task(void *data)
 					keyboardReset();
 				}
 			}
-    		ev.buttons = buttons;
-    		ev.keys = keys;
-    		ev.rotary = rotary;
-    		ev.events = function_event | (button_event << 1) | (rotary_event << 3) | key_event;
-    		ev.hasEvent = keyOrButtonChanged || function_event;
-    		ev.time = fw_millis();
+			ev.buttons = buttons;
+			ev.keys = keys;
+			ev.rotary = rotary;
+			ev.events = function_event | (button_event << 1) | (rotary_event << 3) | key_event;
+			ev.hasEvent = keyOrButtonChanged || function_event;
+			ev.time = fw_millis();
 
-        	menuSystemCallCurrentMenuTick(&ev);
+			menuSystemCallCurrentMenuTick(&ev);
 
 #if defined(PLATFORM_RD5R)
-        	if (keyFunction == TOGGLE_TORCH)
-        	{
-        		toggle_torch();
-        	}
+			if (keyFunction == TOGGLE_TORCH)
+			{
+				toggle_torch();
+			}
 #endif
 
 #if defined(PLATFORM_GD77S)
-        	if ((battery_voltage < (CUTOFF_VOLTAGE_LOWER_HYST + 6))
-        			&& ((lowbatteryTimerForGD77S == 0) || ((fw_millis() - lowbatteryTimerForGD77S) > LOW_BATTERY_INTERVAL_GD77S)))
-        	{
-        		uint8_t buf[2];
+			if ((battery_voltage < (CUTOFF_VOLTAGE_LOWER_HYST + 6))
+					&& ((lowbatteryTimerForGD77S == 0) || ((fw_millis() - lowbatteryTimerForGD77S) > LOW_BATTERY_INTERVAL_GD77S)))
+			{
+				uint8_t buf[2];
 
-        		lowbatteryTimerForGD77S = fw_millis();
+				lowbatteryTimerForGD77S = fw_millis();
 
-        		buf[0U] = 1;
-        		buf[1U] = SPEECH_SYNTHESIS_PLEASE_CHARGE_THE_BATTERY;
-        		speechSynthesisSpeak(buf);
-        	}
+				buf[0U] = 1;
+				buf[1U] = SPEECH_SYNTHESIS_PLEASE_CHARGE_THE_BATTERY;
+				speechSynthesisSpeak(buf);
+			}
 #endif
 
 #if defined(PLATFORM_RD5R)
-        	if ((battery_voltage < CUTOFF_VOLTAGE_LOWER_HYST)
-        			&& (menuSystemGetCurrentMenuNumber() != UI_POWER_OFF))
+			if ((battery_voltage < CUTOFF_VOLTAGE_LOWER_HYST)
+					&& (menuSystemGetCurrentMenuNumber() != UI_POWER_OFF))
 #else
-        	if (((GPIO_PinRead(GPIO_Power_Switch, Pin_Power_Switch) != 0)
-        			|| (battery_voltage < CUTOFF_VOLTAGE_LOWER_HYST))
-        			&& (menuSystemGetCurrentMenuNumber() != UI_POWER_OFF))
+			if (((GPIO_PinRead(GPIO_Power_Switch, Pin_Power_Switch) != 0)
+					|| (battery_voltage < CUTOFF_VOLTAGE_LOWER_HYST))
+					&& (menuSystemGetCurrentMenuNumber() != UI_POWER_OFF))
 #endif
-        	{
-        		if (battery_voltage < CUTOFF_VOLTAGE_LOWER_HYST)
-        		{
-        			show_lowbattery();
+			{
+				if (battery_voltage < CUTOFF_VOLTAGE_LOWER_HYST)
+				{
+					show_lowbattery();
 #if defined(PLATFORM_RD5R)
-        			fw_powerOffFinalStage();
+					fw_powerOffFinalStage();
 #else
-        			if (GPIO_PinRead(GPIO_Power_Switch, Pin_Power_Switch) != 0)
-        			{
-        				fw_powerOffFinalStage();
-        			}
+					if (GPIO_PinRead(GPIO_Power_Switch, Pin_Power_Switch) != 0)
+					{
+						fw_powerOffFinalStage();
+					}
 #endif
-        		}
-        		else
-        		{
-        			menuSystemPushNewMenu(UI_POWER_OFF);
-        		}
-        		GPIO_PinWrite(GPIO_audio_amp_enable, Pin_audio_amp_enable, 0);
-        		set_melody(NULL);
-        	}
+				}
+				else
+				{
+					menuSystemPushNewMenu(UI_POWER_OFF);
+				}
+				GPIO_PinWrite(GPIO_audio_amp_enable, Pin_audio_amp_enable, 0);
+				set_melody(NULL);
+			}
 
-    		if ((nonVolatileSettings.backlightMode == BACKLIGHT_MODE_AUTO) && (menuDisplayLightTimer > 0))
-    		{
-    			menuDisplayLightTimer--;
-    			if (menuDisplayLightTimer==0)
-    			{
-    				displayEnableBacklight(false);
-    			}
-    		}
-    		tick_melody();
-    		speechSynthesisTick();
-    		voxTick();
-    	}
+			if ((nonVolatileSettings.backlightMode == BACKLIGHT_MODE_AUTO) && (menuDisplayLightTimer > 0))
+			{
+				menuDisplayLightTimer--;
+				if (menuDisplayLightTimer==0)
+				{
+					displayEnableBacklight(false);
+				}
+			}
+			tick_melody();
+			speechSynthesisTick();
+			voxTick();
+		}
 		vTaskDelay(0);
-    }
+	}
 }

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -355,21 +355,21 @@ void fw_main_task(void *data)
 #if defined(PLATFORM_RD5R)
 					if (button_event == EVENT_BUTTON_CHANGE && (buttons & BUTTON_SK2))
 #else
-						if (button_event == EVENT_BUTTON_CHANGE && ((buttons & BUTTON_ORANGE) || (buttons & BUTTON_SK2)))
+					if (button_event == EVENT_BUTTON_CHANGE && ((buttons & BUTTON_ORANGE) || (buttons & BUTTON_SK2)))
 #endif
+					{
+						if ((PTTToggledDown == false) && (menuSystemGetCurrentMenuNumber() != UI_LOCK_SCREEN))
 						{
-							if ((PTTToggledDown == false) && (menuSystemGetCurrentMenuNumber() != UI_LOCK_SCREEN))
-							{
-								menuSystemPushNewMenu(UI_LOCK_SCREEN);
-							}
-
-							button_event = EVENT_BUTTON_NONE;
-
-							if (nonVolatileSettings.pttToggle && PTTToggledDown)
-							{
-								PTTToggledDown = false;
-							}
+							menuSystemPushNewMenu(UI_LOCK_SCREEN);
 						}
+
+						button_event = EVENT_BUTTON_NONE;
+
+						if (nonVolatileSettings.pttToggle && PTTToggledDown)
+						{
+							PTTToggledDown = false;
+						}
+					}
 				}
 				else if (PTTLocked)
 				{

--- a/firmware/source/user_interface/menuOptions.c
+++ b/firmware/source/user_interface/menuOptions.c
@@ -169,31 +169,31 @@ static void handleEvent(uiEvent_t *ev)
 				doFactoryReset = true;
 				break;
 			case OPTIONS_MENU_USE_CALIBRATION:
-				nonVolatileSettings.useCalibration=true;
+				nonVolatileSettings.useCalibration = true;
 				break;
 			case OPTIONS_MENU_TX_FREQ_LIMITS:
-				nonVolatileSettings.txFreqLimited=true;
+				nonVolatileSettings.txFreqLimited = true;
 				break;
 			case OPTIONS_MENU_KEYPAD_TIMER_LONG:
-				if (nonVolatileSettings.keypadTimerLong<90)
+				if (nonVolatileSettings.keypadTimerLong < 90)
 				{
 					nonVolatileSettings.keypadTimerLong++;
 				}
 				break;
 			case OPTIONS_MENU_KEYPAD_TIMER_REPEAT:
-				if (nonVolatileSettings.keypadTimerRepeat<90)
+				if (nonVolatileSettings.keypadTimerRepeat < 90)
 				{
 					nonVolatileSettings.keypadTimerRepeat++;
 				}
 				break;
 			case OPTIONS_MENU_DMR_MONITOR_CAPTURE_TIMEOUT:
-				if (nonVolatileSettings.dmrCaptureTimeout<90)
+				if (nonVolatileSettings.dmrCaptureTimeout < 90)
 				{
 					nonVolatileSettings.dmrCaptureTimeout++;
 				}
 				break;
 			case OPTIONS_MENU_SCAN_DELAY:
-				if (nonVolatileSettings.scanDelay<30)
+				if (nonVolatileSettings.scanDelay < 30)
 				{
 					nonVolatileSettings.scanDelay++;
 				}
@@ -248,31 +248,31 @@ static void handleEvent(uiEvent_t *ev)
 				doFactoryReset = false;
 				break;
 			case OPTIONS_MENU_USE_CALIBRATION:
-				nonVolatileSettings.useCalibration=false;
+				nonVolatileSettings.useCalibration = false;
 				break;
 			case OPTIONS_MENU_TX_FREQ_LIMITS:
-				nonVolatileSettings.txFreqLimited=false;
+				nonVolatileSettings.txFreqLimited = false;
 				break;
 			case OPTIONS_MENU_KEYPAD_TIMER_LONG:
-				if (nonVolatileSettings.keypadTimerLong>1)
+				if (nonVolatileSettings.keypadTimerLong > 1)
 				{
 					nonVolatileSettings.keypadTimerLong--;
 				}
 				break;
 			case OPTIONS_MENU_KEYPAD_TIMER_REPEAT:
-				if (nonVolatileSettings.keypadTimerRepeat>0)
+				if (nonVolatileSettings.keypadTimerRepeat > 1) // Don't set it to zero, otherwise watchdog may kicks in.
 				{
 					nonVolatileSettings.keypadTimerRepeat--;
 				}
 				break;
 			case OPTIONS_MENU_DMR_MONITOR_CAPTURE_TIMEOUT:
-				if (nonVolatileSettings.dmrCaptureTimeout>1)
+				if (nonVolatileSettings.dmrCaptureTimeout > 1)
 				{
 					nonVolatileSettings.dmrCaptureTimeout--;
 				}
 				break;
 			case OPTIONS_MENU_SCAN_DELAY:
-				if (nonVolatileSettings.scanDelay>1)
+				if (nonVolatileSettings.scanDelay > 1)
 				{
 					nonVolatileSettings.scanDelay--;
 				}

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -156,11 +156,14 @@ void menuSystemPopAllAndDisplayRootMenu(void)
 	menuFunctions[menuControlData.stack[menuControlData.stackPosition]](&ev,true);
 }
 
-void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu)
+void menuSystemPopAllAndDisplaySpecificRootMenu(int newRootMenu, bool resetKeyboard)
 {
 	uiEvent_t ev = { .buttons = 0, .keys = NO_KEYCODE, .rotary = 0, .function = 0, .events = NO_EVENT, .hasEvent = false, .time = fw_millis() };
 
-	keyboardReset();
+	if (resetKeyboard)
+	{
+		keyboardReset();
+	}
 	memset(menuControlData.itemIndex, 0, sizeof(menuControlData.itemIndex));
 	menuControlData.stack[0]  = newRootMenu;
 	menuControlData.stackPosition = 0;

--- a/firmware/source/user_interface/menuZoneList.c
+++ b/firmware/source/user_interface/menuZoneList.c
@@ -89,7 +89,7 @@ static void handleEvent(uiEvent_t *ev)
 		nonVolatileSettings.currentChannelIndexInZone = 0;// Since we are switching zones the channel index should be reset
 		nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE]=0;// Since we are switching zones the TRx Group index should be reset
 		channelScreenChannelData.rxFreq=0x00; // Flag to the Channel screen that the channel data is now invalid and needs to be reloaded
-		menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE);
+		menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE, true);
 		SETTINGS_PLATFORM_SPECIFIC_SAVE_SETTINGS(false);// For Baofeng RD-5R
 
 		return;

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -1429,7 +1429,7 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 					nonVolatileSettings.tsManualOverride &= 0xF0;// Clear lower nibble value
 					nonVolatileSettings.tsManualOverride |= (trxGetDMRTimeSlot()+1);// Store manual TS override
 
-					menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE);
+					menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE, true);
 
 					set_melody(melody_ACK_beep);
 
@@ -1639,7 +1639,7 @@ static void initScan(void)
 
 	scanTimer=500;
 	scanState = SCAN_SCANNING;
-	menuSystemPopAllAndDisplaySpecificRootMenu(UI_VFO_MODE);
+	menuSystemPopAllAndDisplaySpecificRootMenu(UI_VFO_MODE, true);
 }
 
 static void scanning(void)


### PR DESCRIPTION
ChannelMode:
    - Fix SK2 + UP/DOWN. It does now handle repeat on zone selection.
    - Can use DOWN to scroll down on repeat. Can't use UP as it start scanning (by design).
    - Fix nuisance crashbug when all channel of the zone are part of the nuisance array (it just stop scanning when this condition is reached)

Options: don't let the key repeat < 1, as key repeat will trigger the watchdog.

main:
    - full reindentation, sorry, was messy.
    - don't play beeps when scanning is running, in both Channel and VFO modes.