### PR TITLE
DCS Inverted

### DIFF
--- a/firmware/include/functions/codeplug.h
+++ b/firmware/include/functions/codeplug.h
@@ -28,6 +28,7 @@ extern const int VFO_FREQ_STEP_TABLE[8];
 
 extern const uint16_t CODEPLUG_CSS_NONE;
 extern const uint16_t CODEPLUG_DCS_FLAGS_MASK;
+extern const uint16_t CODEPLUG_DCS_INVERTED_MASK;
 
 extern int codeplugChannelsPerZone;
 

--- a/firmware/include/functions/trx.h
+++ b/firmware/include/functions/trx.h
@@ -28,7 +28,8 @@ typedef enum
 {
 	CSS_NONE = 0,
 	CSS_CTCSS,
-	CSS_DCS
+	CSS_DCS,
+	CSS_DCS_INVERTED
 } CSSTypes_t;
 
 typedef struct frequencyBand

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -135,6 +135,7 @@ void drawDMRMicLevelBarGraph(void);
 void setOverrideTGorPC(int tgOrPc, bool privateCall);
 void printFrequency(bool isTX, bool hasFocus, uint8_t y, uint32_t frequency, bool displayVFOChannel,bool isScanMode);
 void printToneAndSquelch(void);
+size_t snprintDCS(char *s, size_t n, uint16_t code, bool inverted);
 void reset_freq_enter_digits(void);
 int read_freq_enter_digits(int startDigit, int endDigit);
 int getBatteryPercentage(void);

--- a/firmware/source/functions/codeplug.c
+++ b/firmware/source/functions/codeplug.c
@@ -69,6 +69,7 @@ const int CODEPLUG_MIN_VARIABLE_SQUELCH = 1;
 
 const uint16_t CODEPLUG_CSS_NONE = 0xFFFF;
 const uint16_t CODEPLUG_DCS_FLAGS_MASK = 0xC000;
