### PR TITLE
Re-introduce button short/long press.

### DIFF
--- a/firmware/include/io/buttons.h
+++ b/firmware/include/io/buttons.h
@@ -65,19 +65,23 @@
 
 #endif
 
-#define BUTTON_NONE        0x00000000
-#define BUTTON_PTT         0x00000001
-#define BUTTON_SK1         0x00000002
-#define BUTTON_SK2         0x00000004
-#if !defined(PLATFORM_RD5R)
-#define BUTTON_ORANGE      0x00000008
+#define BUTTON_NONE             0x00000000
+#define BUTTON_PTT              0x00000001
+#define BUTTON_SK1              0x00000002
+#define BUTTON_SK1_SHORT_UP     0x00000004
+#define BUTTON_SK1_LONG_DOWN    0x00000008
+#define BUTTON_SK2              0x00000010
+#define BUTTON_SK2_SHORT_UP     0x00000020
+#define BUTTON_SK2_LONG_DOWN    0x00000040
+#if ! defined(PLATFORM_RD5R)
+#define BUTTON_ORANGE           0x00000080
+#define BUTTON_ORANGE_SHORT_UP  0x00000100
 
 // Long press
-#define BUTTON_ORANGE_LONG 0x00000010
+#if defined(PLATFORM_GD77S)
+#define BUTTON_ORANGE_LONG_DOWN 0x00000200
 #endif
-
-#define BUTTON_SK1_LONG    0x00000020
-#define BUTTON_SK2_LONG    0x00000040
+#endif // ! PLATFORM_RD5R
 
 #define EVENT_BUTTON_NONE   0
 #define EVENT_BUTTON_CHANGE 1
@@ -86,6 +90,6 @@ extern volatile bool PTTLocked;
 
 void buttonsInit(void);
 uint32_t buttonsRead(void);
-void buttonsCheckButtonsEvent(uint32_t *buttons, int *event);
+void buttonsCheckButtonsEvent(uint32_t *buttons, int *event, bool keyIsDown);
 
 #endif /* _FW_BUTTONS_H_ */

--- a/firmware/include/io/buttons.h
+++ b/firmware/include/io/buttons.h
@@ -78,9 +78,7 @@
 #define BUTTON_ORANGE_SHORT_UP  0x00000100
 
 // Long press
-#if defined(PLATFORM_GD77S)
 #define BUTTON_ORANGE_LONG_DOWN 0x00000200
-#endif
 #endif // ! PLATFORM_RD5R
 
 #define EVENT_BUTTON_NONE   0

--- a/firmware/include/user_interface/menuSystem.h
+++ b/firmware/include/user_interface/menuSystem.h
@@ -42,6 +42,12 @@ typedef struct
 
 #define MENU_MAX_DISPLAYED_ENTRIES 3
 
+// Short press event
+#define BUTTONCHECK_SHORTUP(e, sk) (((e)->keys.key == 0) && ((e)->buttons & sk ## _SHORT_UP))
+// Long press event
+#define BUTTONCHECK_LONGDOWN(e, sk) (((e)->keys.key == 0) && ((e)->buttons & sk ## _LONG_DOWN))
+// SK*/ORANGE button is down, regardless event status
+#define BUTTONCHECK_DOWN(e, sk) (((e)->buttons & sk))
 
 
 extern bool uiChannelModeScanActive;

--- a/firmware/source/interfaces/pit.c
+++ b/firmware/source/interfaces/pit.c
@@ -26,10 +26,8 @@ volatile uint32_t timer_keypad;
 volatile uint32_t timer_keypad_timeout;
 volatile uint32_t PITCounter;
 
-//#if defined(PLATFORM_GD77S)
 volatile uint32_t timer_mbuttons[3];
 volatile uint32_t timer_mbuttons_timeout[3];
