### PR TITLE
Fix font_tool compilation with GCC 9

### DIFF
--- a/tools/font_tools/font_converter/Makefile
+++ b/tools/font_tools/font_converter/Makefile
@@ -3,8 +3,8 @@ src = UC1701_font_tool.c
 obj = $(src:.c=.o)
 
 CC = gcc
-CFLAGS = -Wall -O2 -DBUILD_FONT_TOOL -I../../../firmware/include/hardware
-CFLAGS_DEBUG = -Wall -O0 -g -DBUILD_FONT_TOOL -I../../../firmware/include/hardware
+CFLAGS = -Wall -Wno-restrict -O2 -DBUILD_FONT_TOOL -I../../../firmware/include/hardware
+CFLAGS_DEBUG = -Wall -Wno-restrict -O0 -g -DBUILD_FONT_TOOL -I../../../firmware/include/hardware
 LDFLAGS = -static -s
 LDFLAGS_DEBUG =
 


### PR DESCRIPTION
Turn off restrict warning (needed for GCC 9.x, as code is a bit "ugly" sometimes).