### PR TITLE
Rule change

### DIFF
--- a/Linux/etc/udev/rules.d/Fedora/readme.txt
+++ b/Linux/etc/udev/rules.d/Fedora/readme.txt
@@ -4,4 +4,4 @@ Add the following lines to /etc/udev/rules.d/92-persistent-usb.rules:
 
 # Radioddity
 SUBSYSTEM=="usb", ATTRS{idVendor}=="15a2", ATTRS{idProduct}=="0073", MODE="666"
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0094", MODE==666, SYMLINK+="OpenGD77"
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0094", SYMLINK+="OpenGD77"


### PR DESCRIPTION
When played with OH1FSS Python CPS r/w I would out that in CPS mode the symlinking does not work (Fedora 30).
SUBSYSTEM must be changed from usb to tty.  I think also MODE==666 is not needed as CPS r/w worked ok without it.