### PR TITLE
Adjust TS1 / CTR indicator position

### DIFF
--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1196,6 +1196,8 @@ void menuUtilityRenderHeader(void)
 		scanBlinkPhase = false;
 	}
 
+	const int MODE_TEXT_X_OFFSET = 1;
+	const int FILTER_TEXT_X_OFFSET = 25;
 	switch(trxGetMode())
 	{
 		case RADIO_MODE_ANALOG:
@@ -1204,11 +1206,11 @@ void menuUtilityRenderHeader(void)
 			{
 				strcat(buffer,"N");
 			}
-			ucPrintCore(0, Y_OFFSET, buffer, ((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) ? FONT_SIZE_1_BOLD : FONT_SIZE_1), TEXT_ALIGN_LEFT, scanBlinkPhase);
+			ucPrintCore(MODE_TEXT_X_OFFSET, Y_OFFSET, buffer, ((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) ? FONT_SIZE_1_BOLD : FONT_SIZE_1), TEXT_ALIGN_LEFT, scanBlinkPhase);
 
 			if (codeplugChannelToneIsCTCSS(currentChannelData->txTone) || codeplugChannelToneIsCTCSS(currentChannelData->rxTone))
 			{
-				int rectWidth = 7;
+				int rectWidth = 9;
 				strcpy(buffer, "C");
 				if (codeplugChannelToneIsCTCSS(currentChannelData->txTone))
 				{
@@ -1223,16 +1225,15 @@ void menuUtilityRenderHeader(void)
 				bool isInverted = (nonVolatileSettings.analogFilterLevel == ANALOG_FILTER_NONE);
 				if (isInverted)
 				{
-					ucFillRect(23, Y_OFFSET - 1, rectWidth, 9, false);
+					ucFillRect(FILTER_TEXT_X_OFFSET - 2, Y_OFFSET - 1, rectWidth, 9, false);
 				}
-				ucPrintCore(24, Y_OFFSET, buffer, FONT_SIZE_1, TEXT_ALIGN_LEFT, isInverted);
+				ucPrintCore(FILTER_TEXT_X_OFFSET, Y_OFFSET, buffer, FONT_SIZE_1, TEXT_ALIGN_LEFT, isInverted);
 			}
 			break;
 
 		case RADIO_MODE_DIGITAL:
 			if (settingsUsbMode != USB_MODE_HOTSPOT)
 			{
-				const int DMR_TEXT_X_OFFSET = 1;
 //				(trxGetMode() == RADIO_MODE_DIGITAL && settingsPrivateCallMuteMode == true)?" MUTE":"");// The location that this was displayed is now used for the power level
 				if (!scanBlinkPhase && (nonVolatileSettings.dmrFilterLevel > DMR_FILTER_CC_TS))
 				{
@@ -1241,19 +1242,19 @@ void menuUtilityRenderHeader(void)
 				if (!scanBlinkPhase)
 				{
 					bool isInverted = scanBlinkPhase ^ (nonVolatileSettings.dmrFilterLevel > DMR_FILTER_CC_TS);
-					ucPrintCore(DMR_TEXT_X_OFFSET, Y_OFFSET, "DMR", ((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) ? FONT_SIZE_1_BOLD : FONT_SIZE_1), TEXT_ALIGN_LEFT, isInverted);
+					ucPrintCore(MODE_TEXT_X_OFFSET, Y_OFFSET, "DMR", ((nonVolatileSettings.hotspotType != HOTSPOT_TYPE_OFF) ? FONT_SIZE_1_BOLD : FONT_SIZE_1), TEXT_ALIGN_LEFT, isInverted);
 				}
 
 				snprintf(buffer, bufferLen, "%s%d", currentLanguage->ts, trxGetDMRTimeSlot() + 1);
 				buffer[bufferLen - 1] = 0;
 				if (nonVolatileSettings.dmrFilterLevel < DMR_FILTER_CC_TS)
 				{
-					ucFillRect(20, Y_OFFSET - 1, 21, 9, false);
-					ucPrintCore(22, Y_OFFSET, buffer, FONT_SIZE_1, TEXT_ALIGN_LEFT, true);
+					ucFillRect(FILTER_TEXT_X_OFFSET - 2, Y_OFFSET - 1, 21, 9, false);
+					ucPrintCore(FILTER_TEXT_X_OFFSET, Y_OFFSET, buffer, FONT_SIZE_1, TEXT_ALIGN_LEFT, true);
 				}
 				else
 				{
-					ucPrintCore(22, Y_OFFSET, buffer, FONT_SIZE_1, TEXT_ALIGN_LEFT, false);
+					ucPrintCore(FILTER_TEXT_X_OFFSET, Y_OFFSET, buffer, FONT_SIZE_1, TEXT_ALIGN_LEFT, false);
 //					if (nonVolatileSettings.tsManualOverride != 0)
 //					{
 //						ucFillRect(34, Y_OFFSET, 7, 8, false);


### PR DESCRIPTION
While working on other things I noticed that the timeslot and ctcss indicators were not in the same position, nor did they have the same border size when filtering was disabled. The mode (FM / DMR) indicator was also not in the same position (FM being one pixel to the left of DMR). This commit fixes the positions and makes them easy to change together if you prefer they be a little further to the left.

This puts them about centered between FMN or DMR and 750mW.

![dmr-ts1](https://user-images.githubusercontent.com/260569/80438916-2ee0cb00-88ba-11ea-9e66-b7f769c48cb1.png)
![fm-ct](https://user-images.githubusercontent.com/260569/80438933-37d19c80-88ba-11ea-9f5d-257218607389.png)
![fmn-ctr](https://user-images.githubusercontent.com/260569/80438938-3b652380-88ba-11ea-83c4-377ab1d2fe1d.png)
