### PR TITLE
Tolerate some loss of CTCSS / DCS in Rx

### DIFF
--- a/firmware/source/functions/trx.c
+++ b/firmware/source/functions/trx.c
@@ -25,6 +25,7 @@
 #include <user_interface/uiUtilities.h>
 
 
+uint8_t trx_css_measure_count = 0;
 int trx_measure_count = 0;
 volatile bool trxTransmissionEnabled = false;
 volatile bool trxIsTransmitting = false;
@@ -463,7 +464,13 @@ void trxCheckAnalogSquelch(void)
 
 			if (trxIsTransmittingTone == false)
 			{
-				disableAudioAmp(AUDIO_AMP_MODE_RF);
+				trx_css_measure_count++;
+				// If using CTCSS or DCS and signal isn't lost, allow some loss of tone / code
+				if ((!rxCSSactive) || (trxRxNoise > squelch) || (trx_css_measure_count >= 8))
+				{
+					disableAudioAmp(AUDIO_AMP_MODE_RF);
+					trx_css_measure_count = 0;
+				}
 			}
 		}
 


### PR DESCRIPTION
Based on #670 by Riku / OH1E and should help the following:
https://www.opengd77.com/viewtopic.php?f=11&t=1179
https://www.opengd77.com/viewtopic.php?f=11&t=794&start=40

I tested using three radios, one with DCS Tx setting, another with no Tx
tone or code, and the GD-77 with this patch receiving. With this patch
the receiving radio will receive if there's a clean DCS signal from the
one radio, and will hold the Rx open just a bit if the signal is doubled
by the second radio or if the first (DCS Tx) radio stops transmitting
but the second is still transmitting. It stops immediately if the signal
is lost.

I don't have any idea if 100 is a good number of measurements to
overcome the observed problems or if it's excessive, but the number can
be tweaked if people who are seeing those problems test and find that it
doesn't quite fix it.

[OpenGD77-ajorg-css-hang-20200821.zip](https://github.com/rogerclarkmelbourne/OpenGD77/files/5111895/OpenGD77-ajorg-css-hang-20200821.zip)
