### PR TITLE
[All Platforms] Fix displaying glitches

### DIFF
--- a/firmware/include/hardware/UC1701.h
+++ b/firmware/include/hardware/UC1701.h
@@ -56,11 +56,18 @@ typedef enum
 
 extern uint8_t screenBuf[];
 
+#if defined(PLATFORM_RD5R)
+#define FONT_SIZE_3_HEIGHT                        8
+#define DISPLAY_SIZE_Y                           48
+#else
+#define FONT_SIZE_3_HEIGHT                       16
+#define DISPLAY_SIZE_Y                           64
+#endif
 
-extern const int FONT_SIZE_3_HEIGHT;
-extern const int DISPLAY_SIZE_Y;
-extern const int DISPLAY_SIZE_X;
-extern const int DISPLAY_NUMBER_OF_ROWS;
+#define DISPLAY_SIZE_X                          128
+#define DISPLAY_NUMBER_OF_ROWS  (DISPLAY_SIZE_Y / 8)
+
+
 
 void ucBegin(bool isInverted);
 void ucClearBuf(void);

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -21,14 +21,28 @@
 #include <functions/settings.h>
 
 
-#define MAX_ZONE_SCAN_NUISANCE_CHANNELS 16
-#define NUM_LASTHEARD_STORED 32
-extern const int QSO_TIMER_TIMEOUT;
-extern const int TX_TIMER_Y_OFFSET;
-extern const int CONTACT_Y_POS;
-extern const int FREQUENCY_X_POS;
-extern const int NUM_PC_OR_TG_DIGITS;
-extern const int MAX_TG_OR_PC_VALUE;
+#define MAX_ZONE_SCAN_NUISANCE_CHANNELS       16
+#define NUM_LASTHEARD_STORED                  32
+
+#define QSO_TIMER_TIMEOUT                   2400
+
+#if defined(PLATFORM_RD5R)
+#define TX_TIMER_Y_OFFSET                     12
+#define CONTACT_Y_POS                         12
+#define CONTACT_FIRST_LINE_Y_POS              24
+#define CONTACT_SECOND_LINE_Y_POS             33
+#else
+#define TX_TIMER_Y_OFFSET                      8
+#define CONTACT_Y_POS                         16
+#define CONTACT_FIRST_LINE_Y_POS              32
+#define CONTACT_SECOND_LINE_Y_POS             48
+#endif
+
+#define FREQUENCY_X_POS  /* '>Ta'*/ ((3 * 8) + 4)
+#define MAX_POWER_SETTING_NUM                  9
+#define NUM_PC_OR_TG_DIGITS                    8
+#define MAX_TG_OR_PC_VALUE              16777215
+
 
 extern struct_codeplugRxGroup_t currentRxGroupData;
 extern struct_codeplugContact_t currentContactData;
@@ -91,7 +105,6 @@ typedef enum
 	SCAN_PAUSED
 } ScanState_t;
 
-extern const int MAX_POWER_SETTING_NUM;
 extern const char *POWER_LEVELS[];
 extern const char *POWER_LEVEL_UNITS[];
 extern const char *DMR_DESTINATION_FILTER_LEVELS[];

--- a/firmware/source/hardware/UC1701.c
+++ b/firmware/source/hardware/UC1701.c
@@ -45,17 +45,7 @@ __attribute__((section(".data.$RAM2"))) uint8_t screenBuf[1024];
 #ifdef DISPLAY_CHECK_BOUNDS
 static const uint8_t *screenBufEnd = screenBuf + sizeof(screenBuf);
 #endif
-int activeBufNum=0;
 
-#if defined(PLATFORM_RD5R)
-const int DISPLAY_SIZE_Y = 48;
-const int FONT_SIZE_3_HEIGHT = 8;
-#else
-const int DISPLAY_SIZE_Y = 64;
-const int FONT_SIZE_3_HEIGHT = 16;
-#endif
-const int DISPLAY_SIZE_X = 128;
-const int DISPLAY_NUMBER_OF_ROWS = (DISPLAY_SIZE_Y / 8);
 
 
 int16_t ucSetPixel(int16_t x, int16_t y, bool color)
