### PR TITLE
Extend AudioAssist

### DIFF
--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -49,7 +49,16 @@ extern int menuDisplayLightTimer;
 extern int uiPrivateCallState;
 extern int uiPrivateCallLastID;
 
-typedef int (*menuFunctionPointer_t)(uiEvent_t *, bool); // Typedef for menu function pointers.  Functions are passed the key, the button and the event data. Event can be a Key or a button or both. Last arg is for when the function is only called to initialise and display its screen.
+typedef enum
+{
+	MENU_STATUS_SUCCESS     = 0,
+	MENU_STATUS_ERROR       = (1 << 0),
+	MENU_STATUS_LIST_TYPE   = (1 << 1),
+	MENU_STATUS_INPUT_TYPE  = (1 << 2),
+	MENU_STATUS_FORCE_FIRST = (1 << 3)
+} menuStatus_t;
+
+typedef menuStatus_t (*menuFunctionPointer_t)(uiEvent_t *, bool); // Typedef for menu function pointers.  Functions are passed the key, the button and the event data. Event can be a Key or a button or both. Last arg is for when the function is only called to initialise and display its screen.
 typedef struct menuControlDataStruct
 {
 	int currentMenuNumber;
@@ -91,7 +100,9 @@ void menuSystemLanguageHasChanged(void);
 void displayLightTrigger(void);
 void displayLightOverrideTimeout(int timeout);
 void menuSystemPushNewMenu(int menuNumber);
+#if 0 // Unused
 void menuSystemPushNewMenuWithQuickFunction(int menuNumber, int quickFunction);
+#endif
 
 void menuSystemSetCurrentMenu(int menuNumber);
 int menuSystemGetCurrentMenuNumber(void);
@@ -189,33 +200,33 @@ extern const menuItemsList_t menuDataContact;
 extern const menuItemsList_t menuDataContactContact;
 extern const menuItemsList_t * menusData[];
 
-int uiVFOMode(uiEvent_t *event, bool isFirstRun);
-int uiVFOModeQuickMenu(uiEvent_t *event, bool isFirstRun);
-int uiChannelMode(uiEvent_t *event, bool isFirstRun);
-int uiChannelModeQuickMenu(uiEvent_t *event, bool isFirstRun);
-int uiCPS(uiEvent_t *event, bool isFirstRun);
-int uiSplashScreen(uiEvent_t *event, bool isFirstRun);
-int uiPowerOff(uiEvent_t *event, bool isFirstRun);
-int menuZoneList(uiEvent_t *event, bool isFirstRun);
-int menuDisplayMenuList(uiEvent_t *event, bool isFirstRun);
-int menuBattery(uiEvent_t *event, bool isFirstRun);
+menuStatus_t uiVFOMode(uiEvent_t *event, bool isFirstRun);
+menuStatus_t uiVFOModeQuickMenu(uiEvent_t *event, bool isFirstRun);
+menuStatus_t uiChannelMode(uiEvent_t *event, bool isFirstRun);
+menuStatus_t uiChannelModeQuickMenu(uiEvent_t *event, bool isFirstRun);
+menuStatus_t uiCPS(uiEvent_t *event, bool isFirstRun);
+menuStatus_t uiSplashScreen(uiEvent_t *event, bool isFirstRun);
+menuStatus_t uiPowerOff(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuZoneList(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuDisplayMenuList(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuBattery(uiEvent_t *event, bool isFirstRun);
 
-int menuFirmwareInfoScreen(uiEvent_t *event, bool isFirstRun);
-int menuNumericalEntry(uiEvent_t *event, bool isFirstRun);
-int menuTxScreen(uiEvent_t *event, bool isFirstRun);
-int menuRSSIScreen(uiEvent_t *event, bool isFirstRun);
-int menuLastHeard(uiEvent_t *event, bool isFirstRun);
-int menuOptions(uiEvent_t *event, bool isFirstRun);
-int menuDisplayOptions(uiEvent_t *event, bool isFirstRun);
-int menuSoundOptions(uiEvent_t *event, bool isFirstRun);
-int menuCredits(uiEvent_t *event, bool isFirstRun);
-int menuChannelDetails(uiEvent_t *event, bool isFirstRun);
-int menuHotspotMode(uiEvent_t *event, bool isFirstRun);
-int menuLockScreen(uiEvent_t *event, bool isFirstRun);
-int menuContactList(uiEvent_t *event, bool isFirstRun);
-int menuContactListSubMenu(uiEvent_t *event, bool isFirstRun);
-int menuContactDetails(uiEvent_t *event, bool isFirstRun);
-int menuLanguage(uiEvent_t *event, bool isFirstRun);
-int menuPrivateCall(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuFirmwareInfoScreen(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuNumericalEntry(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuTxScreen(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuRSSIScreen(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuLastHeard(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuOptions(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuDisplayOptions(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuSoundOptions(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuCredits(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuChannelDetails(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuHotspotMode(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuLockScreen(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuContactList(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuContactListSubMenu(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuContactDetails(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuLanguage(uiEvent_t *event, bool isFirstRun);
+menuStatus_t menuPrivateCall(uiEvent_t *event, bool isFirstRun);
 
 #endif

--- a/firmware/source/hotspot/uiHotspot.c
+++ b/firmware/source/hotspot/uiHotspot.c
@@ -335,7 +335,7 @@ static void sendDebug5(const char *text, int16_t n1, int16_t n2, int16_t n3, int
 #endif
 
 
-int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -435,7 +435,7 @@ int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 		{
 			if (handleEvent(ev) == false)
 			{
-				return 0;
+				return MENU_STATUS_SUCCESS;
 			}
 		}
 	}
@@ -457,7 +457,7 @@ int menuHotspotMode(uiEvent_t *ev, bool isFirstRun)
 		}
 	}
 
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 void menuHotspotRestoreSettings(void)

--- a/firmware/source/user_interface/menuBattery.c
+++ b/firmware/source/user_interface/menuBattery.c
@@ -94,7 +94,7 @@ static size_t circularBufferGetData(voltageCircularBuffer_t *cb, int32_t *data, 
      return count;
 }
 
-int menuBattery(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuBattery(uiEvent_t *ev, bool isFirstRun)
 {
 	static uint32_t m = 0;
 
@@ -118,7 +118,7 @@ int menuBattery(uiEvent_t *ev, bool isFirstRun)
 		if (ev->hasEvent)
 			handleEvent(ev);
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void updateScreen(bool forceRedraw)
@@ -284,7 +284,7 @@ static void handleEvent(uiEvent_t *ev)
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_PRESS(ev->keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -41,6 +41,8 @@ static struct_codeplugChannel_t tmpChannel;// update a temporary copy of the cha
 static char channelName[17];
 static int namePos;
 
+static menuStatus_t menuChannelDetailsExitCode = MENU_STATUS_SUCCESS;
+
 
 enum CHANNEL_DETAILS_DISPLAY_LIST { CH_DETAILS_NAME = 0,
 									CH_DETAILS_RXFREQ, CH_DETAILS_TXFREQ,
@@ -233,7 +235,7 @@ static void cssDecrementFromEvent(uiEvent_t *ev, uint16_t *tone, int32_t *index,
 	}
 }
 
-int menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -272,14 +274,18 @@ int menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
 
 		updateScreen();
 		updateCursor(true);
+
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuChannelDetailsExitCode = MENU_STATUS_SUCCESS;
+
 		updateCursor(false);
 		if (ev->hasEvent)
 			handleEvent(ev);
 	}
-	return 0;
+	return menuChannelDetailsExitCode;
 }
 
 static void updateCursor(bool moved)
@@ -549,13 +555,15 @@ static void handleEvent(uiEvent_t *ev)
 
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN))
 	{
-		 menuSystemMenuIncrement(&gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
+		menuSystemMenuIncrement(&gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
 		updateScreen();
+		menuChannelDetailsExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		menuSystemMenuDecrement(&gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
 		updateScreen();
+		menuChannelDetailsExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 	{

--- a/firmware/source/user_interface/menuContactDetails.c
+++ b/firmware/source/user_interface/menuContactDetails.c
@@ -43,7 +43,7 @@ static int menuContactDetailsState;
 static int menuContactDetailsTimeout;
 enum MENU_CONTACT_DETAILS_STATE {MENU_CONTACT_DETAILS_DISPLAY=0, MENU_CONTACT_DETAILS_SAVED, MENU_CONTACT_DETAILS_EXISTS};
 
-int menuContactDetails(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuContactDetails(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -76,6 +76,8 @@ int menuContactDetails(uiEvent_t *ev, bool isFirstRun)
 
 		updateScreen();
 		updateCursor(true);
+
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
@@ -86,7 +88,7 @@ int menuContactDetails(uiEvent_t *ev, bool isFirstRun)
 
 		}
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void updateCursor(bool moved)

--- a/firmware/source/user_interface/menuContactList.c
+++ b/firmware/source/user_interface/menuContactList.c
@@ -29,6 +29,7 @@ static int contactCallType;
 static int menuContactListDisplayState;
 static int menuContactListTimeout;
 static int menuContactListOverrideState = 0;
+static menuStatus_t menuContactListExitCode = MENU_STATUS_SUCCESS;
 
 enum MENU_CONTACT_LIST_STATE
 {
@@ -51,7 +52,7 @@ static void reloadContactList(void)
 	}
 }
 
-int menuContactList(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuContactList(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -73,15 +74,18 @@ int menuContactList(uiEvent_t *ev, bool isFirstRun)
 		}
 
 		updateScreen();
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuContactListExitCode = MENU_STATUS_SUCCESS;
+
 		if (ev->hasEvent || (menuContactListTimeout > 0))
 		{
 			handleEvent(ev);
 		}
 	}
-	return 0;
+	return menuContactListExitCode;
 }
 
 static void updateScreen(void)
@@ -152,6 +156,7 @@ static void handleEvent(uiEvent_t *ev)
 					gMenusCurrentItemIndex + 1, contactCallType,
 					&contactListContactData);
 			updateScreen();
+			menuContactListExitCode |= MENU_STATUS_LIST_TYPE;
 		}
 		else if (KEYCHECK_PRESS(ev->keys, KEY_UP))
 		{
@@ -160,6 +165,7 @@ static void handleEvent(uiEvent_t *ev)
 					gMenusCurrentItemIndex + 1, contactCallType,
 					&contactListContactData);
 			updateScreen();
+			menuContactListExitCode |= MENU_STATUS_LIST_TYPE;
 		}
 		else if (KEYCHECK_SHORTUP(ev->keys, KEY_HASH))
 		{
@@ -319,17 +325,18 @@ static void handleSubMenuEvent(uiEvent_t *ev)
 	}
 }
 
-int menuContactListSubMenu(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuContactListSubMenu(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
 		updateSubMenuScreen();
 		keyboardInit();
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
 		if (ev->hasEvent)
 			handleSubMenuEvent(ev);
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }

--- a/firmware/source/user_interface/menuCredits.c
+++ b/firmware/source/user_interface/menuCredits.c
@@ -32,7 +32,7 @@ const int NUM_CREDITS = 7;
 static const char *creditTexts[] = {"Roger VK3KYY","Daniel F1RMB","Dzmitry EW1ADG","Colin G4EML","Alex DL4LEX","Kai DG4KLU","Jason VK7ZJA"};
 static int currentDisplayIndex=0;
 
-int menuCredits(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuCredits(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -53,7 +53,7 @@ int menuCredits(uiEvent_t *ev, bool isFirstRun)
 		}
 */
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void updateScreen(void)

--- a/firmware/source/user_interface/menuDisplayMenuList.c
+++ b/firmware/source/user_interface/menuDisplayMenuList.c
@@ -22,7 +22,9 @@
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
-int menuDisplayMenuList(uiEvent_t *ev, bool isFirstRun)
+static menuStatus_t menuDisplayListExitCode = MENU_STATUS_SUCCESS;
+
+menuStatus_t menuDisplayMenuList(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -30,15 +32,18 @@ int menuDisplayMenuList(uiEvent_t *ev, bool isFirstRun)
 		gMenuCurrentMenuList = (menuItemNewData_t *)menusData[currentMenuNumber]->items;
 		gMenusEndIndex = menusData[currentMenuNumber]->numItems;
 		updateScreen();
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuDisplayListExitCode = MENU_STATUS_SUCCESS;
+
 		if (ev->hasEvent)
 		{
 			handleEvent(ev);
 		}
 	}
-	return 0;
+	return menuDisplayListExitCode;
 }
 
 static void updateScreen(void)
@@ -73,11 +78,13 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		menuSystemMenuIncrement(&gMenusCurrentItemIndex, gMenusEndIndex);
 		updateScreen();
+		menuDisplayListExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		menuSystemMenuDecrement(&gMenusCurrentItemIndex, gMenusEndIndex);
 		updateScreen();
+		menuDisplayListExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{

--- a/firmware/source/user_interface/menuDisplayOptions.c
+++ b/firmware/source/user_interface/menuDisplayOptions.c
@@ -26,6 +26,8 @@ static void handleEvent(uiEvent_t *ev);
 static void updateBacklightMode(uint8_t mode);
 static void setDisplayInvert(bool invert);
 
+static menuStatus_t menuDisplayOptionsExitCode = MENU_STATUS_SUCCESS;
+
 static const int BACKLIGHT_MAX_TIMEOUT = 30;
 #if defined (PLATFORM_RD5R)
 	static const int CONTRAST_MAX_VALUE = 10;// Maximum value which still seems to be readable
@@ -47,7 +49,7 @@ enum DISPLAY_MENU_LIST { 	DISPLAY_MENU_BRIGHTNESS = 0, DISPLAY_MENU_BRIGHTNESS_O
 							NUM_DISPLAY_MENU_ITEMS};
 
 
-int menuDisplayOptions(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuDisplayOptions(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -55,13 +57,16 @@ int menuDisplayOptions(uiEvent_t *ev, bool isFirstRun)
 		memcpy(&originalNonVolatileSettings, &nonVolatileSettings, sizeof(settingsStruct_t));
 
 		updateScreen();
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuDisplayOptionsExitCode = MENU_STATUS_SUCCESS;
+
 		if (ev->hasEvent)
 			handleEvent(ev);
 	}
-	return 0;
+	return menuDisplayOptionsExitCode;
 }
 
 static void updateScreen(void)
@@ -191,10 +196,12 @@ static void handleEvent(uiEvent_t *ev)
 		if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 		{
 			menuSystemMenuIncrement(&gMenusCurrentItemIndex, NUM_DISPLAY_MENU_ITEMS);
+			menuDisplayOptionsExitCode |= MENU_STATUS_LIST_TYPE;
 		}
 		else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 		{
 			menuSystemMenuDecrement(&gMenusCurrentItemIndex, NUM_DISPLAY_MENU_ITEMS);
+			menuDisplayOptionsExitCode |= MENU_STATUS_LIST_TYPE;
 		}
 		else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 		{

--- a/firmware/source/user_interface/menuFirmwareInfoScreen.c
+++ b/firmware/source/user_interface/menuFirmwareInfoScreen.c
@@ -21,7 +21,7 @@
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
-int menuFirmwareInfoScreen(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuFirmwareInfoScreen(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -34,7 +34,7 @@ int menuFirmwareInfoScreen(uiEvent_t *ev, bool isFirstRun)
 			handleEvent(ev);
 		}
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void updateScreen(void)
@@ -77,12 +77,12 @@ static void handleEvent(uiEvent_t *ev)
 {
 	displayLightTrigger();
 
-	if (KEYCHECK_PRESS(ev->keys,KEY_RED))
+	if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 	{
 		menuSystemPopPreviousMenu();
 		return;
 	}
-	else if (KEYCHECK_PRESS(ev->keys,KEY_GREEN))
+	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{
 		menuSystemPopAllAndDisplayRootMenu();
 		return;

--- a/firmware/source/user_interface/menuLanguage.c
+++ b/firmware/source/user_interface/menuLanguage.c
@@ -22,20 +22,23 @@
 
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
+static menuStatus_t menuLanguageExitCode = MENU_STATUS_SUCCESS;
 
-
-int menuLanguage(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuLanguage(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
 		updateScreen();
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuLanguageExitCode = MENU_STATUS_SUCCESS;
+
 		if (ev->hasEvent)
 			handleEvent(ev);
 	}
-	return 0;
+	return menuLanguageExitCode;
 }
 
 static void updateScreen(void)
@@ -64,11 +67,13 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		menuSystemMenuIncrement(&gMenusCurrentItemIndex, NUM_LANGUAGES);
 		updateScreen();
+		menuLanguageExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		menuSystemMenuDecrement(&gMenusCurrentItemIndex, NUM_LANGUAGES);
 		updateScreen();
+		menuLanguageExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -22,11 +22,12 @@
 
 static const int LAST_HEARD_NUM_LINES_ON_DISPLAY = 3;
 static bool displayLHDetails = false;
+static menuStatus_t menuLastHeardExitCode = MENU_STATUS_SUCCESS;
 
 static void handleEvent(uiEvent_t *ev);
 static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_t now, uint32_t TGorPC, size_t maxLen, bool displayDetails);
 
-int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 {
 	static uint32_t m = 0;
 
@@ -38,9 +39,12 @@ int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 		displayLightTrigger();
 		menuLastHeardUpdateScreen(true, displayLHDetails);
 		m = ev->time;
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuLastHeardExitCode = MENU_STATUS_SUCCESS;
+
 		// do live update by checking if the item at the top of the list has changed
 		if ((gMenusStartIndex != LinkHead->id) || (menuDisplayQSODataState == QSO_DISPLAY_CALLER_DATA))
 		{
@@ -67,7 +71,7 @@ int menuLastHeard(uiEvent_t *ev, bool isFirstRun)
 		}
 
 	}
-	return 0;
+	return menuLastHeardExitCode;
 }
 
 void menuLastHeardUpdateScreen(bool showTitleOrHeader, bool displayDetails)
@@ -139,16 +143,15 @@ static void handleEvent(uiEvent_t *ev)
 {
 	displayLightTrigger();
 
-	if (KEYCHECK_PRESS(ev->keys, KEY_DOWN) && (gMenusEndIndex != 0))
+	if (KEYCHECK_PRESS(ev->keys, KEY_DOWN))
 	{
-		gMenusCurrentItemIndex++;
+		menuSystemMenuIncrement(&gMenusCurrentItemIndex, gMenusEndIndex);
+		menuLastHeardExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys, KEY_UP))
 	{
-		if (gMenusCurrentItemIndex > 0)
-		{
-			gMenusCurrentItemIndex--;
-		}
+		menuSystemMenuDecrement(&gMenusCurrentItemIndex, gMenusEndIndex);
+		menuLastHeardExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys, KEY_RED))
 	{

--- a/firmware/source/user_interface/menuOptions.c
+++ b/firmware/source/user_interface/menuOptions.c
@@ -23,6 +23,8 @@
 
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
+
+static menuStatus_t menuOptionsExitCode = MENU_STATUS_SUCCESS;
 static bool	doFactoryReset;
 enum OPTIONS_MENU_LIST { OPTIONS_MENU_FACTORY_RESET = 0, OPTIONS_MENU_USE_CALIBRATION,
 							OPTIONS_MENU_TX_FREQ_LIMITS,
@@ -33,7 +35,7 @@ enum OPTIONS_MENU_LIST { OPTIONS_MENU_FACTORY_RESET = 0, OPTIONS_MENU_USE_CALIBR
 							OPTIONS_MENU_PRIVATE_CALLS,
 							NUM_OPTIONS_MENU_ITEMS};
 
-int menuOptions(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuOptions(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -41,13 +43,16 @@ int menuOptions(uiEvent_t *ev, bool isFirstRun)
 		// Store original settings, used on cancel event.
 		memcpy(&originalNonVolatileSettings, &nonVolatileSettings, sizeof(settingsStruct_t));
 		updateScreen();
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuOptionsExitCode = MENU_STATUS_SUCCESS;
+
 		if (ev->hasEvent)
 			handleEvent(ev);
 	}
-	return 0;
+	return menuOptionsExitCode;
 }
 
 static void updateScreen(void)
@@ -156,10 +161,12 @@ static void handleEvent(uiEvent_t *ev)
 	if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 	{
 		menuSystemMenuIncrement(&gMenusCurrentItemIndex, NUM_OPTIONS_MENU_ITEMS);
+		menuOptionsExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		menuSystemMenuDecrement(&gMenusCurrentItemIndex, NUM_OPTIONS_MENU_ITEMS);
+		menuOptionsExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 	{

--- a/firmware/source/user_interface/menuRSSIScreen.c
+++ b/firmware/source/user_interface/menuRSSIScreen.c
@@ -26,7 +26,7 @@ static calibrationRSSIMeter_t rssiCalibration;
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
-int menuRSSIScreen(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuRSSIScreen(uiEvent_t *ev, bool isFirstRun)
 {
 	static uint32_t m = 0;
 
@@ -46,7 +46,7 @@ int menuRSSIScreen(uiEvent_t *ev, bool isFirstRun)
 			updateScreen();
 		}
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 

--- a/firmware/source/user_interface/menuSoundOptions.c
+++ b/firmware/source/user_interface/menuSoundOptions.c
@@ -24,25 +24,30 @@
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
+static menuStatus_t menuSoundExitCode = MENU_STATUS_SUCCESS;
+
 enum SOUND_MENU_LIST { OPTIONS_MENU_TIMEOUT_BEEP = 0, OPTIONS_MENU_BEEP_VOLUME, OPTIONS_MENU_DMR_BEEP,
 						OPTIONS_MIC_GAIN_DMR, OPTIONS_MIC_GAIN_FM,
 						OPTIONS_VOX_THRESHOLD, OPTIONS_VOX_TAIL, OPTIONS_AUDIO_PROMPT_MODE,
 						NUM_SOUND_MENU_ITEMS};
 
-int menuSoundOptions(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuSoundOptions(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
 		// Store original settings, used on cancel event.
 		memcpy(&originalNonVolatileSettings, &nonVolatileSettings, sizeof(settingsStruct_t));
 		updateScreen();
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuSoundExitCode = MENU_STATUS_SUCCESS;
+
 		if (ev->hasEvent)
 			handleEvent(ev);
 	}
-	return 0;
+	return menuSoundExitCode;
 }
 
 static void updateScreen(void)
@@ -146,10 +151,12 @@ static void handleEvent(uiEvent_t *ev)
 		if (KEYCHECK_PRESS(ev->keys,KEY_DOWN) && gMenusEndIndex!=0)
 		{
 			menuSystemMenuIncrement(&gMenusCurrentItemIndex, NUM_SOUND_MENU_ITEMS);
+			menuSoundExitCode |= MENU_STATUS_LIST_TYPE;
 		}
 		else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 		{
 			menuSystemMenuDecrement(&gMenusCurrentItemIndex, NUM_SOUND_MENU_ITEMS);
+			menuSoundExitCode |= MENU_STATUS_LIST_TYPE;
 		}
 		else if (KEYCHECK_PRESS(ev->keys,KEY_RIGHT))
 		{

--- a/firmware/source/user_interface/menuZoneList.c
+++ b/firmware/source/user_interface/menuZoneList.c
@@ -24,20 +24,25 @@
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
-int menuZoneList(uiEvent_t *ev, bool isFirstRun)
+static menuStatus_t menuZoneExitCode = MENU_STATUS_SUCCESS;
+
+menuStatus_t menuZoneList(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
 		gMenusEndIndex = codeplugZonesGetCount();
 		gMenusCurrentItemIndex = nonVolatileSettings.currentZone;
 		updateScreen();
+		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
 	}
 	else
 	{
+		menuZoneExitCode = MENU_STATUS_SUCCESS;
+
 		if (ev->hasEvent)
 			handleEvent(ev);
 	}
-	return 0;
+	return menuZoneExitCode;
 }
 
 static void updateScreen(void)
@@ -76,11 +81,13 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		menuSystemMenuIncrement(&gMenusCurrentItemIndex, gMenusEndIndex);
 		updateScreen();
+		menuZoneExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys,KEY_UP))
 	{
 		menuSystemMenuDecrement(&gMenusCurrentItemIndex, gMenusEndIndex);
 		updateScreen();
+		menuZoneExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 	{

--- a/firmware/source/user_interface/uiCPS.c
+++ b/firmware/source/user_interface/uiCPS.c
@@ -28,7 +28,7 @@ static int radioMode;
 static int radioBandWidth;
 
 
-int uiCPS(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t uiCPS(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -48,7 +48,7 @@ int uiCPS(uiEvent_t *ev, bool isFirstRun)
 			handleTick();
 		}
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 void uiCPSUpdate(int command,int x, int y, ucFont_t fontSize, ucTextAlign_t alignment, bool isInverted,char *szMsg)

--- a/firmware/source/user_interface/uiLockScreen.c
+++ b/firmware/source/user_interface/uiLockScreen.c
@@ -29,7 +29,7 @@ static bool lockDisplayed = false;
 static const uint32_t TIMEOUT_MS = 500;
 int lockState = LOCK_NONE;
 
-int menuLockScreen(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuLockScreen(uiEvent_t *ev, bool isFirstRun)
 {
 	static uint32_t m = 0;
 
@@ -55,7 +55,7 @@ int menuLockScreen(uiEvent_t *ev, bool isFirstRun)
 			handleEvent(ev);
 		}
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void redrawScreen(bool update, bool state)

--- a/firmware/source/user_interface/uiPowerOff.c
+++ b/firmware/source/user_interface/uiPowerOff.c
@@ -22,7 +22,7 @@ static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
 
-int uiPowerOff(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t uiPowerOff(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -32,7 +32,7 @@ int uiPowerOff(uiEvent_t *ev, bool isFirstRun)
 	{
 		handleEvent(ev);
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void updateScreen(void)

--- a/firmware/source/user_interface/uiPrivateCall.c
+++ b/firmware/source/user_interface/uiPrivateCall.c
@@ -27,7 +27,7 @@ static void handleEvent(uiEvent_t *ev);
 int uiPrivateCallState = NOT_IN_CALL;
 int uiPrivateCallLastID;
 
-int menuPrivateCall(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuPrivateCall(uiEvent_t *ev, bool isFirstRun)
 {
 	if (isFirstRun)
 	{
@@ -45,7 +45,7 @@ int menuPrivateCall(uiEvent_t *ev, bool isFirstRun)
 			handleEvent(ev);
 		}
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void updateScreen(void)

--- a/firmware/source/user_interface/uiSplashScreen.c
+++ b/firmware/source/user_interface/uiSplashScreen.c
@@ -21,7 +21,7 @@
 static void updateScreen(void);
 static void handleEvent(uiEvent_t *ev);
 
-int uiSplashScreen(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t uiSplashScreen(uiEvent_t *ev, bool isFirstRun)
 {
 	uint8_t melodyBuf[512];
 
@@ -50,7 +50,7 @@ int uiSplashScreen(uiEvent_t *ev, bool isFirstRun)
 		handleEvent(ev);
 	}
 
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void updateScreen(void)

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -33,7 +33,7 @@ static bool isShowingLastHeard;
 extern bool PTTToggledDown;
 static bool startBeepPlayed;
 
-int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
+menuStatus_t menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 {
 	static uint32_t m = 0, micm = 0, mto = 0;
 
@@ -181,7 +181,7 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 		if ((currentChannelData->tot != 0) && (timeInSeconds == 0))
 		{
 			if ((ev->time - mto) < 500)
-				return 0;
+				return MENU_STATUS_SUCCESS;
 		}
 
 
@@ -195,7 +195,7 @@ int menuTxScreen(uiEvent_t *ev, bool isFirstRun)
 			m = ev->time;
 		}
 	}
-	return 0;
+	return MENU_STATUS_SUCCESS;
 }
 
 static void updateScreen(void)
@@ -278,7 +278,7 @@ static void handleEvent(uiEvent_t *ev)
 		if (PTTToggledDown == false)
 		{
 			// Send 1750Hz
-			if ((ev->buttons & BUTTON_SK2) != 0)
+			if (ev->buttons & BUTTON_SK2)
 			{
 				trxIsTransmittingTone = true;
 				trxSetTone1(1750);


### PR DESCRIPTION
Special beeps to every list + special beep for TG/PC/DMRId inputs.
Fix beep and SK2+Function.
Reset beep sound to default if we are scanning, otherwise the AudioAssist one could be played instead.
Add FIRST beep when VFO A is selected.
Handle key repeat.