### PR TITLE
Fix 1750 and DTMF keys when PTT Latch is used (ANALOG only).

### DIFF
--- a/firmware/include/io/keyboard.h
+++ b/firmware/include/io/keyboard.h
@@ -107,6 +107,7 @@ typedef struct keyboardCode
 
 void keyboardInit(void);
 void keyboardReset(void);
+bool keyboardKeyIsDTMFKey(char key);
 uint32_t keyboardRead(void);
 void keyboardCheckKeyEvent(keyboardCode_t *keys, int *event);
 bool heyboardScanKey(uint32_t scancode, char *keycode);

--- a/firmware/source/io/keyboard.c
+++ b/firmware/source/io/keyboard.c
@@ -116,6 +116,22 @@ void keyboardReset(void)
 	keyState = KEY_WAIT_RELEASED;
 }
 
+bool keyboardKeyIsDTMFKey(char key)
+{
+	switch (key)
+	{
+		case KEY_0 ... KEY_9:
+		case KEY_STAR:
+		case KEY_HASH:
+		case KEY_LEFT:  // A
+		case KEY_UP:    // B
+		case KEY_DOWN:  // C
+		case KEY_RIGHT: // D
+			return true;
+	}
+	return false;
+}
+
 static inline uint8_t keyboardReadCol(void)
 {
 #if defined(PLATFORM_GD77S)

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -490,15 +490,13 @@ void mainTask(void *data)
 			// PTT toggle feature
 			//
 			// PTT is locked down, but any button, except SK1 or SK2(1750Hz in FM) or DTMF Key in Analog, is pressed, virtually release PTT
-#if defined(PLATFORM_RD5R)
 			if ((nonVolatileSettings.pttToggle && PTTToggledDown) &&
-					(((button_event & EVENT_BUTTON_CHANGE) && ((trxMode != RADIO_MODE_ANALOG) && (buttons & BUTTON_SK2))) ||
-							((keys.key != 0) && (keys.event & KEY_MOD_UP) && (((trxMode == RADIO_MODE_ANALOG) && keyboardKeyIsDTMFKey(keys.key)) == false))))
-#else
-			if ((nonVolatileSettings.pttToggle && PTTToggledDown) &&
-					(((button_event & EVENT_BUTTON_CHANGE) && ((buttons & BUTTON_ORANGE) || ((trxMode != RADIO_MODE_ANALOG) && (buttons & BUTTON_SK2)))) ||
-							((keys.key != 0) && (keys.event & KEY_MOD_UP) && (((trxMode == RADIO_MODE_ANALOG) && keyboardKeyIsDTMFKey(keys.key)) == false))))
+					(((button_event & EVENT_BUTTON_CHANGE) && (
+#if ! defined(PLATFORM_RD5R)
+							(buttons & BUTTON_ORANGE) ||
 #endif
+							((trxMode != RADIO_MODE_ANALOG) && (buttons & BUTTON_SK2)))) ||
+							((keys.key != 0) && (keys.event & KEY_MOD_UP) && (((trxMode == RADIO_MODE_ANALOG) && keyboardKeyIsDTMFKey(keys.key)) == false))))
 			{
 				PTTToggledDown = false;
 				button_event = EVENT_BUTTON_CHANGE;

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -485,18 +485,19 @@ void mainTask(void *data)
 			}
 			 */
 
+			int trxMode = trxGetMode();
 			//
 			// PTT toggle feature
 			//