@@ -83,7 +73,7 @@ int16_t ucSetPixel(int16_t x, int16_t y, bool color)
 
 void ucRender(void)
 {
-	ucRenderRows(0,8);
+	ucRenderRows(0, DISPLAY_NUMBER_OF_ROWS);
 }
 
 //#define DISPLAY_CHECK_BOUNDS

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -470,10 +470,10 @@ void uiChannelModeUpdateScreen(int txTimeSecs)
 #if defined(PLATFORM_RD5R)
 		ucFillRect(0, 0, DISPLAY_SIZE_X, 8, true);
 #else
-		ucClearRows(0,  2, false);
+		ucClearRows(0, 2, false);
 #endif
 		menuUtilityRenderHeader();
-		ucRenderRows(0,  2);
+		ucRenderRows(0, 2);
 		return;
 	}
 
@@ -556,7 +556,6 @@ void uiChannelModeUpdateScreen(int txTimeSecs)
 						}
 
 						ucPrintCentered(CH_NAME_Y_POS, (char *)nameBuf, FONT_SIZE_1);
-
 					}
 				}
 			}

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -448,9 +448,18 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 					ucPrintAt(DISPLAY_SIZE_X - ((7 * 8) + 2), TX_FREQ_Y_POS, buffer, FONT_SIZE_3);
 					// Scanning direction arrow
 					static const int scanDirArrow[2][6] = {
-							{ 59, 55, 67, 51, 67, 59 }, // Down
-							{ 59, 59, 59, 51, 67, 55 }, // Up
+							{ // Down
+									59, (TX_FREQ_Y_POS + (FONT_SIZE_3_HEIGHT / 2) - 1),
+									67, (TX_FREQ_Y_POS + (FONT_SIZE_3_HEIGHT / 2) - (FONT_SIZE_3_HEIGHT / 4) - 1),
+									67, (TX_FREQ_Y_POS + (FONT_SIZE_3_HEIGHT / 2) + (FONT_SIZE_3_HEIGHT / 4) - 1)
+							}, // Up
+							{
+									59, (TX_FREQ_Y_POS + (FONT_SIZE_3_HEIGHT / 2) + (FONT_SIZE_3_HEIGHT / 4) - 1),
+									59, (TX_FREQ_Y_POS + (FONT_SIZE_3_HEIGHT / 2) - (FONT_SIZE_3_HEIGHT / 4) - 1),
+									67, (TX_FREQ_Y_POS + (FONT_SIZE_3_HEIGHT / 2) - 1)
+							}
 					};
+
 					ucFillTriangle(scanDirArrow[(scanDirection > 0)][0], scanDirArrow[(scanDirection > 0)][1],
 								   scanDirArrow[(scanDirection > 0)][2], scanDirArrow[(scanDirection > 0)][3],
 								   scanDirArrow[(scanDirection > 0)][4], scanDirArrow[(scanDirection > 0)][5], true);
