### PR TITLE
Fix not sticky no beep audio setting.

### DIFF
--- a/firmware/source/functions/voicePrompts.c
+++ b/firmware/source/functions/voicePrompts.c
@@ -72,7 +72,7 @@ void voicePromptsCacheInit(void)
 	}
 
 	// is data is not loaded change prompt mode back to beep.
-	if (!voicePromptDataIsLoaded && (nonVolatileSettings.audioPromptMode > AUDIO_PROMPT_MODE_BEEP))
+	if ((nonVolatileSettings.audioPromptMode > AUDIO_PROMPT_MODE_BEEP) && (voicePromptDataIsLoaded == false))
 
 	{
 		nonVolatileSettings.audioPromptMode = AUDIO_PROMPT_MODE_BEEP;

--- a/firmware/source/functions/voicePrompts.c
+++ b/firmware/source/functions/voicePrompts.c
@@ -72,7 +72,8 @@ void voicePromptsCacheInit(void)
 	}
 
 	// is data is not loaded change prompt mode back to beep.
-	if (!voicePromptDataIsLoaded  && nonVolatileSettings.audioPromptMode < AUDIO_PROMPT_MODE_VOICE_LEVEL_1)
+	if (!voicePromptDataIsLoaded && (nonVolatileSettings.audioPromptMode > AUDIO_PROMPT_MODE_BEEP))
+
 	{
 		nonVolatileSettings.audioPromptMode = AUDIO_PROMPT_MODE_BEEP;
 	}


### PR DESCRIPTION
If voice prompts data are missing, just reset the beep level if selected mode is one of the voice levels.