+const uint16_t CODEPLUG_DCS_INVERTED_MASK = 0x4000;
 
 typedef struct
 {

--- a/firmware/source/functions/trx.c
+++ b/firmware/source/functions/trx.c
@@ -1028,11 +1028,15 @@ void trxSetTxCSS(uint16_t tone)
 		I2CWriteReg2byte(AT1846S_I2C_MASTER_SLAVE_ADDR_7BIT, 0x4d, 0x00, 0x00);
 		// The AT1846S wants the Golay{23,12} encoding of the DCS code, rather than just the code itself.
 		uint32_t encoded = trxDCSEncode(tone & ~CODEPLUG_DCS_FLAGS_MASK);
+		uint8_t tx_flags_high = 0x04;
+		if (tone & CODEPLUG_DCS_INVERTED_MASK)
+		{
+			tx_flags_high |= 0x01;
+		}
 		I2CWriteReg2byte(AT1846S_I2C_MASTER_SLAVE_ADDR_7BIT,	0x4b, 0x00, (encoded >> 16) & 0xff);           // init cdcss_code
 		I2CWriteReg2byte(AT1846S_I2C_MASTER_SLAVE_ADDR_7BIT,	0x4c, (encoded >> 8) & 0xff, encoded & 0xff);  // init cdcss_code
 		AT1846SetClearReg2byteWithMask(0x3a, 0xFF, 0xE0, 0x00, 0x06); // enable receive DCS
-		AT1846SetClearReg2byteWithMask(0x4e, 0x38, 0x3F, 0x04, 0x00); // enable transmit DCS
-		//set_clear_I2C_reg_2byte_with_mask(0x4e, 0xF9, 0xFF, 0x04, 0x00); // enable transmit DCS
+		AT1846SetClearReg2byteWithMask(0x4e, 0x38, 0x3F, tx_flags_high, 0x00); // enable transmit DCS
 	}
 	taskEXIT_CRITICAL();
 }

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -52,26 +52,30 @@ enum CHANNEL_DETAILS_DISPLAY_LIST { CH_DETAILS_NAME = 0,
 // Returns the index in either the CTCSS or DCS list of the tone (or closest match)
 static int cssIndex(uint16_t tone, CSSTypes_t type)
 {
-	if (type == CSS_DCS)
+	switch (type)
 	{
-		tone &= 0777;
-		for (int i = 0; i < TRX_NUM_DCS; i++)
-		{
-			if (TRX_DCSCodes[i] >= tone)
+		case CSS_CTCSS:
+			for (int i = 0; i < TRX_NUM_CTCSS; i++)
 			{
-				return i;
+				if (TRX_CTCSSTones[i] >= tone)
+				{
+					return i;
+				}
 			}
-		}
-	}
-	else if (type == CSS_CTCSS)
-	{
-		for (int i = 0; i < TRX_NUM_CTCSS; i++)
-		{
-			if (TRX_CTCSSTones[i] >= tone)
+			break;
+		case CSS_DCS:
+		case CSS_DCS_INVERTED:
+			tone &= 0777;
+			for (int i = 0; i < TRX_NUM_DCS; i++)
 			{
-				return i;
+				if (TRX_DCSCodes[i] >= tone)
+				{
+					return i;
+				}
 			}
-		}
+			break;
+		case CSS_NONE:
+			break;
 	}
 	return 0;
 }
@@ -79,38 +83,47 @@ static int cssIndex(uint16_t tone, CSSTypes_t type)
 void cssIncrement(uint16_t *tone, int32_t *index, CSSTypes_t *type, bool loop)
 {
 	(*index)++;
-	if (*type == CSS_CTCSS)
+	switch (*type)
 	{
-		if (*index >= TRX_NUM_CTCSS)
-		{
-			*type = CSS_DCS;
-			*index = 0;
-			*tone = TRX_DCSCodes[*index] | 0x8000;
-			return;
-		}
-		*tone = TRX_CTCSSTones[*index];
-	}
-	else if (*type == CSS_DCS)
-	{
-		if (*index >= TRX_NUM_DCS)
-		{
-			if (loop)
+		case CSS_CTCSS:
+			if (*index >= TRX_NUM_CTCSS)
 			{
-				*type = CSS_CTCSS;
+				*type = CSS_DCS;
 				*index = 0;
-				*tone = TRX_CTCSSTones[*index];
+				*tone = TRX_DCSCodes[*index] | 0x8000;
 				return;
 			}
-
-			*index = TRX_NUM_DCS - 1;
-		}
-		*tone = TRX_DCSCodes[*index] | 0x8000;
-	}
-	else
-	{
-		*type = CSS_CTCSS;
-		*index = 0;
-		*tone = TRX_CTCSSTones[*index];
+			*tone = TRX_CTCSSTones[*index];
+			break;
+		case CSS_DCS:
+			if (*index >= TRX_NUM_DCS)
+			{
+				*type = CSS_DCS_INVERTED;
+				*index = 0;
+				*tone = TRX_DCSCodes[*index] | 0xC000;
+				return;
+			}
+			*tone = TRX_DCSCodes[*index] | 0x8000;
+			break;
+		case CSS_DCS_INVERTED:
+			if (*index >= TRX_NUM_DCS)
+			{
+				if (loop)
+				{
+					*type = CSS_CTCSS;
+					*index = 0;
+					*tone = TRX_CTCSSTones[*index];
+					return;
+				}
+				*index = TRX_NUM_DCS - 1;
+			}
+			*tone = TRX_DCSCodes[*index] | 0xC000;
+			break;
+		case CSS_NONE:
+			*type = CSS_CTCSS;
+			*index = 0;
+			*tone = TRX_CTCSSTones[*index];
+			break;
 	}
 	return;
 }
@@ -140,6 +153,19 @@ static void cssIncrementFromEvent(uiEvent_t *ev, uint16_t *tone, int32_t *index,
 					*index = (TRX_NUM_DCS - 1);
 					*tone = TRX_DCSCodes[*index] | 0x8000;
 				}
+				else
+				{
+					*type = CSS_DCS_INVERTED;
+					*index = 0;
+					*tone = TRX_DCSCodes[*index] | 0xC000;
+				}
+				break;
+			case CSS_DCS_INVERTED:
+				if (*index < (TRX_NUM_DCS - 1))
+				{
+					*index = (TRX_NUM_DCS - 1);
+					*tone = TRX_DCSCodes[*index] | 0xC000;
+				}
 				break;
 			case CSS_NONE:
 				*type = CSS_CTCSS;
@@ -162,32 +188,42 @@ static void cssIncrementFromEvent(uiEvent_t *ev, uint16_t *tone, int32_t *index,
 static void cssDecrement(uint16_t *tone, int32_t *index, CSSTypes_t *type)
 {
 	(*index)--;
-	if (*type == CSS_CTCSS)
+	switch (*type)
 	{
-		if (*index < 0)
-		{
-			*type = CSS_NONE;
+		case CSS_CTCSS:
+			if (*index < 0)
+			{
+				*type = CSS_NONE;
+				*index = 0;
+				*tone = CODEPLUG_CSS_NONE;
+				return;
+			}
+			*tone = TRX_CTCSSTones[*index];
+			break;
+		case CSS_DCS:
+			if (*index < 0)
+			{
+				*type = CSS_CTCSS;
+				*index = TRX_NUM_CTCSS - 1;
+				*tone = TRX_CTCSSTones[*index];
+				return;
+			}
+			*tone = TRX_DCSCodes[*index] | 0x8000;
+			break;
+		case CSS_DCS_INVERTED:
+			if (*index < 0)
+			{
+				*type = CSS_DCS;
+				*index = (TRX_NUM_DCS - 1);
+				*tone = TRX_DCSCodes[*index] | 0x8000;
+				return;
+			}
+			*tone = TRX_DCSCodes[*index] | 0xC000;
+			break;
+		case CSS_NONE:
 			*index = 0;
 			*tone = CODEPLUG_CSS_NONE;
-			return;
-		}
-		*tone = TRX_CTCSSTones[*index];
-	}
-	else if (*type == CSS_DCS)
-	{
-		if (*index < 0)
-		{
-			*type = CSS_CTCSS;
-			*index = TRX_NUM_CTCSS - 1;
-			*tone = TRX_CTCSSTones[*index];
-			return;
-		}
-		*tone = TRX_DCSCodes[*index] | 0x8000;
-	}
-	else
-	{
-		*index = 0;
-		*tone = CODEPLUG_CSS_NONE;
+			break;
 	}
 }
 
@@ -223,6 +259,19 @@ static void cssDecrementFromEvent(uiEvent_t *ev, uint16_t *tone, int32_t *index,
 					*tone = TRX_CTCSSTones[*index];
 				}
 				break;
+			case CSS_DCS_INVERTED:
+				if (*index > 0)
+				{
+					*index = 0;
+					*tone = TRX_DCSCodes[*index] | 0xC000;
+				}
+				else
+				{
+					*type = CSS_DCS;
+					*index = (TRX_NUM_DCS - 1);
+					*tone = TRX_DCSCodes[*index] | 0x8000;
+				}
+				break;
 			case CSS_NONE:
 				break;
 		}
@@ -247,7 +296,14 @@ menuStatus_t menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
 
 		if (codeplugChannelToneIsDCS(tmpChannel.txTone))
 		{
-			TxCSSType = CSS_DCS;
+			if (tmpChannel.txTone & CODEPLUG_DCS_INVERTED_MASK)
+			{
+				TxCSSType = CSS_DCS_INVERTED;
+			}
+			else
+			{
+				TxCSSType = CSS_DCS;
+			}
 		}
 		else if (codeplugChannelToneIsCTCSS(tmpChannel.txTone))
 		{
@@ -257,7 +313,14 @@ menuStatus_t menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
 
 		if (codeplugChannelToneIsDCS(tmpChannel.rxTone))
 		{
-			RxCSSType = CSS_DCS;
+			if (tmpChannel.rxTone & CODEPLUG_DCS_INVERTED_MASK)
+			{
+				RxCSSType = CSS_DCS_INVERTED;
+			}
+			else
+			{
+				RxCSSType = CSS_DCS;
+			}
 		}
 		else if (codeplugChannelToneIsCTCSS(tmpChannel.rxTone))
 		{
@@ -392,7 +455,7 @@ static void updateScreen(bool isFirstRun)
 						}
 						else if (codeplugChannelToneIsDCS(tmpChannel.rxTone))
 						{
-							snprintf(rightSideVar, bufferLen, "Rx DCS:D%03oN", tmpChannel.rxTone & 0777);
+							snprintf(rightSideVar, bufferLen, "Rx DCS:D%03o%c", tmpChannel.rxTone & 0777, (tmpChannel.rxTone & CODEPLUG_DCS_INVERTED_MASK) ? 'I' : 'N');
 						}
 						else
 						{
@@ -414,7 +477,7 @@ static void updateScreen(bool isFirstRun)
 						}
 						else if (codeplugChannelToneIsDCS(tmpChannel.txTone))
 						{
-							snprintf(rightSideVar, bufferLen, "Tx DCS:D%03oN", tmpChannel.txTone & 0777);
+							snprintf(rightSideVar, bufferLen, "Tx DCS:D%03o%c", tmpChannel.txTone & 0777, (tmpChannel.txTone & CODEPLUG_DCS_INVERTED_MASK) ? 'I' : 'N');
 						}
 						else
 						{

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1404,32 +1404,35 @@ void setOverrideTGorPC(int tgOrPc, bool privateCall)
 void printToneAndSquelch(void)
 {
 	char buf[24];
+	int pos = 0;
 	if (trxGetMode() == RADIO_MODE_ANALOG)
 	{
+		pos += snprintf(buf+pos, 24-pos, "Rx:");
 		if (codeplugChannelToneIsCTCSS(currentChannelData->rxTone))
 		{
-			snprintf(buf, 24, "Rx:%d.%dHz|", currentChannelData->rxTone / 10 , currentChannelData->rxTone % 10);
+			pos += snprintf(buf+pos, 24-pos, "%d.%dHz", currentChannelData->rxTone / 10 , currentChannelData->rxTone % 10);
 		}
 		else if (codeplugChannelToneIsDCS(currentChannelData->rxTone))
 		{
-			snprintf(buf, 24, "Rx:D%03oN|", currentChannelData->rxTone & 0777);
+			pos += snprintDCS(buf+pos, 24-pos, currentChannelData->rxTone & 0777, (currentChannelData->rxTone & CODEPLUG_DCS_INVERTED_MASK));
 		}
 		else
 		{
-			snprintf(buf, 24, "Rx:%s|", currentLanguage->none);
+			pos += snprintf(buf+pos, 24-pos, "%s", currentLanguage->none);
 		}
+		pos += snprintf(buf+pos, 24-pos, "|Tx:");
 
 		if (codeplugChannelToneIsCTCSS(currentChannelData->txTone))
 		{
-			snprintf(buf, 24, "%sTx:%d.%dHz", buf, currentChannelData->txTone / 10 , currentChannelData->txTone % 10);
+			pos += snprintf(buf+pos, 24-pos, "%d.%dHz", currentChannelData->txTone / 10 , currentChannelData->txTone % 10);
 		}
 		else if (codeplugChannelToneIsDCS(currentChannelData->txTone))
 		{
-			snprintf(buf, 24, "%sTx:D%03oN", buf, currentChannelData->txTone & 0777);
+			pos += snprintDCS(buf+pos, 24-pos, currentChannelData->txTone & 0777, (currentChannelData->txTone & CODEPLUG_DCS_INVERTED_MASK));
 		}
 		else
 		{
-			snprintf(buf, 24, "%sTx:%s", buf, currentLanguage->none);
+			pos += snprintf(buf+pos, 24-pos, "%s", currentLanguage->none);
 		}
 
 #if defined(PLATFORM_RD5R)
@@ -1472,6 +1475,11 @@ const int VFO_LETTER_Y_OFFSET = 8;// This is the different in height of the SIZE
 	buffer[bufferLen - 1] = 0;
 	ucPrintAt(FREQUENCY_X_POS, y, buffer, FONT_SIZE_3);
 	ucPrintAt(DISPLAY_SIZE_X - (3 * 8), y, "MHz", FONT_SIZE_3);
+}
+
+size_t snprintDCS(char *s, size_t n, uint16_t code, bool inverted)
+{
+	return snprintf(s, n, "D%03o%c", code, (inverted ? 'I' : 'N'));
 }
 
 void reset_freq_enter_digits(void)

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -385,17 +385,20 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 
 				if(scanToneActive)
 				{
-					if (scanToneType == CSS_CTCSS)
+					switch (scanToneType)
 					{
-						sprintf(buffer, "%CTCSS %3d.%dHz", currentChannelData->rxTone / 10, currentChannelData->rxTone % 10);
-					}
-					else if (scanToneType == CSS_DCS)
-					{
-						sprintf(buffer, "DCS D%03oN", currentChannelData->rxTone & 0777);
-					}
-					else
-					{
-						sprintf(buffer, "%s", "TONE ERROR");
+						case CSS_CTCSS:
+							sprintf(buffer, "CTCSS %3d.%dHz", currentChannelData->rxTone / 10, currentChannelData->rxTone % 10);
+							break;
+						case CSS_DCS:
+							sprintf(buffer, "DCS D%03oN", currentChannelData->rxTone & 0777);
+							break;
+						case CSS_DCS_INVERTED:
+							sprintf(buffer, "DCS D%03oI", currentChannelData->rxTone & 0777);
+							break;
+						default:
+							sprintf(buffer, "%s", "TONE ERROR");
+							break;
 					}
 
 					ucPrintCentered(16, buffer, FONT_SIZE_3);


### PR DESCRIPTION
Implemented in display strings, channel details, and tone scanning.

Inverted DCS is really just DCS with mark and space in the data stream
inverted. It can be important to have this because older implementations
didn't agree on the meaning of mark and space, so some radios or
repeaters could call normal inverted and vice versa.

Because of how the math works out, inverted codes can be expressed as
non-standard codes. This also means that some non-standard codes are
actually inverted normal codes.

[OpenGD77-ajorg-dcs-inverted-20200704.zip](https://github.com/rogerclarkmelbourne/OpenGD77/files/4874202/OpenGD77-ajorg-dcs-inverted-20200704.zip)