@@ -460,6 +469,12 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 			{
 				int8_t xCursor = -1;
 				int8_t yCursor = -1;
+				int labelsVOffset =
+#if defined(PLATFORM_RD5R)
+						4;
+#else
+						0;
+#endif
 
 				if (screenOperationMode[nonVolatileSettings.currentVFONumber] == VFO_SCREEN_OPERATION_NORMAL)
 				{
@@ -472,42 +487,30 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 					snprintf(buffer, bufferLen, FREQ_DISP_STR, freq_enter_digits[0], freq_enter_digits[1], freq_enter_digits[2],
 							freq_enter_digits[3], freq_enter_digits[4], freq_enter_digits[5], freq_enter_digits[6], freq_enter_digits[7]);
 
-#if defined(PLATFORM_RD5R)
-					ucPrintCentered((selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX) ? TX_FREQ_Y_POS : 24, buffer, FONT_SIZE_3);
-#else
 					ucPrintCentered((selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX) ? TX_FREQ_Y_POS : RX_FREQ_Y_POS, buffer, FONT_SIZE_3);
-#endif
+
 					// Cursor
 					if (freq_enter_idx < 8)
 					{
 						xCursor = ((DISPLAY_SIZE_X - (strlen(buffer) * 8)) >> 1) + ((freq_enter_idx + ((freq_enter_idx > 2) ? 1 : 0)) * 8);
-						yCursor = ((selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX) ? TX_FREQ_Y_POS : RX_FREQ_Y_POS) + 14;
+						yCursor = ((selectedFreq == VFO_SELECTED_FREQUENCY_INPUT_TX) ? TX_FREQ_Y_POS : RX_FREQ_Y_POS) + (FONT_SIZE_3_HEIGHT - 2);
 					}
 				}
 				else
 				{
 					uint8_t hiX = DISPLAY_SIZE_X - ((7 * 8) + 2);
-					ucPrintAt(5, (DISPLAY_SIZE_Y / 2), "Low", FONT_SIZE_3);
-#if defined(PLATFORM_RD5R)
-					ucDrawFastVLine(0, 29, 24, true);
-#else
-					ucDrawFastVLine(0, 37, 24, true);
-#endif
-					ucDrawFastHLine(1, TX_FREQ_Y_POS, 57, true);
+					ucPrintAt(5, RX_FREQ_Y_POS - labelsVOffset, "Low", FONT_SIZE_3);
+					ucDrawFastVLine(0, RX_FREQ_Y_POS - labelsVOffset, ((FONT_SIZE_3_HEIGHT * 2) + labelsVOffset), true);
+					ucDrawFastHLine(1, TX_FREQ_Y_POS - (labelsVOffset / 2), 57, true);
 
 					sprintf(buffer, "%c%c%c.%c%c%c", freq_enter_digits[0], freq_enter_digits[1], freq_enter_digits[2],
 													 freq_enter_digits[3], freq_enter_digits[4], freq_enter_digits[5]);
 
 					ucPrintAt(2, TX_FREQ_Y_POS, buffer, FONT_SIZE_3);
 
-#if defined(PLATFORM_RD5R)
-					ucPrintAt(73, 24, "High", FONT_SIZE_3);
-					ucDrawFastVLine(68, 29, 24, true);
-#else
-					ucPrintAt(73, 32, "High", FONT_SIZE_3);
-					ucDrawFastVLine(68, 37, 24, true);
-#endif
-					ucDrawFastHLine(69, TX_FREQ_Y_POS, 57, true);
+					ucPrintAt(73, RX_FREQ_Y_POS - labelsVOffset, "High", FONT_SIZE_3);
+					ucDrawFastVLine(68, RX_FREQ_Y_POS - labelsVOffset, ((FONT_SIZE_3_HEIGHT * 2) + labelsVOffset), true);
+					ucDrawFastHLine(69, TX_FREQ_Y_POS - (labelsVOffset / 2), 57, true);
 
 					sprintf(buffer, "%c%c%c.%c%c%c", freq_enter_digits[6], freq_enter_digits[7], freq_enter_digits[8],
 													 freq_enter_digits[9], freq_enter_digits[10], freq_enter_digits[11]);
@@ -521,7 +524,7 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 								+ (((freq_enter_idx < 6) ? (freq_enter_idx - 1) : (freq_enter_idx - 7)) * 8) // Length
 								+ ((freq_enter_idx > 2 ? (freq_enter_idx > 8 ? 2 : 1) : 0) * 8); // MHz/kHz separator(s)
 
-						yCursor = TX_FREQ_Y_POS + 14;
+						yCursor = TX_FREQ_Y_POS + (FONT_SIZE_3_HEIGHT - 2);
 					}
 				}
 


### PR DESCRIPTION
Turn many "extern const int" into #defines, as GCC won't handle them as real const unless there declared in the C file (there is constexpr in C++).
Add some safety in printSplitOrSpanText().
Remove and merge many platform conditional code about contact displaying.
Fix freq input for normal and VFO scanning + directional arrow (scanning direction) for RD-5R