-			// PTT is locked down, but any button but SK1 is pressed, virtually release PTT
+			// PTT is locked down, but any button, except SK1 or SK2(1750Hz in FM) or DTMF Key in Analog, is pressed, virtually release PTT
 #if defined(PLATFORM_RD5R)
 			if ((nonVolatileSettings.pttToggle && PTTToggledDown) &&
-					(((buttons & BUTTON_SK2)) ||
-							((keys.key != 0) && (keys.event & KEY_MOD_UP))))
+					(((button_event & EVENT_BUTTON_CHANGE) && ((trxMode != RADIO_MODE_ANALOG) && (buttons & BUTTON_SK2))) ||
+							((keys.key != 0) && (keys.event & KEY_MOD_UP) && (((trxMode == RADIO_MODE_ANALOG) && keyboardKeyIsDTMFKey(keys.key)) == false))))
 #else
 			if ((nonVolatileSettings.pttToggle && PTTToggledDown) &&
-					(((button_event & EVENT_BUTTON_CHANGE) && ((buttons & BUTTON_ORANGE) || (buttons & BUTTON_SK2))) ||
-							((keys.key != 0) && (keys.event & KEY_MOD_UP))))
+					(((button_event & EVENT_BUTTON_CHANGE) && ((buttons & BUTTON_ORANGE) || ((trxMode != RADIO_MODE_ANALOG) && (buttons & BUTTON_SK2)))) ||
+							((keys.key != 0) && (keys.event & KEY_MOD_UP) && (((trxMode == RADIO_MODE_ANALOG) && keyboardKeyIsDTMFKey(keys.key)) == false))))
 #endif
 			{
 				PTTToggledDown = false;
@@ -505,6 +506,7 @@ void mainTask(void *data)
 				key_event = NO_EVENT;
 				keys.key = 0;
 			}
+
 			// PTT toggle action
 			if (nonVolatileSettings.pttToggle)
 			{
@@ -553,7 +555,7 @@ void mainTask(void *data)
 					 * if ((slot_state == DMR_STATE_IDLE || trxDMRMode == DMR_MODE_PASSIVE)  &&
 					 *
 					 */
-					if ((trxGetMode() != RADIO_MODE_NONE) &&
+					if ((trxMode != RADIO_MODE_NONE) &&
 							(settingsUsbMode != USB_MODE_HOTSPOT) &&
 							(currentMenu != UI_POWER_OFF) &&
 							(currentMenu != UI_SPLASH_SCREEN) &&

--- a/firmware/source/user_interface/uiTxScreen.c
+++ b/firmware/source/user_interface/uiTxScreen.c
@@ -278,29 +278,26 @@ static void handleEvent(uiEvent_t *ev)
 	// Key action while xmitting (ANALOG), Tone triggering
 	if (!trxIsTransmittingTone && ((ev->buttons & BUTTON_PTT) != 0) && trxTransmissionEnabled && (trxGetMode() == RADIO_MODE_ANALOG))
 	{
-		if (PTTToggledDown == false)
+		// Send 1750Hz
+		if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
 		{
-			// Send 1750Hz
-			if (BUTTONCHECK_DOWN(ev, BUTTON_SK2))
+			trxIsTransmittingTone = true;
+			trxSetTone1(1750);
+			trxSelectVoiceChannel(AT1846_VOICE_CHANNEL_TONE1);
+			enableAudioAmp(AUDIO_AMP_MODE_RF);
+			GPIO_PinWrite(GPIO_RX_audio_mux, Pin_RX_audio_mux, 1);
+		}
+		else
+		{ // Send DTMF
+			int keyval = menuGetKeypadKeyValue(ev, false);
+
+			if (keyval != 99)
 			{
+				trxSetDTMF(keyval);
 				trxIsTransmittingTone = true;
-				trxSetTone1(1750);
-				trxSelectVoiceChannel(AT1846_VOICE_CHANNEL_TONE1);
+				trxSelectVoiceChannel(AT1846_VOICE_CHANNEL_DTMF);
 				enableAudioAmp(AUDIO_AMP_MODE_RF);
 				GPIO_PinWrite(GPIO_RX_audio_mux, Pin_RX_audio_mux, 1);
-			}
-			else
-			{ // Send DTMF
-				int keyval = menuGetKeypadKeyValue(ev, false);
-
-				if (keyval != 99)
-				{
-					trxSetDTMF(keyval);
-					trxIsTransmittingTone = true;
-					trxSelectVoiceChannel(AT1846_VOICE_CHANNEL_DTMF);
-					enableAudioAmp(AUDIO_AMP_MODE_RF);
-					GPIO_PinWrite(GPIO_RX_audio_mux, Pin_RX_audio_mux, 1);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Tested on GD-77, DM-1801 and RD-5R.
