### PR TITLE
Bugfix chanmode switch

### DIFF
--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -1072,6 +1072,11 @@ static void handleEvent(uiEvent_t *ev)
 		{
 			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))  // Toggle Channel Mode
 			{
+				channelScreenChannelData.chMode = (trxGetMode() == RADIO_MODE_ANALOG)?RADIO_MODE_DIGITAL:RADIO_MODE_ANALOG;
+				loadChannelData(true, false);
+
+				menuChannelExitStatus |= MENU_STATUS_FORCE_FIRST;
+/*
 				if (trxGetMode() == RADIO_MODE_ANALOG)
 				{
 					channelScreenChannelData.chMode = RADIO_MODE_DIGITAL;
@@ -1085,6 +1090,7 @@ static void handleEvent(uiEvent_t *ev)
 					trxSetModeAndBandwidth(channelScreenChannelData.chMode, ((channelScreenChannelData.flag4 & 0x02) == 0x02));
 					trxSetRxCSS(currentChannelData->rxTone);
 				}
+*/
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 				uiChannelModeUpdateScreen(0);
 			}

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -1076,21 +1076,6 @@ static void handleEvent(uiEvent_t *ev)
 				loadChannelData(true, false);
 
 				menuChannelExitStatus |= MENU_STATUS_FORCE_FIRST;
-/*
-				if (trxGetMode() == RADIO_MODE_ANALOG)
-				{
-					channelScreenChannelData.chMode = RADIO_MODE_DIGITAL;
-					trxSetModeAndBandwidth(channelScreenChannelData.chMode, false);
-
-					menuChannelExitStatus |= MENU_STATUS_FORCE_FIRST;
-				}
-				else
-				{
-					channelScreenChannelData.chMode = RADIO_MODE_ANALOG;
-					trxSetModeAndBandwidth(channelScreenChannelData.chMode, ((channelScreenChannelData.flag4 & 0x02) == 0x02));
-					trxSetRxCSS(currentChannelData->rxTone);
-				}
-*/
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 				uiChannelModeUpdateScreen(0);
 			}

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -1072,10 +1072,18 @@ static void handleEvent(uiEvent_t *ev)
 		{
 			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))  // Toggle Channel Mode
 			{
-				channelScreenChannelData.chMode = (trxGetMode() == RADIO_MODE_ANALOG)?RADIO_MODE_DIGITAL:RADIO_MODE_ANALOG;
-				loadChannelData(true, false);
-
-				menuChannelExitStatus |= MENU_STATUS_FORCE_FIRST;
+				if (trxGetMode() == RADIO_MODE_ANALOG)
+				{
+					channelScreenChannelData.chMode = RADIO_MODE_DIGITAL;
+					loadChannelData(true, false);
+					menuChannelExitStatus |= MENU_STATUS_FORCE_FIRST;
+				}
+				else
+				{
+					channelScreenChannelData.chMode = RADIO_MODE_ANALOG;
+					trxSetModeAndBandwidth(channelScreenChannelData.chMode, ((channelScreenChannelData.flag4 & 0x02) == 0x02));
+					trxSetRxCSS(currentChannelData->rxTone);
+				}
 				menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 				uiChannelModeUpdateScreen(0);
 			}


### PR DESCRIPTION
Fix of the incomplete channel setup after manual switch of the channel mode between analog and digital. Especially for the digital mode, a lot of properties (CC, TS, RxGroup..) were not set up and some subsequent manipulation (like a short PTT press) was neccessary to fix it.