### PR TITLE
Fix rd5r (and other platforms) squelch area clearing

### DIFF
--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -31,11 +31,15 @@
 #define CONTACT_Y_POS                         12
 #define CONTACT_FIRST_LINE_Y_POS              24
 #define CONTACT_SECOND_LINE_Y_POS             33
+#define SQUELCH_BAR_Y_POS                     14
+#define SQUELCH_BAR_H                          4
 #else
 #define TX_TIMER_Y_OFFSET                      8
 #define CONTACT_Y_POS                         16
 #define CONTACT_FIRST_LINE_Y_POS              32
 #define CONTACT_SECOND_LINE_Y_POS             48
+#define SQUELCH_BAR_Y_POS                     17
+#define SQUELCH_BAR_H                          9
 #endif
 
 #define FREQUENCY_X_POS  /* '>Ta'*/ ((3 * 8) + 4)

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -38,7 +38,7 @@
 #define CONTACT_Y_POS                         16
 #define CONTACT_FIRST_LINE_Y_POS              32
 #define CONTACT_SECOND_LINE_Y_POS             48
-#define SQUELCH_BAR_Y_POS                     17
+#define SQUELCH_BAR_Y_POS                     16
 #define SQUELCH_BAR_H                          9
 #endif
 

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -115,6 +115,8 @@ menuStatus_t uiChannelMode(uiEvent_t *ev, bool isFirstRun)
 		displayChannelSettings = false;
 		reverseRepeater = false;
 		nextChannelReady = false;
+		displaySquelch = false;
+
 
 		// We're in digital mode, RXing, and current talker is already at the top of last heard list,
 		// hence immediately display complete contact/TG info on screen
@@ -205,13 +207,12 @@ menuStatus_t uiChannelMode(uiEvent_t *ev, bool isFirstRun)
 				if (displaySquelch && ((ev->time - sqm) > 1000))
 				{
 					displaySquelch = false;
-
 #if defined(PLATFORM_RD5R)
-					ucFillRect(0, 15, DISPLAY_SIZE_X, 9, true);
+					ucClearRows(2, 3, false);
 #else
 					ucClearRows(2, 4, false);
 #endif
-					ucRenderRows(2,4);
+					ucRenderRows(2, 4);
 				}
 
 				if ((ev->time - m) > RSSI_UPDATE_COUNTER_RELOAD)

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -221,11 +221,7 @@ menuStatus_t uiChannelMode(uiEvent_t *ev, bool isFirstRun)
 
 					if (scanActive && (scanState == SCAN_PAUSED))
 					{
-#if defined(PLATFORM_RD5R)
-						ucFillRect(0, 16, DISPLAY_SIZE_X, 8, true);
-#else
 						ucClearRows(0, 2, false);
-#endif
 						menuUtilityRenderHeader();
 					}
 					else
