### PR TITLE
Fix rxgroup list

### DIFF
--- a/firmware/include/functions/codeplug.h
+++ b/firmware/include/functions/codeplug.h
@@ -122,7 +122,7 @@ uint32_t byteSwap32(uint32_t n);
 uint32_t bcd2int(uint32_t in);
 int int2bcd(int i);
 
-void codeplugRxGroupGetDataForIndex(int index, struct_codeplugRxGroup_t *rxGroupBuf);
+bool codeplugRxGroupGetDataForIndex(int index, struct_codeplugRxGroup_t *rxGroupBuf);
 bool codeplugContactGetDataForIndex(int index, struct_codeplugContact_t *contact);
 void codeplugDTMFContactGetDataForIndex(struct_codeplugDTMFContactList_t *contactList);
 int codeplugGetUserDMRID(void);

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -454,8 +454,7 @@ static void handleEvent(uiEvent_t *ev)
 				tmpVal++;
 				while (tmpVal < 76)
 				{
-					codeplugRxGroupGetDataForIndex(tmpVal, &rxGroupBuf);
-					if (rxGroupBuf.name[0] != 0) {
+					if (codeplugRxGroupGetDataForIndex(tmpVal, &rxGroupBuf)) {
 						tmpChannel.rxGroupList = tmpVal;
 						break;
 					}
@@ -566,8 +565,7 @@ static void handleEvent(uiEvent_t *ev)
 					tmpVal--;
 					while (tmpVal > 0)
 					{
-						codeplugRxGroupGetDataForIndex(tmpVal, &rxGroupBuf);
-						if (rxGroupBuf.name[0] != 0) {
+						if (codeplugRxGroupGetDataForIndex(tmpVal, &rxGroupBuf)) {
 							tmpChannel.rxGroupList = tmpVal;
 							break;
 						}

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -245,9 +245,16 @@ static void updateScreen(void)
 					break;
 
 				case CH_DETAILS_RXGROUP:
-					codeplugRxGroupGetDataForIndex(tmpChannel.rxGroupList, &rxGroupBuf);
-					codeplugUtilConvertBufToString(rxGroupBuf.name, rxNameBuf, 16);
-					snprintf(buf, bufferLen, "%s:%s", currentLanguage->rx_group, rxNameBuf);
+					if (tmpChannel.chMode == RADIO_MODE_DIGITAL)
+					{
+						codeplugRxGroupGetDataForIndex(tmpChannel.rxGroupList, &rxGroupBuf);
+						codeplugUtilConvertBufToString(rxGroupBuf.name, rxNameBuf, 16);
+						snprintf(buf, bufferLen, "%s:%s", currentLanguage->rx_group, rxNameBuf);
+					}
+					else
+					{
+						snprintf(buf, bufferLen, "%s:%s", currentLanguage->rx_group, currentLanguage->n_a);
+					}
 					break;
 				case CH_DETAILS_VOX:
 					snprintf(buf, bufferLen, "VOX:%s",((tmpChannel.flag4 & 0x40) == 0x40) ? currentLanguage->on : currentLanguage->off);

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -317,6 +317,8 @@ static void setNextChannel(void)
 
 static void loadChannelData(bool useChannelDataInMemory)
 {
+	bool rxGroupValid;
+
 	if (currentZone.NOT_IN_MEMORY_isAllChannelsZone)
 	{
 		settingsCurrentChannelNumber = nonVolatileSettings.currentChannelIndexInAllZone;
@@ -363,9 +365,9 @@ static void loadChannelData(bool useChannelDataInMemory)
 		nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] = channelScreenChannelData.contact - 1;
 #endif
 
-		codeplugRxGroupGetDataForIndex(channelScreenChannelData.rxGroupList, &currentRxGroupData);
+		rxGroupValid = codeplugRxGroupGetDataForIndex(channelScreenChannelData.rxGroupList, &currentRxGroupData);
 		// Check if this channel has an Rx Group
-		if (currentRxGroupData.name[0]!=0 && nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] < currentRxGroupData.NOT_IN_CODEPLUG_numTGsInGroup)
+		if (rxGroupValid && nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] < currentRxGroupData.NOT_IN_CODEPLUG_numTGsInGroup)
 		{
 			codeplugContactGetDataForIndex(currentRxGroupData.contacts[nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE]],&currentContactData);
 		}


### PR DESCRIPTION
Fix for #357 

There is an extra array of 76 bytes in the codeplug which determines if a rx group is valid.
Deleting a rx group in the cps does not clear the name. It removes all TGs from the group entry and sets the associated value in above array to 0.
