### PR TITLE
Permit to stay in settings mode on PTT and Rotary events.

### DIFF
--- a/firmware/include/interfaces/pit.h
+++ b/firmware/include/interfaces/pit.h
@@ -31,6 +31,10 @@ extern volatile uint32_t timer_watchdogtask;
 extern volatile uint32_t timer_keypad;
 extern volatile uint32_t timer_keypad_timeout;
 extern volatile uint32_t PITCounter;
+#if defined(PLATFORM_GD77S)
+extern volatile uint32_t timer_mbuttons[3];
+extern volatile uint32_t timer_mbuttons_timeout[3];
+#endif
 
 void init_pit(void);
 void PIT0_IRQHandler(void);

--- a/firmware/include/io/buttons.h
+++ b/firmware/include/io/buttons.h
@@ -74,6 +74,8 @@
 
 #if defined(PLATFORM_GD77S)
 #define BUTTON_ORANGE_LONG 0x00000010
+#define BUTTON_SK1_LONG    0x00000020
+#define BUTTON_SK2_LONG    0x00000040
 #endif
 #endif
 

--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -111,8 +111,6 @@ void menuAcceptPrivateCall(int id);
 void menuHotspotRestoreSettings(void);
 
 #if defined(PLATFORM_GD77S)
-bool isInSettingsForGD77S(void);
-void leaveSettingsForGS77S(void);
 void heartBeatActivityForGD77S(uiEvent_t *ev);
 #endif
 

--- a/firmware/source/functions/speech_synthesis.c
+++ b/firmware/source/functions/speech_synthesis.c
@@ -146,6 +146,7 @@ static SpeechCurrentSequence_t ssSeq;
 
 #endif
 
+#if defined(PLATFORM_GD77S)
 static void speechSynthesisSilence(void)
 {
 	if (trxGetMode() == RADIO_MODE_ANALOG)
@@ -177,6 +178,7 @@ static void speechSynthesisSilence(void)
 		GPIO_PinWrite(GPIO_LEDgreen, Pin_LEDgreen, 0);
 	}
 }