-//#endif
 
 void init_pit(void)
 {
@@ -40,10 +38,8 @@ void init_pit(void)
 	timer_watchdogtask=0;
 	timer_keypad=0;
 	timer_keypad_timeout=0;
-//#if defined(PLATFORM_GD77S)
 	timer_mbuttons[0] = timer_mbuttons[1] = timer_mbuttons[2] = 0;
 	timer_mbuttons_timeout[0] = timer_mbuttons_timeout[1] = timer_mbuttons_timeout[1] = 0;
-//#endif
 	taskEXIT_CRITICAL();
 
 	pit_config_t pitConfig;
@@ -86,7 +82,6 @@ void PIT0_IRQHandler(void)
 	{
 		timer_keypad_timeout--;
 	}
-//#if defined(PLATFORM_GD77S)
 	if (timer_mbuttons[0]>0)
 	{
 		timer_mbuttons[0]--;
@@ -111,7 +106,6 @@ void PIT0_IRQHandler(void)
 	{
 		timer_mbuttons_timeout[2]--;
 	}
-//#endif
 
     /* Clear interrupt flag.*/
     PIT_ClearStatusFlags(PIT, kPIT_Chnl_0, kPIT_TimerFlag);

--- a/firmware/source/io/buttons.c
+++ b/firmware/source/io/buttons.c
@@ -89,9 +89,7 @@ uint32_t buttonsRead(void)
 	if (GPIO_PinRead(GPIO_Orange, Pin_Orange) == 0)
 	{
 		result |= BUTTON_ORANGE;
-#if defined(PLATFORM_GD77S)
 		checkMButtonState(MBUTTON_ORANGE);
-#endif
 	}
 #endif // ! PLATFORM_RD5R
 
@@ -138,11 +136,6 @@ static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonI
 			// Set LONG bit
 			*buttons |= buttonLong;
 		}
-		else
-		{
-			// Still not a short or long press
-			//*buttons &= ~buttonID;
-		}
 	}
 	else if (((*buttons & buttonID) == 0) && isMButtonPressed(mbutton) && (isMButtonLong(mbutton) == false) && (tmp_timer_mbutton != 0))
 	{
@@ -173,9 +166,9 @@ void buttonsCheckButtonsEvent(uint32_t *buttons, int *event, bool keyIsDown)
 {
 	*buttons = buttonsRead();
 
-#if defined(PLATFORM_GD77S)
+#if ! defined(PLATFORM_RD5R)
 	checkMButtons(buttons, MBUTTON_ORANGE, BUTTON_ORANGE, BUTTON_ORANGE_SHORT_UP, BUTTON_ORANGE_LONG_DOWN);
-#endif
+#endif // ! PLATFORM_RD5R
 	checkMButtons(buttons, MBUTTON_SK1, BUTTON_SK1, BUTTON_SK1_SHORT_UP, BUTTON_SK1_LONG_DOWN);
 	checkMButtons(buttons, MBUTTON_SK2, BUTTON_SK2, BUTTON_SK2_SHORT_UP, BUTTON_SK2_LONG_DOWN);
 
@@ -186,20 +179,14 @@ void buttonsCheckButtonsEvent(uint32_t *buttons, int *event, bool keyIsDown)
 				( (*buttons & BUTTON_SK1_SHORT_UP) || (*buttons & BUTTON_SK1_LONG_DOWN)
 						|| (*buttons & BUTTON_SK2_SHORT_UP) || (*buttons & BUTTON_SK2_LONG_DOWN)
 #if ! defined(PLATFORM_RD5R)
-						|| (*buttons & BUTTON_ORANGE_SHORT_UP)
-#if defined(PLATFORM_GD77S)
-						|| (*buttons & BUTTON_ORANGE_LONG_DOWN)
-#endif
+						|| (*buttons & BUTTON_ORANGE_SHORT_UP) || (*buttons & BUTTON_ORANGE_LONG_DOWN)
 #endif // ! PLATFORM_RD5R
 				) )
 		{
 			// Clear shortup/longdown bits
 			*buttons &= ~(BUTTON_SK1_SHORT_UP | BUTTON_SK1_LONG_DOWN | BUTTON_SK2_SHORT_UP | BUTTON_SK2_LONG_DOWN
 #if ! defined(PLATFORM_RD5R)
-					| BUTTON_ORANGE_SHORT_UP
-#if defined(PLATFORM_GD77S)
-					| BUTTON_ORANGE_LONG_DOWN
-#endif
+					| BUTTON_ORANGE_SHORT_UP | BUTTON_ORANGE_LONG_DOWN
 #endif // ! PLATFORM_RD5R
 			);
 

--- a/firmware/source/io/buttons.c
+++ b/firmware/source/io/buttons.c
@@ -27,7 +27,6 @@ volatile bool PTTLocked = false;
 
 #define MBUTTON_PRESSED  0x01
 #define MBUTTON_LONG     0x02
-#define MBUTTON_DOWN     0x04 // Maybe not needed
 
 typedef enum
 {
@@ -37,7 +36,7 @@ typedef enum
 	MBUTTON_MAX
 } MBUTTON_t;
 
-static uint16_t mbuttons;
+static uint8_t mbuttons;
 
 void buttonsInit(void)
 {
@@ -61,12 +60,12 @@ void buttonsInit(void)
 
 static bool isMButtonPressed(MBUTTON_t mbutton)
 {
-     return (((mbuttons >> (mbutton * 3)) & MBUTTON_PRESSED) & MBUTTON_PRESSED);
+     return (((mbuttons >> (mbutton * 2)) & MBUTTON_PRESSED) & MBUTTON_PRESSED);
 }
 
 static bool isMButtonLong(MBUTTON_t mbutton)
 {
-     return (((mbuttons >> (mbutton * 3)) & MBUTTON_LONG) & MBUTTON_LONG);
+     return (((mbuttons >> (mbutton * 2)) & MBUTTON_LONG) & MBUTTON_LONG);
 }
 
 static void checkMButtonState(MBUTTON_t mbutton)
@@ -77,8 +76,8 @@ static void checkMButtonState(MBUTTON_t mbutton)
 		timer_mbuttons[mbutton] = (nonVolatileSettings.keypadTimerLong * 1000);
 		taskEXIT_CRITICAL();
 
-		mbuttons |= (MBUTTON_PRESSED << (mbutton * 3));
-		mbuttons &= ~(MBUTTON_LONG << (mbutton * 3));
+		mbuttons |= (MBUTTON_PRESSED << (mbutton * 2));
+		mbuttons &= ~(MBUTTON_LONG << (mbutton * 2));
 	}
 }
 
@@ -134,7 +133,7 @@ static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonI
 		if (tmp_timer_mbutton == 0)
 		{
 			// Long press
-			mbuttons |= (MBUTTON_LONG << (mbutton * 3));
+			mbuttons |= (MBUTTON_LONG << (mbutton * 2));
 
 			// Set LONG bit
 			*buttons |= buttonLong;
@@ -148,8 +147,8 @@ static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonI
 	else if (((*buttons & buttonID) == 0) && isMButtonPressed(mbutton) && (isMButtonLong(mbutton) == false) && (tmp_timer_mbutton != 0))
 	{
 		// Short press/release cycle
-		mbuttons &= ~(MBUTTON_PRESSED << (mbutton * 3));
-		mbuttons &= ~(MBUTTON_LONG << (mbutton * 3));
+		mbuttons &= ~(MBUTTON_PRESSED << (mbutton * 2));
+		mbuttons &= ~(MBUTTON_LONG << (mbutton * 2));
 
 		taskENTER_CRITICAL();
 		timer_mbuttons[mbutton] = 0;
@@ -162,8 +161,8 @@ static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonI
 	else if (((*buttons & buttonID) == 0) && isMButtonPressed(mbutton) && isMButtonLong(mbutton))
 	{
 		// Button was still down after a long press, now handle release
-		mbuttons &= ~(MBUTTON_PRESSED << (mbutton * 3));
-		mbuttons &= ~(MBUTTON_LONG << (mbutton * 3));
+		mbuttons &= ~(MBUTTON_PRESSED << (mbutton * 2));
+		mbuttons &= ~(MBUTTON_LONG << (mbutton * 2));
 
 		// Remove LONG
 		*buttons &= ~buttonLong;

--- a/firmware/source/io/buttons.c
+++ b/firmware/source/io/buttons.c
@@ -22,11 +22,12 @@
 #include <usb_com.h>
 
 
-static uint32_t old_button_state;
+static uint32_t prevButtonState;
 volatile bool PTTLocked = false;
 
 #define MBUTTON_PRESSED  0x01
 #define MBUTTON_LONG     0x02
+#define MBUTTON_DOWN     0x04 // Maybe not needed
 
 typedef enum
 {
@@ -36,7 +37,7 @@ typedef enum
 	MBUTTON_MAX
 } MBUTTON_t;
 
-static uint8_t mbuttons;
+static uint16_t mbuttons;
 
 void buttonsInit(void)
 {
@@ -55,18 +56,17 @@ void buttonsInit(void)
 #endif
 
     mbuttons = 0x00;
-
-    old_button_state = 0;
+    prevButtonState = 0;
 }
-#if defined(PLATFORM_GD77S)
+
 static bool isMButtonPressed(MBUTTON_t mbutton)
 {
-     return (((mbuttons >> (mbutton * 2)) & MBUTTON_PRESSED) & MBUTTON_PRESSED);
+     return (((mbuttons >> (mbutton * 3)) & MBUTTON_PRESSED) & MBUTTON_PRESSED);
 }
 
 static bool isMButtonLong(MBUTTON_t mbutton)
 {
-     return (((mbuttons >> (mbutton * 2)) & MBUTTON_LONG) & MBUTTON_LONG);
+     return (((mbuttons >> (mbutton * 3)) & MBUTTON_LONG) & MBUTTON_LONG);
 }
 
 static void checkMButtonState(MBUTTON_t mbutton)
@@ -77,11 +77,11 @@ static void checkMButtonState(MBUTTON_t mbutton)
 		timer_mbuttons[mbutton] = (nonVolatileSettings.keypadTimerLong * 1000);
 		taskEXIT_CRITICAL();
 
-		mbuttons |= (MBUTTON_PRESSED << (mbutton * 2));
-		mbuttons &= ~(MBUTTON_LONG << (mbutton * 2));
+		mbuttons |= (MBUTTON_PRESSED << (mbutton * 3));
+		mbuttons &= ~(MBUTTON_LONG << (mbutton * 3));
 	}
 }
-#endif
+
 uint32_t buttonsRead(void)
 {
 	uint32_t result = BUTTON_NONE;
@@ -104,23 +104,19 @@ uint32_t buttonsRead(void)
 	if (GPIO_PinRead(GPIO_SK1, Pin_SK1) == 0)
 	{
 		result |= BUTTON_SK1;
-#if defined(PLATFORM_GD77S)
 		checkMButtonState(MBUTTON_SK1);
-#endif
 	}
 
 	if (GPIO_PinRead(GPIO_SK2, Pin_SK2) == 0)
 	{
 		result |= BUTTON_SK2;
-#if defined(PLATFORM_GD77S)
 		checkMButtonState(MBUTTON_SK2);
-#endif
 	}
 
 	return result;
 }
-#if defined(PLATFORM_GD77S)
-static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonID, uint32_t buttonLong)
+
+static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonID, uint32_t buttonShortUp, uint32_t buttonLong)
 {
 	taskENTER_CRITICAL();
 	uint32_t tmp_timer_mbutton = timer_mbuttons[mbutton];
@@ -138,7 +134,7 @@ static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonI
 		if (tmp_timer_mbutton == 0)
 		{
 			// Long press
-			mbuttons |= (MBUTTON_LONG << (mbutton * 2));
+			mbuttons |= (MBUTTON_LONG << (mbutton * 3));
 
 			// Set LONG bit
 			*buttons |= buttonLong;
@@ -146,49 +142,83 @@ static void checkMButtons(uint32_t *buttons, MBUTTON_t mbutton, uint32_t buttonI
 		else
 		{
 			// Still not a short or long press
-			*buttons &= ~buttonID;
+			//*buttons &= ~buttonID;
 		}
 	}
 	else if (((*buttons & buttonID) == 0) && isMButtonPressed(mbutton) && (isMButtonLong(mbutton) == false) && (tmp_timer_mbutton != 0))
 	{
 		// Short press/release cycle
-		mbuttons &= ~(MBUTTON_PRESSED << (mbutton * 2));
-		mbuttons &= ~(MBUTTON_LONG << (mbutton * 2));
+		mbuttons &= ~(MBUTTON_PRESSED << (mbutton * 3));
+		mbuttons &= ~(MBUTTON_LONG << (mbutton * 3));
 
 		taskENTER_CRITICAL();
 		timer_mbuttons[mbutton] = 0;
 		taskEXIT_CRITICAL();
 
 		// Set SHORT press
-		*buttons |= buttonID;
+		*buttons |= buttonShortUp;
 		*buttons &= ~buttonLong;
 	}
 	else if (((*buttons & buttonID) == 0) && isMButtonPressed(mbutton) && isMButtonLong(mbutton))
 	{
 		// Button was still down after a long press, now handle release
-		mbuttons &= ~(MBUTTON_PRESSED << (mbutton * 2));
-		mbuttons &= ~(MBUTTON_LONG << (mbutton * 2));
+		mbuttons &= ~(MBUTTON_PRESSED << (mbutton * 3));
+		mbuttons &= ~(MBUTTON_LONG << (mbutton * 3));
 
 		// Remove LONG
 		*buttons &= ~buttonLong;
 	}
 }
-#endif
 
-void buttonsCheckButtonsEvent(uint32_t *buttons, int *event)
+void buttonsCheckButtonsEvent(uint32_t *buttons, int *event, bool keyIsDown)
 {
 	*buttons = buttonsRead();
 
 #if defined(PLATFORM_GD77S)
-	checkMButtons(buttons, MBUTTON_ORANGE, BUTTON_ORANGE, BUTTON_ORANGE_LONG);
-	checkMButtons(buttons, MBUTTON_SK1, BUTTON_SK1, BUTTON_SK1_LONG);
-	checkMButtons(buttons, MBUTTON_SK2, BUTTON_SK2, BUTTON_SK2_LONG);
+	checkMButtons(buttons, MBUTTON_ORANGE, BUTTON_ORANGE, BUTTON_ORANGE_SHORT_UP, BUTTON_ORANGE_LONG_DOWN);
 #endif
+	checkMButtons(buttons, MBUTTON_SK1, BUTTON_SK1, BUTTON_SK1_SHORT_UP, BUTTON_SK1_LONG_DOWN);
+	checkMButtons(buttons, MBUTTON_SK2, BUTTON_SK2, BUTTON_SK2_SHORT_UP, BUTTON_SK2_LONG_DOWN);
 
-	if (old_button_state != *buttons)
+	if (prevButtonState != *buttons)
 	{
-		old_button_state = *buttons;
-		*event = EVENT_BUTTON_CHANGE;
+		// If a keypad key is down, the buttons are acting as modifier and mask shortup/longdown status
+		if (keyIsDown &&
+				( (*buttons & BUTTON_SK1_SHORT_UP) || (*buttons & BUTTON_SK1_LONG_DOWN)
+						|| (*buttons & BUTTON_SK2_SHORT_UP) || (*buttons & BUTTON_SK2_LONG_DOWN)
+#if ! defined(PLATFORM_RD5R)
+						|| (*buttons & BUTTON_ORANGE_SHORT_UP)
+#if defined(PLATFORM_GD77S)
+						|| (*buttons & BUTTON_ORANGE_LONG_DOWN)
+#endif
+#endif // ! PLATFORM_RD5R
+				) )
+		{
+			// Clear shortup/longdown bits
+			*buttons &= ~(BUTTON_SK1_SHORT_UP | BUTTON_SK1_LONG_DOWN | BUTTON_SK2_SHORT_UP | BUTTON_SK2_LONG_DOWN
+#if ! defined(PLATFORM_RD5R)
+					| BUTTON_ORANGE_SHORT_UP
+#if defined(PLATFORM_GD77S)
+					| BUTTON_ORANGE_LONG_DOWN
+#endif
+#endif // ! PLATFORM_RD5R
+			);
+
+			if (prevButtonState != *buttons)
+			{
+				prevButtonState = *buttons;
+				*event = EVENT_BUTTON_CHANGE;
+			}
+			else
+			{
+				*event = EVENT_BUTTON_NONE;
+			}
+		}
+		else
+		{
+			prevButtonState = *buttons;
+			*event = EVENT_BUTTON_CHANGE;
+		}
 	}
 	else
 	{

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -177,7 +177,7 @@ void mainTask(void *data)
 	keyboardInit();
 	rotarySwitchInit();
 
-	buttonsCheckButtonsEvent(&buttons, &button_event);// Read button state and event
+	buttonsCheckButtonsEvent(&buttons, &button_event, false);// Read button state and event
 
 	if (buttons & BUTTON_SK2)
 	{
@@ -315,9 +315,9 @@ void mainTask(void *data)
 
 			tick_com_request();
 
-			buttonsCheckButtonsEvent(&buttons, &button_event); // Read button state and event
-
 			keyboardCheckKeyEvent(&keys, &key_event); // Read keyboard state and event
+
+			buttonsCheckButtonsEvent(&buttons, &button_event, (keys.key != 0)); // Read button state and event
 
 			rotarySwitchCheckRotaryEvent(&rotary, &rotary_event); // Rotary switch state and event (GD-77S only)
 

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -125,7 +125,7 @@ static void keyBeepHandler(uiEvent_t *ev, bool PTTToggledDown)
 	{
 		if ((PTTToggledDown == false) && (uiVFOModeIsScanning() == false) && (uiChannelModeIsScanning() == false))
 		{
-			if (nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_BEEP)
+			if ((nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_BEEP) || (nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_VOICE))
 			{
 				soundSetMelody(nextKeyBeepMelody);
 			}

--- a/firmware/source/user_interface/menuBattery.c
+++ b/firmware/source/user_interface/menuBattery.c
@@ -291,7 +291,7 @@ static void handleEvent(uiEvent_t *ev)
 {
 	displayLightTrigger();
 
-	if (ev->buttons & BUTTON_SK1)
+	if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK1))
 	{
 		voicePromptsPlay();
 	}

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -117,7 +117,7 @@ void cssIncrement(uint16_t *tone, int32_t *index, CSSTypes_t *type, bool loop)
 
 static void cssIncrementFromEvent(uiEvent_t *ev, uint16_t *tone, int32_t *index, CSSTypes_t *type)
 {
-	if (ev->buttons & BUTTON_SK2)
+	if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 	{
 		switch (*type)
 		{
@@ -193,7 +193,7 @@ static void cssDecrement(uint16_t *tone, int32_t *index, CSSTypes_t *type)
 
 static void cssDecrementFromEvent(uiEvent_t *ev, uint16_t *tone, int32_t *index, CSSTypes_t *type)
 {
-	if (ev->buttons & BUTTON_SK2)
+	if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 	{
 		switch (*type)
 		{
@@ -575,7 +575,7 @@ static void handleEvent(uiEvent_t *ev)
 			case CH_DETAILS_NAME:
 				if (settingsCurrentChannelNumber != -1)
 				{
-					moveCursorRightInString(channelName, &namePos, 16, (ev->buttons & BUTTON_SK2));
+					moveCursorRightInString(channelName, &namePos, 16, BUTTONCHECK_DOWN(ev, BUTTON_SK2));
 					updateCursor(true);
 				}
 				break;
@@ -670,7 +670,7 @@ static void handleEvent(uiEvent_t *ev)
 			case CH_DETAILS_NAME:
 				if (settingsCurrentChannelNumber != -1)
 				{
-					moveCursorLeftInString(channelName, &namePos, (ev->buttons & BUTTON_SK2));
+					moveCursorLeftInString(channelName, &namePos, BUTTONCHECK_DOWN(ev, BUTTON_SK2));
 					updateCursor(true);
 				}
 				break;
@@ -771,7 +771,7 @@ static void handleEvent(uiEvent_t *ev)
 		// settingsCurrentChannelNumber is -1 when in VFO mode
 		// But the VFO is stored in the nonVolatile settings, and not saved back to the codeplug
 		// Also don't store this back to the codeplug unless the Function key (Blue / SK2 ) is pressed at the same time.
-		if (settingsCurrentChannelNumber != -1 && (ev->buttons & BUTTON_SK2))
+		if (settingsCurrentChannelNumber != -1 && BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 		{
 			codeplugChannelSaveDataForIndex(settingsCurrentChannelNumber, currentChannelData);
 		}

--- a/firmware/source/user_interface/menuContactDetails.c
+++ b/firmware/source/user_interface/menuContactDetails.c
@@ -224,7 +224,7 @@ static void handleEvent(uiEvent_t *ev)
 						switch(gMenusCurrentItemIndex)
 						{
 						case CONTACT_DETAILS_NAME:
-							moveCursorRightInString(contactName, &namePos, 16, (ev->buttons & BUTTON_SK2));
+							moveCursorRightInString(contactName, &namePos, 16, BUTTONCHECK_DOWN(ev, BUTTON_SK2));
 							updateCursor(true);
 							break;
 						case CONTACT_DETAILS_TG:
@@ -256,7 +256,7 @@ static void handleEvent(uiEvent_t *ev)
 							switch(gMenusCurrentItemIndex)
 							{
 								case CONTACT_DETAILS_NAME:
-									moveCursorLeftInString(contactName, &namePos, (ev->buttons & BUTTON_SK2));
+									moveCursorLeftInString(contactName, &namePos, BUTTONCHECK_DOWN(ev, BUTTON_SK2));
 									updateCursor(true);
 									break;
 								case CONTACT_DETAILS_TG:

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -165,7 +165,7 @@ static void handleEvent(uiEvent_t *ev)
 	}
 
 	// Toggles LH simple/details view on SK2 press
-	if (ev->buttons & BUTTON_SK2)
+	if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 	{
 		displayLHDetails = true;//!displayLHDetails;
 	}

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -106,7 +106,7 @@ const menuFunctionPointer_t menuFunctions[] = { uiSplashScreen,
 
 static void menuSystemCheckForFirstEntryAudible(menuStatus_t status)
 {
-	if (nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_BEEP)
+	if ((nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_BEEP) || (nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_VOICE))
 	{
 		 if (((status & MENU_STATUS_LIST_TYPE) && (gMenusCurrentItemIndex == 0)) || (status & MENU_STATUS_FORCE_FIRST))
 		 {

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -71,7 +71,9 @@ static void uiChannelUpdateTrxID(void);
 static void searchNextChannel(void);
 static void setNextChannel(void);
 static void announceChannelName(void);
+#if ! defined(PLATFORM_GD77S)
 static void announceTG(void);
+#endif
 
 static struct_codeplugZone_t currentZone;
 static char currentZoneName[17];
@@ -647,7 +649,7 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		// Key pressed during scanning
 
-		if ((ev->buttons & BUTTON_SK2) == 0)
+		if (BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0)
 		{
 			// if we are scanning and down key is pressed then enter current channel into nuisance delete array.
 			if((scanState == SCAN_PAUSED) && (ev->keys.key == KEY_RIGHT))
@@ -683,7 +685,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		// stop the scan on any button except UP without Shift (allows scan to be manually continued)
 		// or SK2 on its own (allows Backlight to be triggered)
-		if (((ev->keys.key == KEY_UP) && (ev->buttons & BUTTON_SK2) == 0) == false)
+		if (((ev->keys.key == KEY_UP) && BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0) == false)
 		{
 			uiChannelModeStopScanning();
 			keyboardReset();
@@ -705,7 +707,7 @@ static void handleEvent(uiEvent_t *ev)
 
 	if (ev->events & BUTTON_EVENT)
 	{
-		if (ev->buttons & BUTTON_SK1)
+		if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK1))
 		{
 			voicePromptsPlay();
 		}
@@ -713,7 +715,7 @@ static void handleEvent(uiEvent_t *ev)
 		uint32_t tg = (LinkHead->talkGroupOrPcId & 0xFFFFFF);
 
 		// If Blue button is pressed during reception it sets the Tx TG to the incoming TG
-		if (isDisplayingQSOData && (ev->buttons & BUTTON_SK2) && trxGetMode() == RADIO_MODE_DIGITAL &&
+		if (isDisplayingQSOData && BUTTONCHECK_DOWN(ev, BUTTON_SK2) && trxGetMode() == RADIO_MODE_DIGITAL &&
 				(trxTalkGroupOrPcId != tg ||
 				(dmrMonitorCapturedTS!=-1 && dmrMonitorCapturedTS != trxGetDMRTimeSlot()) ||
 				(trxGetDMRColourCode() != currentChannelData->rxColor)))
@@ -747,7 +749,7 @@ static void handleEvent(uiEvent_t *ev)
 			return;
 		}
 
-		if ((reverseRepeater == false) && ((ev->buttons & BUTTON_SK1) && (ev->buttons & BUTTON_SK2)))
+		if ((reverseRepeater == false) && (BUTTONCHECK_DOWN(ev, BUTTON_SK1) && BUTTONCHECK_DOWN(ev, BUTTON_SK2)))
 		{
 			trxSetFrequency(channelScreenChannelData.txFreq, channelScreenChannelData.rxFreq, DMR_MODE_ACTIVE);// Swap Tx and Rx freqs but force DMR Active
 			reverseRepeater = true;
@@ -755,7 +757,7 @@ static void handleEvent(uiEvent_t *ev)
 			uiChannelModeUpdateScreen(0);
 			return;
 		}
-		else if ((reverseRepeater == true) && ((ev->buttons & BUTTON_SK2) == 0))
+		else if ((reverseRepeater == true) && (BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0))
 		{
 			trxSetFrequency(channelScreenChannelData.rxFreq, channelScreenChannelData.txFreq, DMR_MODE_AUTO);
 			reverseRepeater = false;
@@ -770,7 +772,7 @@ static void handleEvent(uiEvent_t *ev)
 			return;
 		}
 		// Display channel settings (RX/TX/etc) while SK1 is pressed
-		else if ((displayChannelSettings == false) && (ev->buttons & BUTTON_SK1))
+		else if ((displayChannelSettings == false) && BUTTONCHECK_DOWN(ev, BUTTON_SK1))
 		{
 			int prevQSODisp = prevDisplayQSODataState;
 			displayChannelSettings = true;
@@ -780,7 +782,7 @@ static void handleEvent(uiEvent_t *ev)
 			return;
 
 		}
-		else if ((displayChannelSettings == true) && ((ev->buttons & BUTTON_SK1) == 0))
+		else if ((displayChannelSettings == true) && (BUTTONCHECK_DOWN(ev, BUTTON_SK1) == 0))
 		{
 			displayChannelSettings = false;
 			menuDisplayQSODataState = prevDisplayQSODataState;
@@ -807,9 +809,9 @@ static void handleEvent(uiEvent_t *ev)
 		}
 
 #if !defined(PLATFORM_RD5R)
-		if ((ev->buttons & BUTTON_ORANGE) && ((ev->buttons & BUTTON_SK1) == 0))
+		if (BUTTONCHECK_DOWN(ev, BUTTON_ORANGE) && (BUTTONCHECK_DOWN(ev, BUTTON_SK1) == 0))
 		{
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				settingsPrivateCallMuteMode = !settingsPrivateCallMuteMode;// Toggle PC mute only mode
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
@@ -870,7 +872,7 @@ static void handleEvent(uiEvent_t *ev)
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 				uiChannelModeUpdateScreen(0);
 			}
-			else if (ev->buttons & BUTTON_SK2 )
+			else if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				menuSystemPushNewMenu(MENU_CHANNEL_DETAILS);
 			}
@@ -884,7 +886,7 @@ static void handleEvent(uiEvent_t *ev)
 		{
 			if (trxGetMode() == RADIO_MODE_DIGITAL)
 			{
-				if ((ev->buttons & BUTTON_SK2) != 0)
+				if (BUTTONCHECK_DOWN(ev, BUTTON_SK2) != 0)
 				{
 					menuSystemPushNewMenu(MENU_CONTACT_QUICKLIST);
 				}
@@ -897,7 +899,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 		{
-			if ((ev->buttons & BUTTON_SK2 ) != 0 && menuUtilityTgBeforePcMode != 0)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2) && (menuUtilityTgBeforePcMode != 0))
 			{
 				nonVolatileSettings.overrideTG = menuUtilityTgBeforePcMode;
 				menuClearPrivateCall();
@@ -930,9 +932,9 @@ static void handleEvent(uiEvent_t *ev)
 		}
 #endif
 #if defined(PLATFORM_RD5R)
-		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_VFO_MR) && ((ev->buttons & BUTTON_SK1) == 0))
+		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_VFO_MR) && (BUTTONCHECK_DOWN(ev, BUTTON_SK1) == 0))
 		{
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				settingsPrivateCallMuteMode = !settingsPrivateCallMuteMode;// Toggle PC mute only mode
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
@@ -955,7 +957,7 @@ static void handleEvent(uiEvent_t *ev)
 		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_RIGHT))
 		{
 			// Long press allows the 5W+ power setting to be selected immediately
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				if (nonVolatileSettings.txPowerLevel == (MAX_POWER_SETTING_NUM - 1))
 				{
@@ -969,7 +971,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		else if (KEYCHECK_PRESS(ev->keys, KEY_RIGHT))
 		{
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				if (nonVolatileSettings.txPowerLevel < (MAX_POWER_SETTING_NUM - 1))
 				{
@@ -1024,7 +1026,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 		{
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				if (nonVolatileSettings.txPowerLevel > 0)
 				{
@@ -1089,7 +1091,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		else if (KEYCHECK_SHORTUP(ev->keys, KEY_STAR))
 		{
-			if (ev->buttons & BUTTON_SK2)  // Toggle Channel Mode
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))  // Toggle Channel Mode
 			{
 				if (trxGetMode() == RADIO_MODE_ANALOG)
 				{
@@ -1134,7 +1136,7 @@ static void handleEvent(uiEvent_t *ev)
 				}
 			}
 		}
-		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_STAR) && ((ev->buttons & BUTTON_SK2) == 0))
+		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_STAR) && (BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0))
 		{
 			if (trxGetMode() == RADIO_MODE_DIGITAL)
 			{
@@ -1158,7 +1160,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		else if (KEYCHECK_SHORTUP(ev->keys, KEY_DOWN) || KEYCHECK_LONGDOWN_REPEAT(ev->keys, KEY_DOWN))
 		{
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				int numZones = codeplugZonesGetCount();
 
@@ -1230,7 +1232,7 @@ static void handleEvent(uiEvent_t *ev)
 			SETTINGS_PLATFORM_SPECIFIC_SAVE_SETTINGS(false);
 			return;
 		}
-		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_UP) && ((ev->buttons & BUTTON_SK2) == 0))
+		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_UP) && (BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0))
 		{
 			startScan();
 		}
@@ -1270,7 +1272,7 @@ static void handleEvent(uiEvent_t *ev)
 #if ! defined(PLATFORM_GD77S)
 static void handleUpKey(uiEvent_t *ev)
 {
-	if (ev->buttons & BUTTON_SK2)
+	if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 	{
 		int numZones = codeplugZonesGetCount();
 
@@ -2006,7 +2008,7 @@ static void handleEventForGD77S(uiEvent_t *ev)
 
 	if (ev->events & BUTTON_EVENT)
 	{
-		if (ev->buttons & BUTTON_ORANGE)
+		if (BUTTONCHECK_DOWN(ev, BUTTON_ORANGE))
 		{
 			if (scanActive)
 			{
@@ -2018,7 +2020,7 @@ static void handleEventForGD77S(uiEvent_t *ev)
 				return;
 			}
 
-			if (ev->buttons & BUTTON_ORANGE_LONG)
+			if (BUTTONCHECK_LONGDOWN(ev, BUTTON_ORANGE))
 			{
 				buf[0U] = 1U;
 				buf[1U] = SPEECH_SYNTHESIS_BATTERY;
@@ -2082,9 +2084,9 @@ static void handleEventForGD77S(uiEvent_t *ev)
 			}
 		}
 
-		if (ev->buttons & BUTTON_SK1)
+		if (BUTTONCHECK_DOWN(ev, BUTTON_SK1))
 		{
-			if (ev->buttons & BUTTON_SK1_LONG)
+			if (BUTTONCHECK_LONGDOWN(ev, BUTTON_SK1))
 			{
 				if (GD77SParameters.channelOutOfBounds == false)
 				{
@@ -2176,14 +2178,14 @@ static void handleEventForGD77S(uiEvent_t *ev)
 
 			}
 		}
-		else if (ev->buttons & BUTTON_SK2)
+		else if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 		{
-			if (ev->buttons & BUTTON_SK2_LONG)
+			if (BUTTONCHECK_LONGDOWN(ev, BUTTON_SK2))
 			{
 				uint32_t tg = (LinkHead->talkGroupOrPcId & 0xFFFFFF);
 
 				// If Blue button is pressed during reception it sets the Tx TG to the incoming TG
-				if (isDisplayingQSOData && (ev->buttons & BUTTON_SK2) && (trxGetMode() == RADIO_MODE_DIGITAL) &&
+				if (isDisplayingQSOData && BUTTONCHECK_DOWN(ev, BUTTON_SK2) && (trxGetMode() == RADIO_MODE_DIGITAL) &&
 						((trxTalkGroupOrPcId != tg) ||
 								((dmrMonitorCapturedTS != -1) && (dmrMonitorCapturedTS != trxGetDMRTimeSlot())) ||
 								(trxGetDMRColourCode() != currentChannelData->rxColor)))

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -2008,325 +2008,314 @@ static void handleEventForGD77S(uiEvent_t *ev)
 
 	if (ev->events & BUTTON_EVENT)
 	{
-		if (BUTTONCHECK_DOWN(ev, BUTTON_ORANGE))
+		if (BUTTONCHECK_DOWN(ev, BUTTON_ORANGE) && scanActive)
 		{
-			if (scanActive)
+			uiChannelModeStopScanning();
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+			uiChannelModeUpdateScreen(0);
+			buildSpeechUiModeForGD77S(buf, 0U, GD77S_UIMODE_SCAN);
+			speechSynthesisSpeak(buf);
+			return;
+		}
+
+		if (BUTTONCHECK_LONGDOWN(ev, BUTTON_ORANGE))
+		{
+			buf[0U] = 1U;
+			buf[1U] = SPEECH_SYNTHESIS_BATTERY;
+			buf[0U] += speechSynthesisBuildNumerical(&buf[2U], SPEECH_SYNTHESIS_BUFFER_SIZE - 2U, getBatteryPercentage(), 1, false);
+		}
+		else if (BUTTONCHECK_SHORTUP(ev, BUTTON_ORANGE))
+		{
+			GD77SParameters.uiMode = (GD77S_UIMODES_t) (GD77SParameters.uiMode + 1) % GD77S_UIMODE_MAX;
+
+			switch (GD77SParameters.uiMode)
 			{
-				uiChannelModeStopScanning();
+				case GD77S_UIMODE_CHANNEL: // Channel Mode
+					buf[0U] = 3U;
+					buf[1U] = SPEECH_SYNTHESIS_CHANNEL;
+					buf[2U] = SPEECH_SYNTHESIS_MODE;
+					buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
+					buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_SCAN:
+					buf[0U] = 2U;
+					buf[1U] = SPEECH_SYNTHESIS_SCAN;
+					buf[2U] = SPEECH_SYNTHESIS_MODE;
+					break;
+
+				case GD77S_UIMODE_TS: // Timeslot Mode
+					buf[0U] = 3U;
+					buf[1U] = SPEECH_SYNTHESIS_KEY;
+					buf[2U] = SPEECH_SYNTHESIS_MODE;
+					buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
+					buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_DMR_FILTER: // DMR Filter (DMR_FILTER_CC_TS or DMR_FILTER_CC_TS_TG)
+					buf[0U] = 3U;
+					buf[1U] = SPEECH_SYNTHESIS_LEVEL;
+					buf[2U] = SPEECH_SYNTHESIS_MODE;
+					buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
+					buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_ZONE: // Zone Mode
+					buf[0U] = 3U;
+					buf[1U] = SPEECH_SYNTHESIS_STORE;
+					buf[2U] = SPEECH_SYNTHESIS_MODE;
+					buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
+					buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_POWER: // Power Mode
+					buf[0U] = 3U;
+					buf[1U] = SPEECH_SYNTHESIS_POWER;
+					buf[2U] = SPEECH_SYNTHESIS_MODE;
+					buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
+					buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_MAX:
+					break;
+			}
+		}
+		else if (BUTTONCHECK_LONGDOWN(ev, BUTTON_SK1))
+		{
+			if (GD77SParameters.channelOutOfBounds == false)
+			{
+				buildSpeechChannelDetailsForGD77S(buf, 0U);
+			}
+		}
+		else if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK1))
+		{
+			switch (GD77SParameters.uiMode)
+			{
+				case GD77S_UIMODE_CHANNEL: // Next in TGList
+					if (trxGetMode() == RADIO_MODE_DIGITAL)
+					{
+						if (nonVolatileSettings.overrideTG == 0)
+						{
+							nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE]++;
+							if (nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] > (currentRxGroupData.NOT_IN_CODEPLUG_numTGsInGroup - 1))
+							{
+								nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] = 0;
+							}
+						}
+						nonVolatileSettings.overrideTG = 0;// setting the override TG to 0 indicates the TG is not overridden
+						menuClearPrivateCall();
+						uiChannelUpdateTrxID();
+						menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+						uiChannelModeUpdateScreen(0);
+						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					}
+					break;
+
+				case GD77S_UIMODE_SCAN:
+					if (scanActive)
+					{
+						uiChannelModeStopScanning();
+						menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+						uiChannelModeUpdateScreen(0);
+					}
+					else
+					{
+						startScan();
+					}
+					buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_TS:
+					if (trxGetMode() == RADIO_MODE_DIGITAL)
+					{
+						toggleTimeslotForGD77S();
+						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					}
+					break;
+
+				case GD77S_UIMODE_DMR_FILTER:
+					if (trxGetMode() == RADIO_MODE_DIGITAL)
+					{
+						nonVolatileSettings.dmrFilterLevel = DMR_FILTER_CC_TS_TG;
+						init_digital_DMR_RX();
+						disableAudioAmp(AUDIO_AMP_MODE_RF);
+						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					}
+					break;
+
+				case GD77S_UIMODE_ZONE: // Zones
+					// No "All Channels" on GD77S
+					menuSystemMenuIncrement((int32_t *)&nonVolatileSettings.currentZone, (codeplugZonesGetCount() - 1));
+
+					nonVolatileSettings.overrideTG = 0; // remove any TG override
+					nonVolatileSettings.tsManualOverride &= 0xF0; // remove TS override from channel
+					nonVolatileSettings.currentChannelIndexInZone = -2; // Will be updated when reloading the UiChannelMode screen
+					channelScreenChannelData.rxFreq = 0x00; // Flag to the Channel screen that the channel data is now invalid and needs to be reloaded
+
+					menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE, true);
+					GD77SParameters.uiMode = GD77S_UIMODE_ZONE;
+
+					buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_POWER: // Power
+					if (nonVolatileSettings.txPowerLevel < MAX_POWER_SETTING_NUM)
+					{
+						nonVolatileSettings.txPowerLevel++;
+					}
+					buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_MAX:
+					break;
+			}
+		}
+		else if (BUTTONCHECK_LONGDOWN(ev, BUTTON_SK2))
+		{
+			uint32_t tg = (LinkHead->talkGroupOrPcId & 0xFFFFFF);
+
+			// If Blue button is pressed during reception it sets the Tx TG to the incoming TG
+			if (isDisplayingQSOData && BUTTONCHECK_DOWN(ev, BUTTON_SK2) && (trxGetMode() == RADIO_MODE_DIGITAL) &&
+					((trxTalkGroupOrPcId != tg) ||
+							((dmrMonitorCapturedTS != -1) && (dmrMonitorCapturedTS != trxGetDMRTimeSlot())) ||
+							(trxGetDMRColourCode() != currentChannelData->rxColor)))
+			{
+				buf[0U] = 2;
+				buf[1U] = SPEECH_SYNTHESIS_CHANNEL;
+				buf[2U] = SPEECH_SYNTHESIS_SET;
+				speechSynthesisSpeak(buf);
+
+				lastHeardClearLastID();
+
+				// Set TS to overriden TS
+				if ((dmrMonitorCapturedTS != -1) && (dmrMonitorCapturedTS != trxGetDMRTimeSlot()))
+				{
+					trxSetDMRTimeSlot(dmrMonitorCapturedTS);
+					nonVolatileSettings.tsManualOverride &= 0xF0;// Clear lower nibble value
+					nonVolatileSettings.tsManualOverride |= (dmrMonitorCapturedTS + 1);// Store manual TS override
+				}
+				if (trxTalkGroupOrPcId != tg)
+				{
+					if ((tg>>24) & PC_CALL_FLAG)
+					{
+						menuAcceptPrivateCall(tg & 0xffffff);
+					}
+					else
+					{
+						trxTalkGroupOrPcId = tg;
+						nonVolatileSettings.overrideTG = trxTalkGroupOrPcId;
+					}
+				}
+
+				currentChannelData->rxColor = trxGetDMRColourCode();// Set the CC to the current CC, which may have been determined by the CC finding algorithm in C6000.c
+
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 				uiChannelModeUpdateScreen(0);
-				buildSpeechUiModeForGD77S(buf, 0U, GD77S_UIMODE_SCAN);
-				speechSynthesisSpeak(buf);
 				return;
 			}
-
-			if (BUTTONCHECK_LONGDOWN(ev, BUTTON_ORANGE))
-			{
-				buf[0U] = 1U;
-				buf[1U] = SPEECH_SYNTHESIS_BATTERY;
-				buf[0U] += speechSynthesisBuildNumerical(&buf[2U], SPEECH_SYNTHESIS_BUFFER_SIZE - 2U, getBatteryPercentage(), 1, false);
-			}
-			else
-			{
-				GD77SParameters.uiMode = (GD77S_UIMODES_t) (GD77SParameters.uiMode + 1) % GD77S_UIMODE_MAX;
-
-				switch (GD77SParameters.uiMode)
-				{
-					case GD77S_UIMODE_CHANNEL: // Channel Mode
-						buf[0U] = 3U;
-						buf[1U] = SPEECH_SYNTHESIS_CHANNEL;
-						buf[2U] = SPEECH_SYNTHESIS_MODE;
-						buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
-						buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
-						break;
-
-					case GD77S_UIMODE_SCAN:
-						buf[0U] = 2U;
-						buf[1U] = SPEECH_SYNTHESIS_SCAN;
-						buf[2U] = SPEECH_SYNTHESIS_MODE;
-						break;
-
-					case GD77S_UIMODE_TS: // Timeslot Mode
-						buf[0U] = 3U;
-						buf[1U] = SPEECH_SYNTHESIS_KEY;
-						buf[2U] = SPEECH_SYNTHESIS_MODE;
-						buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
-						buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
-						break;
-
-					case GD77S_UIMODE_DMR_FILTER: // DMR Filter (DMR_FILTER_CC_TS or DMR_FILTER_CC_TS_TG)
-						buf[0U] = 3U;
-						buf[1U] = SPEECH_SYNTHESIS_LEVEL;
-						buf[2U] = SPEECH_SYNTHESIS_MODE;
-						buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
-						buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
-						break;
-
-					case GD77S_UIMODE_ZONE: // Zone Mode
-						buf[0U] = 3U;
-						buf[1U] = SPEECH_SYNTHESIS_STORE;
-						buf[2U] = SPEECH_SYNTHESIS_MODE;
-						buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
-						buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
-						break;
-
-					case GD77S_UIMODE_POWER: // Power Mode
-						buf[0U] = 3U;
-						buf[1U] = SPEECH_SYNTHESIS_POWER;
-						buf[2U] = SPEECH_SYNTHESIS_MODE;
-						buf[3U] = SPEECH_SYNTHESIS_SEQUENCE_SEPARATOR;
-						buildSpeechUiModeForGD77S(buf, buf[0U], GD77SParameters.uiMode);
-						break;
-
-					case GD77S_UIMODE_MAX:
-						break;
-				}
-			}
 		}
-
-		if (BUTTONCHECK_DOWN(ev, BUTTON_SK1))
+		else if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK2))
 		{
-			if (BUTTONCHECK_LONGDOWN(ev, BUTTON_SK1))
+			switch (GD77SParameters.uiMode)
 			{
-				if (GD77SParameters.channelOutOfBounds == false)
-				{
-					buildSpeechChannelDetailsForGD77S(buf, 0U);
-				}
-			}
-			else // Short SK1 press
-			{
-				switch (GD77SParameters.uiMode)
-				{
-					case GD77S_UIMODE_CHANNEL: // Next in TGList
-						if (trxGetMode() == RADIO_MODE_DIGITAL)
-						{
-							if (nonVolatileSettings.overrideTG == 0)
-							{
-								nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE]++;
-								if (nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] > (currentRxGroupData.NOT_IN_CODEPLUG_numTGsInGroup - 1))
-								{
-									nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] = 0;
-								}
-							}
-							nonVolatileSettings.overrideTG = 0;// setting the override TG to 0 indicates the TG is not overridden
-							menuClearPrivateCall();
-							uiChannelUpdateTrxID();
-							menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
-							uiChannelModeUpdateScreen(0);
-							buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						}
-						break;
-
-					case GD77S_UIMODE_SCAN:
-						if (scanActive)
-						{
-							uiChannelModeStopScanning();
-							menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
-							uiChannelModeUpdateScreen(0);
-						}
-						else
-						{
-							startScan();
-						}
-						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						break;
-
-					case GD77S_UIMODE_TS:
-						if (trxGetMode() == RADIO_MODE_DIGITAL)
-						{
-							toggleTimeslotForGD77S();
-							buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						}
-						break;
-
-					case GD77S_UIMODE_DMR_FILTER:
-						if (trxGetMode() == RADIO_MODE_DIGITAL)
-						{
-							nonVolatileSettings.dmrFilterLevel = DMR_FILTER_CC_TS_TG;
-							init_digital_DMR_RX();
-							disableAudioAmp(AUDIO_AMP_MODE_RF);
-							buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						}
-						break;
-
-					case GD77S_UIMODE_ZONE: // Zones
-						// No "All Channels" on GD77S
-						menuSystemMenuIncrement((int32_t *)&nonVolatileSettings.currentZone, (codeplugZonesGetCount() - 1));
-
-						nonVolatileSettings.overrideTG = 0; // remove any TG override
-						nonVolatileSettings.tsManualOverride &= 0xF0; // remove TS override from channel
-						nonVolatileSettings.currentChannelIndexInZone = -2; // Will be updated when reloading the UiChannelMode screen
-						channelScreenChannelData.rxFreq = 0x00; // Flag to the Channel screen that the channel data is now invalid and needs to be reloaded
-
-						menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE, true);
-						GD77SParameters.uiMode = GD77S_UIMODE_ZONE;
-
-						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						break;
-
-					case GD77S_UIMODE_POWER: // Power
-						if (nonVolatileSettings.txPowerLevel < MAX_POWER_SETTING_NUM)
-						{
-							nonVolatileSettings.txPowerLevel++;
-						}
-						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						break;
-
-					case GD77S_UIMODE_MAX:
-						break;
-				}
-
-			}
-		}
-		else if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
-		{
-			if (BUTTONCHECK_LONGDOWN(ev, BUTTON_SK2))
-			{
-				uint32_t tg = (LinkHead->talkGroupOrPcId & 0xFFFFFF);
-
-				// If Blue button is pressed during reception it sets the Tx TG to the incoming TG
-				if (isDisplayingQSOData && BUTTONCHECK_DOWN(ev, BUTTON_SK2) && (trxGetMode() == RADIO_MODE_DIGITAL) &&
-						((trxTalkGroupOrPcId != tg) ||
-								((dmrMonitorCapturedTS != -1) && (dmrMonitorCapturedTS != trxGetDMRTimeSlot())) ||
-								(trxGetDMRColourCode() != currentChannelData->rxColor)))
-				{
-					buf[0U] = 2;
-					buf[1U] = SPEECH_SYNTHESIS_CHANNEL;
-					buf[2U] = SPEECH_SYNTHESIS_SET;
-					speechSynthesisSpeak(buf);
-
-					lastHeardClearLastID();
-
-					// Set TS to overriden TS
-					if ((dmrMonitorCapturedTS != -1) && (dmrMonitorCapturedTS != trxGetDMRTimeSlot()))
+				case GD77S_UIMODE_CHANNEL: // Previous in TGList
+					if (trxGetMode() == RADIO_MODE_DIGITAL)
 					{
-						trxSetDMRTimeSlot(dmrMonitorCapturedTS);
-						nonVolatileSettings.tsManualOverride &= 0xF0;// Clear lower nibble value
-						nonVolatileSettings.tsManualOverride |= (dmrMonitorCapturedTS + 1);// Store manual TS override
-					}
-					if (trxTalkGroupOrPcId != tg)
-					{
-						if ((tg>>24) & PC_CALL_FLAG)
+						// To Do change TG in on same channel freq
+						if (nonVolatileSettings.overrideTG == 0)
 						{
-							menuAcceptPrivateCall(tg & 0xffffff);
-						}
-						else
-						{
-							trxTalkGroupOrPcId = tg;
-							nonVolatileSettings.overrideTG = trxTalkGroupOrPcId;
-						}
-					}
-
-					currentChannelData->rxColor = trxGetDMRColourCode();// Set the CC to the current CC, which may have been determined by the CC finding algorithm in C6000.c
-
-					menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
-					uiChannelModeUpdateScreen(0);
-					return;
-				}
-			}
-			else // Short SK2 press
-			{
-				switch (GD77SParameters.uiMode)
-				{
-					case GD77S_UIMODE_CHANNEL: // Previous in TGList
-						if (trxGetMode() == RADIO_MODE_DIGITAL)
-						{
-							// To Do change TG in on same channel freq
-							if (nonVolatileSettings.overrideTG == 0)
+							nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE]--;
+							if (nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] < 0)
 							{
-								nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE]--;
-								if (nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] < 0)
-								{
-									nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] = currentRxGroupData.NOT_IN_CODEPLUG_numTGsInGroup - 1;
-								}
+								nonVolatileSettings.currentIndexInTRxGroupList[SETTINGS_CHANNEL_MODE] = currentRxGroupData.NOT_IN_CODEPLUG_numTGsInGroup - 1;
 							}
-							nonVolatileSettings.overrideTG = 0;// setting the override TG to 0 indicates the TG is not overridden
-							menuClearPrivateCall();
-							uiChannelUpdateTrxID();
-							menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
-							uiChannelModeUpdateScreen(0);
-							buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
 						}
-						break;
+						nonVolatileSettings.overrideTG = 0;// setting the override TG to 0 indicates the TG is not overridden
+						menuClearPrivateCall();
+						uiChannelUpdateTrxID();
+						menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+						uiChannelModeUpdateScreen(0);
+						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					}
+					break;
 
-					case GD77S_UIMODE_SCAN:
-						if (scanActive)
+				case GD77S_UIMODE_SCAN:
+					if (scanActive)
+					{
+						// if we are scanning and down key is pressed then enter current channel into nuisance delete array.
+						if(scanState == SCAN_PAUSED)
 						{
-							// if we are scanning and down key is pressed then enter current channel into nuisance delete array.
-							if(scanState == SCAN_PAUSED)
+							// There is no more channel available in the Zone, just stop scanning
+							if (nuisanceDeleteIndex == (currentZone.NOT_IN_MEMORY_numChannelsInZone - 1))
 							{
-								// There is no more channel available in the Zone, just stop scanning
-								if (nuisanceDeleteIndex == (currentZone.NOT_IN_MEMORY_numChannelsInZone - 1))
-								{
-									uiChannelModeStopScanning();
-									menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
-									uiChannelModeUpdateScreen(0);
-									return;
-								}
-
-								nuisanceDelete[nuisanceDeleteIndex++] = settingsCurrentChannelNumber;
-								if(nuisanceDeleteIndex > (MAX_ZONE_SCAN_NUISANCE_CHANNELS - 1))
-								{
-									nuisanceDeleteIndex = 0; //rolling list of last MAX_NUISANCE_CHANNELS deletes.
-								}
-								scanTimer = SCAN_SKIP_CHANNEL_INTERVAL;	//force scan to continue;
-								scanState = SCAN_SCANNING;
+								uiChannelModeStopScanning();
+								menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+								uiChannelModeUpdateScreen(0);
 								return;
 							}
 
-							// Left key reverses the scan direction
-							if (scanState == SCAN_SCANNING)
+							nuisanceDelete[nuisanceDeleteIndex++] = settingsCurrentChannelNumber;
+							if(nuisanceDeleteIndex > (MAX_ZONE_SCAN_NUISANCE_CHANNELS - 1))
 							{
-								scanDirection *= -1;
-								return;
+								nuisanceDeleteIndex = 0; //rolling list of last MAX_NUISANCE_CHANNELS deletes.
 							}
+							scanTimer = SCAN_SKIP_CHANNEL_INTERVAL;	//force scan to continue;
+							scanState = SCAN_SCANNING;
+							return;
 						}
-						break;
 
-					case GD77S_UIMODE_TS:
-						if (trxGetMode() == RADIO_MODE_DIGITAL)
+						// Left key reverses the scan direction
+						if (scanState == SCAN_SCANNING)
 						{
-							toggleTimeslotForGD77S();
-							buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+							scanDirection *= -1;
+							return;
 						}
-						break;
+					}
+					break;
 
-					case GD77S_UIMODE_DMR_FILTER:
-						if (trxGetMode() == RADIO_MODE_DIGITAL)
-						{
-							nonVolatileSettings.dmrFilterLevel = DMR_FILTER_CC_TS;
-							init_digital_DMR_RX();
-							disableAudioAmp(AUDIO_AMP_MODE_RF);
-							buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						}
-						break;
-
-					case GD77S_UIMODE_ZONE: // Zones
-						// No "All Channels" on GD77S
-						menuSystemMenuDecrement((int32_t *)&nonVolatileSettings.currentZone, (codeplugZonesGetCount() - 1));
-
-						nonVolatileSettings.overrideTG = 0; // remove any TG override
-						nonVolatileSettings.tsManualOverride &= 0xF0; // remove TS override from channel
-						nonVolatileSettings.currentChannelIndexInZone = -2; // Will be updated when reloading the UiChannelMode screen
-						channelScreenChannelData.rxFreq = 0x00; // Flag to the Channel screeen that the channel data is now invalid and needs to be reloaded
-
-						menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE, true);
-						GD77SParameters.uiMode = GD77S_UIMODE_ZONE;
-
+				case GD77S_UIMODE_TS:
+					if (trxGetMode() == RADIO_MODE_DIGITAL)
+					{
+						toggleTimeslotForGD77S();
 						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						break;
+					}
+					break;
 
-					case GD77S_UIMODE_POWER: // Power
-						if (nonVolatileSettings.txPowerLevel > 0)
-						{
-							nonVolatileSettings.txPowerLevel--;
-						}
+				case GD77S_UIMODE_DMR_FILTER:
+					if (trxGetMode() == RADIO_MODE_DIGITAL)
+					{
+						nonVolatileSettings.dmrFilterLevel = DMR_FILTER_CC_TS;
+						init_digital_DMR_RX();
+						disableAudioAmp(AUDIO_AMP_MODE_RF);
 						buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
-						break;
+					}
+					break;
 
-					case GD77S_UIMODE_MAX:
-						break;
-				}
+				case GD77S_UIMODE_ZONE: // Zones
+					// No "All Channels" on GD77S
+					menuSystemMenuDecrement((int32_t *)&nonVolatileSettings.currentZone, (codeplugZonesGetCount() - 1));
+
+					nonVolatileSettings.overrideTG = 0; // remove any TG override
+					nonVolatileSettings.tsManualOverride &= 0xF0; // remove TS override from channel
+					nonVolatileSettings.currentChannelIndexInZone = -2; // Will be updated when reloading the UiChannelMode screen
+					channelScreenChannelData.rxFreq = 0x00; // Flag to the Channel screeen that the channel data is now invalid and needs to be reloaded
+
+					menuSystemPopAllAndDisplaySpecificRootMenu(UI_CHANNEL_MODE, true);
+					GD77SParameters.uiMode = GD77S_UIMODE_ZONE;
+
+					buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_POWER: // Power
+					if (nonVolatileSettings.txPowerLevel > 0)
+					{
+						nonVolatileSettings.txPowerLevel--;
+					}
+					buildSpeechUiModeForGD77S(buf, 0U, GD77SParameters.uiMode);
+					break;
+
+				case GD77S_UIMODE_MAX:
+					break;
 			}
 		}
 

