### PR TITLE
fix backlight stuck to off when toggling screen invert.

### DIFF
--- a/firmware/source/user_interface/menuDisplayOptions.c
+++ b/firmware/source/user_interface/menuDisplayOptions.c
@@ -264,9 +264,11 @@ static void handleEvent(uiEvent_t *ev)
 							settingsSet(nonVolatileSettings.displayBacklightPercentageOff, BACKLIGHT_MAX_PERCENTAGE);
 						}
 
-						if (nonVolatileSettings.displayBacklightPercentageOff > nonVolatileSettings.displayBacklightPercentage)
+						if (nonVolatileSettings.displayBacklightPercentageOff >= nonVolatileSettings.displayBacklightPercentage)
 						{
-							settingsSet(nonVolatileSettings.displayBacklightPercentageOff, nonVolatileSettings.displayBacklightPercentage);
+
+							settingsSet(nonVolatileSettings.displayBacklightPercentageOff,
+									nonVolatileSettings.displayBacklightPercentage ? (nonVolatileSettings.displayBacklightPercentage - 1) : 0);
 						}
 
 						if ((nonVolatileSettings.backlightMode == BACKLIGHT_MODE_MANUAL) && (!displayIsLit))
@@ -330,9 +332,10 @@ static void handleEvent(uiEvent_t *ev)
 						settingsSet(nonVolatileSettings.displayBacklightPercentage, 0);
 					}
 
-					if (nonVolatileSettings.displayBacklightPercentageOff > nonVolatileSettings.displayBacklightPercentage)
+					if (nonVolatileSettings.displayBacklightPercentageOff >= nonVolatileSettings.displayBacklightPercentage)
 					{
-						settingsSet(nonVolatileSettings.displayBacklightPercentageOff, nonVolatileSettings.displayBacklightPercentage);
+						settingsSet(nonVolatileSettings.displayBacklightPercentageOff,
+								nonVolatileSettings.displayBacklightPercentage ? (nonVolatileSettings.displayBacklightPercentage - 1) : 0);
 					}
 					break;
 				case DISPLAY_MENU_BRIGHTNESS_OFF:


### PR DESCRIPTION
To reproduce, set min backlight value equal to backlight value, toggle invert: backlight off, and won't lit until reboot.
Because there is no other way to detect if the backlight is on, the PWM value is compared to displayBacklightPercentageOff.
So, minimum backlight need to be < to backlight value (and this is logical anyway).

(noticed that bug in a recent videoo on YT)