+#endif
 
 void speechSynthesisInit(void)
 {

--- a/firmware/source/interfaces/pit.c
+++ b/firmware/source/interfaces/pit.c
@@ -26,6 +26,11 @@ volatile uint32_t timer_keypad;
 volatile uint32_t timer_keypad_timeout;
 volatile uint32_t PITCounter;
 
+#if defined(PLATFORM_GD77S)
+volatile uint32_t timer_mbuttons[3];
+volatile uint32_t timer_mbuttons_timeout[3];
+#endif
+
 void init_pit(void)
 {
 	taskENTER_CRITICAL();
@@ -35,6 +40,10 @@ void init_pit(void)
 	timer_watchdogtask=0;
 	timer_keypad=0;
 	timer_keypad_timeout=0;
+#if defined(PLATFORM_GD77S)
+	timer_mbuttons[0] = timer_mbuttons[1] = timer_mbuttons[2] = 0;
+	timer_mbuttons_timeout[0] = timer_mbuttons_timeout[1] = timer_mbuttons_timeout[1] = 0;
+#endif
 	taskEXIT_CRITICAL();
 
 	pit_config_t pitConfig;
@@ -77,6 +86,33 @@ void PIT0_IRQHandler(void)
 	{
 		timer_keypad_timeout--;
 	}
+#if defined(PLATFORM_GD77S)
+	if (timer_mbuttons[0]>0)
+	{
+		timer_mbuttons[0]--;
+	}
+	if (timer_mbuttons_timeout[0]>0)
+	{
+		timer_mbuttons_timeout[0]--;
+	}
+	if (timer_mbuttons[1]>0)
+	{
+		timer_mbuttons[1]--;
+	}
+	if (timer_mbuttons_timeout[1]>0)
+	{
+		timer_mbuttons_timeout[1]--;
+	}
+	if (timer_mbuttons[2]>0)
+	{
+		timer_mbuttons[2]--;
+	}
+	if (timer_mbuttons_timeout[2]>0)
+	{
+		timer_mbuttons_timeout[2]--;
+	}
+#endif
+
     /* Clear interrupt flag.*/
     PIT_ClearStatusFlags(PIT, kPIT_Chnl_0, kPIT_TimerFlag);
     __DSB();

--- a/firmware/source/io/buttons.c
+++ b/firmware/source/io/buttons.c
@@ -26,8 +26,21 @@ static uint32_t old_button_state;
 volatile bool PTTLocked = false;
 
 #if defined(PLATFORM_GD77S)
-static bool orangeButtonPressed;
-static bool orangeButtonReleased;
+typedef enum
+{
+	MBUTTON_ORANGE,
+	MBUTTON_SK1,
+	MBUTTON_SK2,
+	MBUTTON_MAX
+} MBUTTON_t;
+
+typedef enum
+{
+	MBUTTON_STATE_PRESSED,
+	MBUTTON_STATE_RELEASED
+} MBUTTON_STATE_t;
+
+static bool mbuttons[MBUTTON_MAX][MBUTTON_STATE_RELEASED + 1];
 #endif
 
 void buttonsInit(void)
@@ -37,9 +50,6 @@ void buttonsInit(void)
     PORT_SetPinMux(Port_SK2, Pin_SK2, kPORT_MuxAsGpio);
 #if ! defined(PLATFORM_RD5R)
     PORT_SetPinMux(Port_Orange, Pin_Orange, kPORT_MuxAsGpio);
-#if defined(PLATFORM_GD77S)
-#endif
-
 #endif
 
     GPIO_PinInit(GPIO_PTT, Pin_PTT, &pin_config_input);
@@ -47,100 +57,125 @@ void buttonsInit(void)
     GPIO_PinInit(GPIO_SK2, Pin_SK2, &pin_config_input);
 #if ! defined(PLATFORM_RD5R)
     GPIO_PinInit(GPIO_Orange, Pin_Orange, &pin_config_input);
-
-#if defined(PLATFORM_GD77S)
-    orangeButtonPressed = false;
-    orangeButtonReleased = true;
 #endif
 
+#if defined(PLATFORM_GD77S)
+    // Reset Orange/SK1/SK2 buttons state
+    for (uint8_t i = 0; i < MBUTTON_MAX; i++)
+    {
+    	mbuttons[i][MBUTTON_STATE_PRESSED] = false;
+    	mbuttons[i][MBUTTON_STATE_RELEASED] = true;
+    }
 #endif
 
     old_button_state = 0;
 }
+
+#if defined(PLATFORM_GD77S)
+static void checkMButtonstate(MBUTTON_t mbutton)
+{
+	if (mbuttons[mbutton][MBUTTON_STATE_RELEASED] && (mbuttons[mbutton][MBUTTON_STATE_PRESSED] == false))
+	{
+		taskENTER_CRITICAL();
+		timer_mbuttons[mbutton] = (nonVolatileSettings.keypadTimerLong * 1000);
+		taskEXIT_CRITICAL();
+
+		mbuttons[mbutton][MBUTTON_STATE_PRESSED] = true;
+		mbuttons[mbutton][MBUTTON_STATE_RELEASED] = false;
+	}
+}
+#endif
 
 uint32_t buttonsRead(void)
 {
 	uint32_t result = BUTTON_NONE;
 
 #if ! defined(PLATFORM_RD5R)
-	if (GPIO_PinRead(GPIO_Orange, Pin_Orange)==0)
+	if (GPIO_PinRead(GPIO_Orange, Pin_Orange) == 0)
 	{
 		result |= BUTTON_ORANGE;
 
 #if defined(PLATFORM_GD77S)
-		if (orangeButtonReleased && (orangeButtonPressed == false))
-		{
-			taskENTER_CRITICAL();
-			timer_keypad = (nonVolatileSettings.keypadTimerLong * 1000);
-			taskEXIT_CRITICAL();
-
-			orangeButtonPressed = true;
-			orangeButtonReleased = false;
-		}
+		checkMButtonstate(MBUTTON_ORANGE);
 #endif
-
 	}
-#endif
+#endif // ! PLATFORM_RD5R
 
-	if (GPIO_PinRead(GPIO_PTT, Pin_PTT)==0)
+	if (GPIO_PinRead(GPIO_PTT, Pin_PTT) == 0)
 	{
 		result |= BUTTON_PTT;
 	}
 
-	if (GPIO_PinRead(GPIO_SK1, Pin_SK1)==0)
+	if (GPIO_PinRead(GPIO_SK1, Pin_SK1) == 0)
 	{
 		result |= BUTTON_SK1;
+
+#if defined(PLATFORM_GD77S)
+		checkMButtonstate(MBUTTON_SK1);
+#endif
 	}
 
-	if (GPIO_PinRead(GPIO_SK2, Pin_SK2)==0)
+	if (GPIO_PinRead(GPIO_SK2, Pin_SK2) == 0)
 	{
 		result |= BUTTON_SK2;
-	}
 
+#if defined(PLATFORM_GD77S)
+		checkMButtonstate(MBUTTON_SK2);
+#endif
+	}
 
 	return result;
 }
