### PR TITLE
Fix tone scan displaying

### DIFF
--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -1522,7 +1522,14 @@ static void updateQuickMenuScreen(bool isFirstRun)
 
 		if (leftSide != NULL)
 		{
-			snprintf(buf, bufferLen, "%s:%s", *leftSide, (rightSideVar[0] ? rightSideVar : *rightSideConst));
+			if ((mNum == VFO_SCREEN_CODE_SCAN) && (rightSideConst == NULL))
+			{
+				snprintf(buf, bufferLen, "%s", *leftSide);
+			}
+			else
+			{
+				snprintf(buf, bufferLen, "%s:%s", *leftSide, (rightSideVar[0] ? rightSideVar : *rightSideConst));
+			}
 		}
 		else
 		{


### PR DESCRIPTION
 ("**Tone scan:N/A**" on digital, "**Tone scan**" on analog as it was **"Tone scan:**")