@@ -469,7 +465,7 @@ void uiChannelModeUpdateScreen(int txTimeSecs)
 			((menuDisplayQSODataState == QSO_DISPLAY_CALLER_DATA) || (menuDisplayQSODataState == QSO_DISPLAY_CALLER_DATA_UPDATE)))
 	{
 #if defined(PLATFORM_RD5R)
-		ucFillRect(0, 0, DISPLAY_SIZE_X, 8, true);
+		ucClearRows(0, 1, false);
 #else
 		ucClearRows(0, 2, false);
 #endif
@@ -504,7 +500,7 @@ void uiChannelModeUpdateScreen(int txTimeSecs)
 				{
 					displaySquelch = false;
 #if defined(PLATFORM_RD5R)
-					ucFillRect(0, 15, DISPLAY_SIZE_X, 9, true);
+					ucClearRows(2, 3, false);
 #else
 					ucClearRows(2, 4, false);
 #endif

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -221,7 +221,11 @@ menuStatus_t uiChannelMode(uiEvent_t *ev, bool isFirstRun)
 
 					if (scanActive && (scanState == SCAN_PAUSED))
 					{
+#if defined(PLATFORM_RD5R)
+						ucClearRows(0, 1, false);
+#else
 						ucClearRows(0, 2, false);
+#endif
 						menuUtilityRenderHeader();
 					}
 					else

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -93,12 +93,8 @@ static menuStatus_t menuQuickChannelExitStatus = MENU_STATUS_SUCCESS;
 
 #if defined(PLATFORM_RD5R)
 static const int  CH_NAME_Y_POS = 40;
-static const int  XBAR_Y_POS = 15;
-static const int  XBAR_H = 4;
 #else
 static const int  CH_NAME_Y_POS = 50;
-static const int  XBAR_Y_POS = 17;
-static const int  XBAR_H = 9;
 #endif
 
 menuStatus_t uiChannelMode(uiEvent_t *ev, bool isFirstRun)
@@ -208,7 +204,7 @@ menuStatus_t uiChannelMode(uiEvent_t *ev, bool isFirstRun)
 				{
 					displaySquelch = false;
 #if defined(PLATFORM_RD5R)
-					ucClearRows(2, 3, false);
+					ucFillRect(0, SQUELCH_BAR_Y_POS, DISPLAY_SIZE_X, 9, true);
 #else
 					ucClearRows(2, 4, false);
 #endif
@@ -504,7 +500,7 @@ void uiChannelModeUpdateScreen(int txTimeSecs)
 				{
 					displaySquelch = false;
 #if defined(PLATFORM_RD5R)
-					ucClearRows(2, 3, false);
+					ucFillRect(0, SQUELCH_BAR_Y_POS, DISPLAY_SIZE_X, 9, true);
 #else
 					ucClearRows(2, 4, false);
 #endif
@@ -513,7 +509,7 @@ void uiChannelModeUpdateScreen(int txTimeSecs)
 				snprintf(buffer, bufferLen, " %d ", txTimeSecs);
 				buffer[bufferLen - 1] = 0;
 				ucPrintCentered(TX_TIMER_Y_OFFSET, buffer, FONT_SIZE_4);
-				verticalPositionOffset=16;
+				verticalPositionOffset = 16;
 			}
 			else
 			{
@@ -598,10 +594,11 @@ void uiChannelModeUpdateScreen(int txTimeSecs)
 				strncpy(buffer, currentLanguage->squelch, 9);
 				buffer[8] = 0; // Avoid overlap with bargraph
 				// Center squelch word between col0 and bargraph, if possible.
-				ucPrintAt(0 + ((strlen(buffer) * 8) < xbar - 2 ? (((xbar - 2) - (strlen(buffer) * 8)) >> 1) : 0), 16, buffer, FONT_SIZE_3);
+				ucPrintAt(0 + ((strlen(buffer) * 8) < xbar - 2 ? (((xbar - 2) - (strlen(buffer) * 8)) >> 1) : 0), SQUELCH_BAR_Y_POS, buffer, FONT_SIZE_3);
+
 				int bargraph = 1 + ((currentChannelData->sql - 1) * 5) /2;
-				ucDrawRect(xbar - 2, XBAR_Y_POS, 55, XBAR_H + 4, true);
-				ucFillRect(xbar, XBAR_Y_POS + 2, bargraph, XBAR_H, false);
+				ucDrawRect(xbar - 2, SQUELCH_BAR_Y_POS, 55, SQUELCH_BAR_H + 4, true);
+				ucFillRect(xbar, SQUELCH_BAR_Y_POS + 2, bargraph, SQUELCH_BAR_H, false);
 			}
 
 			// SK1 is pressed, we don't want to clear the first info row after 1s
@@ -1141,6 +1138,8 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		else if (KEYCHECK_SHORTUP(ev->keys, KEY_DOWN) || KEYCHECK_LONGDOWN_REPEAT(ev->keys, KEY_DOWN))
 		{
+			displaySquelch = false;
+
 			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 			{
 				int numZones = codeplugZonesGetCount();
@@ -1207,6 +1206,7 @@ static void handleEvent(uiEvent_t *ev)
 		}
 		else if (KEYCHECK_SHORTUP(ev->keys, KEY_UP) || KEYCHECK_LONGDOWN_REPEAT(ev->keys, KEY_UP))
 		{
+			displaySquelch = false;
 			handleUpKey(ev);
 			return;
 		}

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -70,8 +70,6 @@ const int TX_FREQ_Y_POS = 40;
 const int CONTACT_TX_Y_POS = 28;
 const int CONTACT_TX_FRAME_Y_POS = 26;
 const int CONTACT_Y_POS_OFFSET = 2;
-const int XBAR_Y_POS = 16;
-const int XBAR_H = 4;
 #else
 const int RX_FREQ_Y_POS = 32;
 const int TX_FREQ_Y_POS = 48;
@@ -79,8 +77,6 @@ const int TX_FREQ_Y_POS = 48;
 const int CONTACT_TX_Y_POS = 34;
 const int CONTACT_TX_FRAME_Y_POS = 34;
 const int CONTACT_Y_POS_OFFSET = 0;
-const int XBAR_Y_POS = 17;
-const int XBAR_H = 9;
 #endif
 
 
@@ -211,7 +207,7 @@ menuStatus_t uiVFOMode(uiEvent_t *ev, bool isFirstRun)
 				{
 					displaySquelch = false;
 #if defined(PLATFORM_RD5R)
-					ucClearRows(2, 3, false);
+					ucFillRect(0, SQUELCH_BAR_Y_POS, DISPLAY_SIZE_X, 9, true);
 #else
 					ucClearRows(2, 4, false);
 #endif
@@ -376,12 +372,11 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 					strncpy(buffer, currentLanguage->squelch, 9);
 					buffer[8] = 0; // Avoid overlap with bargraph
 					// Center squelch word between col0 and bargraph, if possible.
-
 					ucPrintAt(0 + ((strlen(buffer) * 8) < xbar - 2 ? (((xbar - 2) - (strlen(buffer) * 8)) >> 1) : 0), 16, buffer, FONT_SIZE_3);
-					int bargraph = 1 + ((currentChannelData->sql - 1) * 5) /2;
 
-					ucDrawRect(xbar - 2, XBAR_Y_POS, 55, XBAR_H + 4, true);
-					ucFillRect(xbar, XBAR_Y_POS + 2, bargraph, XBAR_H, false);
+					int bargraph = 1 + ((currentChannelData->sql - 1) * 5) /2;
+					ucDrawRect(xbar - 2, SQUELCH_BAR_Y_POS, 55, SQUELCH_BAR_H + 4, true);
+					ucFillRect(xbar, SQUELCH_BAR_Y_POS + 2, bargraph, SQUELCH_BAR_H, false);
 				}
 
 				// SK1 is pressed, we don't want to clear the first info row after 1s
@@ -429,7 +424,11 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 					if (displaySquelch)
 					{
 						displaySquelch = false;
+#if defined(PLATFORM_RD5R)
+						ucFillRect(0, SQUELCH_BAR_Y_POS, DISPLAY_SIZE_X, 9, true);
+#else
 						ucClearRows(2, 4, false);
+#endif
 					}
 					snprintf(buffer, bufferLen, " %d ", txTimeSecs);
 					ucPrintCentered(TX_TIMER_Y_OFFSET, buffer, FONT_SIZE_4);

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -224,7 +224,11 @@ menuStatus_t uiVFOMode(uiEvent_t *ev, bool isFirstRun)
 
 					if (scanActive && (scanState == SCAN_PAUSED))
 					{
+#if defined(PLATFORM_RD5R)
+						ucClearRows(0, 1, false);
+#else
 						ucClearRows(0, 2, false);
+#endif
 						menuUtilityRenderHeader();
 					}
 					else

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -95,6 +95,7 @@ menuStatus_t uiVFOMode(uiEvent_t *ev, bool isFirstRun)
 
 		isDisplayingQSOData = false;
 		reverseRepeater = false;
+		displaySquelch = false;
 		settingsSet(nonVolatileSettings.initialMenuNumber, UI_VFO_MODE);
 		prevDisplayQSODataState = QSO_DISPLAY_IDLE;
 		currentChannelData = &settingsVFOChannel[nonVolatileSettings.currentVFONumber];
@@ -210,11 +211,11 @@ menuStatus_t uiVFOMode(uiEvent_t *ev, bool isFirstRun)
 				{
 					displaySquelch = false;
 #if defined(PLATFORM_RD5R)
-					ucFillRect(0, 16, DISPLAY_SIZE_X, 12, true);
+					ucClearRows(2, 3, false);
 #else
 					ucClearRows(2, 4, false);
 #endif
-					ucRenderRows(2,4);
+					ucRenderRows(2, 4);
 				}
 
 				if ((ev->time - m) > RSSI_UPDATE_COUNTER_RELOAD)

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -372,7 +372,7 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 					strncpy(buffer, currentLanguage->squelch, 9);
 					buffer[8] = 0; // Avoid overlap with bargraph
 					// Center squelch word between col0 and bargraph, if possible.
-					ucPrintAt(0 + ((strlen(buffer) * 8) < xbar - 2 ? (((xbar - 2) - (strlen(buffer) * 8)) >> 1) : 0), 16, buffer, FONT_SIZE_3);
+					ucPrintAt(0 + ((strlen(buffer) * 8) < xbar - 2 ? (((xbar - 2) - (strlen(buffer) * 8)) >> 1) : 0), SQUELCH_BAR_Y_POS, buffer, FONT_SIZE_3);
 
 					int bargraph = 1 + ((currentChannelData->sql - 1) * 5) /2;
 					ucDrawRect(xbar - 2, SQUELCH_BAR_Y_POS, 55, SQUELCH_BAR_H + 4, true);

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -298,12 +298,12 @@ void uiVFOModeUpdateScreen(int txTimeSecs)
 			((menuDisplayQSODataState == QSO_DISPLAY_CALLER_DATA) || (menuDisplayQSODataState == QSO_DISPLAY_CALLER_DATA_UPDATE)))
 	{
 #if defined(PLATFORM_RD5R)
-		ucFillRect(0, 0, DISPLAY_SIZE_X, 8, true);
+		ucClearRows(0, 1, false);
 #else
-		ucClearRows(0,  2, false);
+		ucClearRows(0, 2, false);
 #endif
 		menuUtilityRenderHeader();
-		ucRenderRows(0,  2);
+		ucRenderRows(0, 2);
 		return;
 	}
 


### PR DESCRIPTION
displaySquelch variable is shared and need to be reset when loading the menu, otherwise region could be cleared when switching between VFO and Channel menus, clearing the contact area (partially). 
Use ucClearRows() as it's possible and faster.