+
+#if defined(PLATFORM_GD77S)
+static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonID, uint32_t buttonLong)
+{
+	taskENTER_CRITICAL();
+	uint32_t tmp_timer_mbutton = timer_mbuttons[mbutton];
+	taskEXIT_CRITICAL();
+
+	if ((*buttons & buttonID) && mbuttons[mbutton][MBUTTON_STATE_PRESSED] && (mbuttons[mbutton][MBUTTON_STATE_RELEASED] == false) && (tmp_timer_mbutton == 0))
+	{
+		// Long press
+		mbuttons[mbutton][MBUTTON_STATE_RELEASED] = true;
+		// Set LONG bit
+		*buttons |= (buttonID | buttonLong);
+	}
+	else if (((*buttons & buttonID) == 0) && mbuttons[mbutton][MBUTTON_STATE_PRESSED] && (mbuttons[mbutton][MBUTTON_STATE_RELEASED] == false) && (tmp_timer_mbutton != 0))
+	{
+		// Short press/release cycle
+		mbuttons[mbutton][MBUTTON_STATE_PRESSED] = false;
+		mbuttons[mbutton][MBUTTON_STATE_RELEASED] = true;
+
+		taskENTER_CRITICAL();
+		timer_mbuttons[mbutton] = 0;
+		taskEXIT_CRITICAL();
+
+		// Set SHORT press
+		*buttons |= buttonID;
+		*buttons &= ~buttonLong;
+	}
+	else if (((*buttons & buttonID) == 0) && mbuttons[mbutton][MBUTTON_STATE_PRESSED] && mbuttons[mbutton][MBUTTON_STATE_RELEASED])
+	{
+		// Button was still down after a long press, now handle release
+		mbuttons[mbutton][MBUTTON_STATE_PRESSED] = false;
+	}
+	else
+	{
+		// Hide Orange state, as short will happen on press/release cycle
+		*buttons &= ~(buttonID | buttonLong);
+	}
+}
+#endif
 
 void buttonsCheckButtonsEvent(uint32_t *buttons, int *event)
 {
 	*buttons = buttonsRead();
 
 #if defined(PLATFORM_GD77S)
-	taskENTER_CRITICAL();
-	uint32_t tmp_timer_keypad = timer_keypad;
-	taskEXIT_CRITICAL();
-
-	if ((*buttons & BUTTON_ORANGE) && orangeButtonPressed && (orangeButtonReleased == false) && (tmp_timer_keypad == 0))
-	{
-		// Long press
-		orangeButtonReleased = true;
-		// Set LONG bit
-		*buttons |= (BUTTON_ORANGE | BUTTON_ORANGE_LONG);
-	}
-	else if (((*buttons & BUTTON_ORANGE) == 0) && orangeButtonPressed && (orangeButtonReleased == false) && (tmp_timer_keypad != 0))
-	{
-		// Short press/release cycle
-		orangeButtonPressed = false;
-		orangeButtonReleased = true;
-
-		taskENTER_CRITICAL();
-		timer_keypad = 0;
-		taskEXIT_CRITICAL();
-
-		// Set SHORT press
-		*buttons |= BUTTON_ORANGE;
-		*buttons &= ~BUTTON_ORANGE_LONG;
-	}
-	else if (((*buttons & BUTTON_ORANGE) == 0) && orangeButtonPressed && orangeButtonReleased)
-	{
-		// Button was still down after a long press, now handle release
-		orangeButtonPressed = false;
-	}
-	else
-	{
-		// Hide Orange state, as short will happen on press/release cycle
-		*buttons &= ~(BUTTON_ORANGE | BUTTON_ORANGE_LONG);
-	}
+	checkMButtons(buttons, MBUTTON_ORANGE, BUTTON_ORANGE, BUTTON_ORANGE_LONG);
+	checkMButtons(buttons, MBUTTON_SK1, BUTTON_SK1, BUTTON_SK1_LONG);
+	checkMButtons(buttons, MBUTTON_SK2, BUTTON_SK2, BUTTON_SK2_LONG);
 #endif
 
 	if (old_button_state != *buttons)

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -557,12 +557,6 @@ void mainTask(void *data)
 						}
 						if (!wasScanning)
 						{
-#if defined(PLATFORM_GD77S)
-							if (isInSettingsForGD77S())
-							{
-								leaveSettingsForGS77S();
-							}
-#endif
 							menuSystemPushNewMenu(UI_TX_SCREEN);
 						}
 					}

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -966,11 +966,6 @@ static void handleEventForGD77S(uiEvent_t *ev)
 					GD77SParameters.inSettings = GD77S_SETTINGS_ZONE;
 
 					buildSpeechSettingsFormGD77S(buf, 0U, GD77SParameters.inSettings);
-					if (buf[0U] != 0U)
-					{
-						speechSynthesisSpeak(buf);
-					}
-					return;
 					break;
 
 				case GD77S_SETTINGS_POWER: // Power
@@ -1009,11 +1004,6 @@ static void handleEventForGD77S(uiEvent_t *ev)
 						GD77SParameters.inSettings = GD77S_SETTINGS_ZONE;
 
 						buildSpeechSettingsFormGD77S(buf, 0U, GD77SParameters.inSettings);
-						if (buf[0U] != 0U)
-						{
-							speechSynthesisSpeak(buf);
-						}
-						return;
 						break;
 
 					case GD77S_SETTINGS_POWER: // Power


### PR DESCRIPTION
+ Have access to battery level in settings mode.
+ Announce timeslot: after ID_CODE xxxx KEY 1/2.
+ Group GD77S parameters into a struct.
+ Add long press state to SK1 and SK2 (ORANGE was already supported).
  * We can operate the GD77S, even in settings mode.
    New key assignments:
       * **SK1**: channel announce,
       * **SK1 Long**: "**+**" in settings,
       * **SK2**: instant channel setting on RX (like on the other platforms),
       * **SK2 Long**: "**-**" in settings.

Booleans to bitfield replacement has been pushed.