--- a/firmware/source/user_interface/uiLockScreen.c
+++ b/firmware/source/user_interface/uiLockScreen.c
@@ -179,7 +179,7 @@ static void handleEvent(uiEvent_t *ev)
 {
 	displayLightTrigger();
 
-	if (KEYCHECK_DOWN(ev->keys, KEY_STAR) && (ev->buttons & BUTTON_SK2))
+	if (KEYCHECK_DOWN(ev->keys, KEY_STAR) && BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 	{
 		keypadLocked = false;
 		PTTLocked = false;

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -278,7 +278,7 @@ static void handleEvent(uiEvent_t *ev)
 		if (PTTToggledDown == false)
 		{
 			// Send 1750Hz
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				trxIsTransmittingTone = true;
 				trxSetTone1(1750);
@@ -303,21 +303,21 @@ static void handleEvent(uiEvent_t *ev)
 	}
 
 	// Stop xmitting Tone
-	if (trxIsTransmittingTone && ((ev->buttons & BUTTON_SK2) == 0) && ((ev->keys.key == 0) || (ev->keys.event & KEY_MOD_UP)))
+	if (trxIsTransmittingTone && (BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0) && ((ev->keys.key == 0) || (ev->keys.event & KEY_MOD_UP)))
 	{
 		trxIsTransmittingTone = false;
 		trxSelectVoiceChannel(AT1846_VOICE_CHANNEL_MIC);
 		disableAudioAmp(AUDIO_AMP_MODE_RF);
 	}
 
-	if (trxGetMode() == RADIO_MODE_DIGITAL && (ev->buttons & BUTTON_SK1) && isShowingLastHeard==false && trxTransmissionEnabled==true)
+	if (trxGetMode() == RADIO_MODE_DIGITAL && BUTTONCHECK_DOWN(ev, BUTTON_SK1) && isShowingLastHeard==false && trxTransmissionEnabled==true)
 	{
 		isShowingLastHeard=true;
 		menuLastHeardUpdateScreen(false, false);
 	}
 	else
 	{
-		if (isShowingLastHeard && (ev->buttons & BUTTON_SK1)==0)
+		if (isShowingLastHeard && BUTTONCHECK_DOWN(ev, BUTTON_SK1) == 0)
 		{
 			isShowingLastHeard=false;
 			updateScreen();

--- a/firmware/source/user_interface/uiTxTgPcContactOwnId.c
+++ b/firmware/source/user_interface/uiTxTgPcContactOwnId.c
@@ -228,7 +228,7 @@ static void handleEvent(uiEvent_t *ev)
 				else
 				{
 					trxDMRID = tmpID;
-					if (ev->buttons & BUTTON_SK2)
+					if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 					{
 						// make the change to DMR ID permanent if Function + Green is pressed
 						codeplugSetUserDMRID(trxDMRID);
@@ -250,7 +250,7 @@ static void handleEvent(uiEvent_t *ev)
 
 				menuNumericalExitStatus |= MENU_STATUS_INPUT_TYPE;
 
-				if (((ev->buttons & BUTTON_SK2) != 0) && (gMenusCurrentItemIndex == ENTRY_SELECT_CONTACT))
+				if ((BUTTONCHECK_DOWN(ev, BUTTON_SK2) != 0) && (gMenusCurrentItemIndex == ENTRY_SELECT_CONTACT))
 				{
 					snprintf(digits, 8, "%d", trxDMRID);
 					digits[8] = 0;

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -256,7 +256,7 @@ menuStatus_t uiVFOMode(uiEvent_t *ev, bool isFirstRun)
 					if ((ev->keys.key != 0) && (ev->keys.event & KEY_MOD_UP))
 #else
 					// PTT key is already handled in main().
-					if (((ev->events & BUTTON_EVENT) && (ev->buttons & BUTTON_ORANGE)) ||
+					if (((ev->events & BUTTON_EVENT) && BUTTONCHECK_DOWN(ev, BUTTON_ORANGE)) ||
 							((ev->keys.key != 0) && (ev->keys.event & KEY_MOD_UP)))
 #endif
 					{
@@ -643,7 +643,7 @@ static void handleEvent(uiEvent_t *ev)
 
 	if (scanActive && (ev->events & KEY_EVENT))
 	{
-		if (!(ev->buttons & BUTTON_SK2))
+		if (BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0)
 		{
 			// Right key sets the current frequency as a 'nuisance' frequency.
 			if(scanState==SCAN_PAUSED &&  ev->keys.key == KEY_RIGHT)
@@ -670,7 +670,7 @@ static void handleEvent(uiEvent_t *ev)
 
 		// Stop the scan on any key except UP without Shift (allows scan to be manually continued)
 		// or SK2 on its own (allows Backlight to be triggered)
-		if (((ev->keys.key == KEY_UP) && (ev->buttons & BUTTON_SK2) == 0) == false)
+		if (((ev->keys.key == KEY_UP) && BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0) == false)
 		{
 			uiVFOModeStopScanning();
 			keyboardReset();
@@ -693,7 +693,7 @@ static void handleEvent(uiEvent_t *ev)
 	{
 #if ! defined(PLATFORM_RD5R)
 		// Stop the scan if any button is pressed.
-		if (scanActive && (ev->buttons & BUTTON_ORANGE))
+		if (scanActive && BUTTONCHECK_DOWN(ev, BUTTON_ORANGE))
 		{
 			uiVFOModeStopScanning();
 			return;
@@ -703,7 +703,7 @@ static void handleEvent(uiEvent_t *ev)
 		uint32_t tg = (LinkHead->talkGroupOrPcId & 0xFFFFFF);
 
 		// If Blue button is pressed during reception it sets the Tx TG to the incoming TG
-		if (isDisplayingQSOData && (ev->buttons & BUTTON_SK2) && trxGetMode() == RADIO_MODE_DIGITAL &&
+		if (isDisplayingQSOData && BUTTONCHECK_DOWN(ev, BUTTON_SK2) && trxGetMode() == RADIO_MODE_DIGITAL &&
 					(trxTalkGroupOrPcId != tg ||
 					(dmrMonitorCapturedTS!=-1 && dmrMonitorCapturedTS != trxGetDMRTimeSlot()) ||
 					(trxGetDMRColourCode() != currentChannelData->rxColor)))
@@ -738,7 +738,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 
 		// Display channel settings (CTCSS, Squelch) while SK1 is pressed
-		if ((displayChannelSettings == false) && (ev->buttons & BUTTON_SK1))
+		if ((displayChannelSettings == false) && BUTTONCHECK_DOWN(ev, BUTTON_SK1))
 		{
 			int prevQSODisp = prevDisplayQSODataState;
 
@@ -748,7 +748,7 @@ static void handleEvent(uiEvent_t *ev)
 			prevDisplayQSODataState = prevQSODisp;
 			return;
 		}
-		else if ((displayChannelSettings == true) && (ev->buttons & BUTTON_SK1) == 0)
+		else if ((displayChannelSettings == true) && BUTTONCHECK_DOWN(ev, BUTTON_SK1) == 0)
 		{
 			displayChannelSettings = false;
 			menuDisplayQSODataState = prevDisplayQSODataState;
@@ -768,9 +768,9 @@ static void handleEvent(uiEvent_t *ev)
 		}
 
 #if !defined(PLATFORM_RD5R)
-		if (ev->buttons & BUTTON_ORANGE)
+		if (BUTTONCHECK_DOWN(ev, BUTTON_ORANGE))
 		{
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				settingsPrivateCallMuteMode = !settingsPrivateCallMuteMode;// Toggle PC mute only mode
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
@@ -796,7 +796,7 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		if (KEYCHECK_SHORTUP(ev->keys,KEY_GREEN))
 		{
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				menuSystemPushNewMenu(MENU_CHANNEL_DETAILS);
 				reset_freq_enter_digits();
@@ -818,7 +818,7 @@ static void handleEvent(uiEvent_t *ev)
 			{
 				if (trxGetMode() == RADIO_MODE_DIGITAL)
 				{
-					if ((ev->buttons & BUTTON_SK2) != 0)
+					if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 					{
 						menuSystemPushNewMenu(MENU_CONTACT_QUICKLIST);
 					}
@@ -832,7 +832,7 @@ static void handleEvent(uiEvent_t *ev)
 
 			if (KEYCHECK_SHORTUP(ev->keys,KEY_STAR))
 			{
-				if (ev->buttons & BUTTON_SK2)
+				if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 				{
 					if (trxGetMode() == RADIO_MODE_ANALOG)
 					{
@@ -905,7 +905,7 @@ static void handleEvent(uiEvent_t *ev)
 			else if (KEYCHECK_SHORTUP(ev->keys, KEY_DOWN) || KEYCHECK_LONGDOWN_REPEAT(ev->keys, KEY_DOWN))
 			{
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
-				if (ev->buttons & BUTTON_SK2)
+				if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 				{
 					// Don't permit to switch from RX/TX while scanning
 					if (screenOperationMode[nonVolatileSettings.currentVFONumber] != VFO_SCREEN_OPERATION_SCAN)
@@ -933,7 +933,7 @@ static void handleEvent(uiEvent_t *ev)
 			{
 				handleUpKey(ev);
 			}
-			else if (KEYCHECK_LONGDOWN(ev->keys, KEY_UP) && ((ev->buttons & BUTTON_SK2) == 0))
+			else if (KEYCHECK_LONGDOWN(ev->keys, KEY_UP) && (BUTTONCHECK_DOWN(ev, BUTTON_SK2) == 0))
 			{
 				if (screenOperationMode[nonVolatileSettings.currentVFONumber] != VFO_SCREEN_OPERATION_SCAN)
 				{
@@ -951,7 +951,7 @@ static void handleEvent(uiEvent_t *ev)
 			}
 			else if (KEYCHECK_SHORTUP(ev->keys,KEY_RED))
 			{
-				if ((ev->buttons & BUTTON_SK2 )!=0 && menuUtilityTgBeforePcMode != 0)
+				if (BUTTONCHECK_DOWN(ev, BUTTON_SK2) && (menuUtilityTgBeforePcMode != 0))
 				{
 					nonVolatileSettings.overrideTG = menuUtilityTgBeforePcMode;
 					uiVFOUpdateTrxID();
@@ -984,9 +984,9 @@ static void handleEvent(uiEvent_t *ev)
 			}
 #endif
 #if defined(PLATFORM_RD5R)
-		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_VFO_MR) && ((ev->buttons & BUTTON_SK1) == 0))
+		else if (KEYCHECK_LONGDOWN(ev->keys, KEY_VFO_MR) && (BUTTONCHECK_DOWN(ev, BUTTON_SK1) == 0))
 		{
-			if (ev->buttons & BUTTON_SK2)
+			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				settingsPrivateCallMuteMode = !settingsPrivateCallMuteMode;// Toggle PC mute only mode
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
@@ -1019,7 +1019,7 @@ static void handleEvent(uiEvent_t *ev)
 			else if (KEYCHECK_LONGDOWN(ev->keys, KEY_RIGHT))
 			{
 				// Long press allows the 5W+ power setting to be selected immediately
-				if (ev->buttons & BUTTON_SK2)
+				if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 				{
 					if (nonVolatileSettings.txPowerLevel == (MAX_POWER_SETTING_NUM - 1))
 					{
@@ -1033,7 +1033,7 @@ static void handleEvent(uiEvent_t *ev)
 			}
 			else if (KEYCHECK_PRESS(ev->keys, KEY_RIGHT))
 			{
-				if (ev->buttons & BUTTON_SK2)
+				if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 				{
 					if (nonVolatileSettings.txPowerLevel < (MAX_POWER_SETTING_NUM - 1))
 					{
@@ -1087,7 +1087,7 @@ static void handleEvent(uiEvent_t *ev)
 			}
 			else if (KEYCHECK_PRESS(ev->keys,KEY_LEFT))
 			{
-				if (ev->buttons & BUTTON_SK2)
+				if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 				{
 					if (nonVolatileSettings.txPowerLevel > 0)
 					{
@@ -1252,7 +1252,7 @@ static void handleEvent(uiEvent_t *ev)
 static void handleUpKey(uiEvent_t *ev)
 {
 	menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
-	if (ev->buttons & BUTTON_SK2)
+	if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 	{
 		// Don't permit to switch from RX/TX while scanning
 		if (screenOperationMode[nonVolatileSettings.currentVFONumber] != VFO_SCREEN_OPERATION_SCAN)
@@ -1526,7 +1526,7 @@ static void handleQuickMenuEvent(uiEvent_t *ev)
 		return;
 	}
 #if defined(PLATFORM_GD77) || defined(PLATFORM_GD77S)
-	else if (((ev->events & BUTTON_EVENT) && (ev->buttons & BUTTON_ORANGE)) && (gMenusCurrentItemIndex==VFO_SCREEN_QUICK_MENU_VFO_A_B))
+	else if (((ev->events & BUTTON_EVENT) && BUTTONCHECK_DOWN(ev, BUTTON_ORANGE)) && (gMenusCurrentItemIndex == VFO_SCREEN_QUICK_MENU_VFO_A_B))
 	{
 		nonVolatileSettings.currentVFONumber = 1 - nonVolatileSettings.currentVFONumber;// Switch to other VFO
 		currentChannelData = &settingsVFOChannel[nonVolatileSettings.currentVFONumber];


### PR DESCRIPTION
Use **BUTTONCHECK_SHORTUP**(uiEvent_t *, BUTTON_{SK,ORANGE}) | **BUTTONCHECK_LONGDOWN**(uiEvent_t *, BUTTON_{SK,ORANGE}) for key like behaviour.
Use **BUTTONCHECK_DOWN**(uiEvent_t *, BUTTON_{SK,ORANGE}) to check the button status when a keypad key is pressed.
Enable ORANGE short/long press on all platforms, except RD-5R.

I have enabled "BeepAssist" when VOICE is ON.

RD-5R not tested (but it compiles).