### PR TITLE
Improved editing of channel name with voice prompts.

### DIFF
--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -198,7 +198,9 @@ void announceVFOAndFrequency(void);
 
 void announceItem(voicePromptItem_t item, audioPromptThreshold_t immediateAnnouceThreshold);
 void playNextSettingSequence(void);
+void SpeakChar(char ch);
 
 void buildTgOrPCDisplayName(char *nameBuf, int bufferLen);
 void acceptPrivateCall(int id );
+
 #endif

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -199,6 +199,8 @@ void announceVFOAndFrequency(void);
 void announceItem(voicePromptItem_t item, audioPromptThreshold_t immediateAnnouceThreshold);
 void playNextSettingSequence(void);
 void SpeakChar(char ch);
+void SpeakCSSCode(uint16_t num, CSSTypes_t cssType, bool inverted);
+
 void buildTgOrPCDisplayName(char *nameBuf, int bufferLen);
 void acceptPrivateCall(int id );
 #endif

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -198,9 +198,7 @@ void announceVFOAndFrequency(void);
 
 void announceItem(voicePromptItem_t item, audioPromptThreshold_t immediateAnnouceThreshold);
 void playNextSettingSequence(void);
-void SpeakChar(char ch);
 
 void buildTgOrPCDisplayName(char *nameBuf, int bufferLen);
 void acceptPrivateCall(int id );
-
 #endif

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -198,7 +198,7 @@ void announceVFOAndFrequency(void);
 
 void announceItem(voicePromptItem_t item, audioPromptThreshold_t immediateAnnouceThreshold);
 void playNextSettingSequence(void);
-
+void SpeakChar(char ch);
 void buildTgOrPCDisplayName(char *nameBuf, int bufferLen);
 void acceptPrivateCall(int id );
 #endif

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -198,7 +198,7 @@ void announceVFOAndFrequency(void);
 
 void announceItem(voicePromptItem_t item, audioPromptThreshold_t immediateAnnouceThreshold);
 void playNextSettingSequence(void);
-void SpeakChar(char ch);
+
 void buildTgOrPCDisplayName(char *nameBuf, int bufferLen);
 void acceptPrivateCall(int id );
 #endif

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -24,7 +24,7 @@
 #include <user_interface/uiUtilities.h>
 #include <user_interface/uiLocalisation.h>
 
-static void updateScreen(bool isFirstRun, bool allowedToSpeakUpdate);
+static void updateScreen(bool isFirstRun);
 static void updateCursor(bool moved);
 static void handleEvent(uiEvent_t *ev);
 
@@ -400,7 +400,7 @@ menuStatus_t menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
 			voicePromptsAppendPrompt(PROMPT_SILENCE);
 		}
 
-		updateScreen(true, true);
+		updateScreen(true);
 		updateCursor(true);
 
 		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
@@ -429,7 +429,7 @@ static void updateCursor(bool moved)
 	}
 }
 
-static void updateScreen(bool isFirstRun, bool allowedToSpeakUpdate)
+static void updateScreen(bool isFirstRun)
 {
 	int mNum = 0;
 	static const int bufferLen = 17;
@@ -618,7 +618,7 @@ static void updateScreen(bool isFirstRun, bool allowedToSpeakUpdate)
 				strcpy(buf, rightSideVar);
 			}
 
-			if ((i == 0) && (allowedToSpeakUpdate &&(nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1)))
+			if ((i == 0) && (nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1))
 			{
 				if (!isFirstRun)
 				{
@@ -688,19 +688,19 @@ static void handleEvent(uiEvent_t *ev)
 			if (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN))
 			{
 				updateFrequency();
-				updateScreen(false, true);
+				updateScreen(false);
 				return;
 			}
 			if (KEYCHECK_SHORTUP(ev->keys, KEY_RED))
 			{
-				updateScreen(false, true);
+				updateScreen(false);
 				return;
 			}
 			if (KEYCHECK_SHORTUP(ev->keys, KEY_LEFT))
 			{
 				freq_enter_idx--;
 				freq_enter_digits[freq_enter_idx] = '-';
-				updateScreen(false, true);
+				updateScreen(false);
 				return;
 			}
 		}
@@ -718,24 +718,24 @@ static void handleEvent(uiEvent_t *ev)
 					updateFrequency();
 					freq_enter_idx = 0;
 				}
-				updateScreen(false, true);
+				updateScreen(false);
 				return;
 			}
 		}
 	}
 
 	// Not entering a frequency numeric digit
-	bool allowedToSpeakUpdate = true;
+
 	if (KEYCHECK_PRESS(ev->keys, KEY_DOWN))
 	{
 		menuSystemMenuIncrement(&gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
-		updateScreen(false, true);
+		updateScreen(false);
 		menuChannelDetailsExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys, KEY_UP))
 	{
 		menuSystemMenuDecrement(&gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
-		updateScreen(false, true);
+		updateScreen(false);
 		menuChannelDetailsExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys, KEY_RIGHT))
@@ -747,7 +747,6 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					moveCursorRightInString(channelName, &namePos, 16, BUTTONCHECK_DOWN(ev, BUTTON_SK2));
 					updateCursor(true);
-					allowedToSpeakUpdate =false;
 				}
 				break;
 			case CH_DETAILS_MODE:
@@ -811,7 +810,7 @@ static void handleEvent(uiEvent_t *ev)
 				break;
 			case CH_DETAILS_ALL_SKIP:
 				tmpChannel.flag4 |= 0x10;// set Channel All Skip bit (was Lone Worker)
-				break;
+				break;				
 			case CH_DETAILS_RXGROUP:
 				if (tmpChannel.chMode == RADIO_MODE_DIGITAL)
 				{
@@ -832,7 +831,7 @@ static void handleEvent(uiEvent_t *ev)
 				tmpChannel.flag4 |= 0x40;
 				break;
 		}
-		updateScreen(false, 					allowedToSpeakUpdate);
+		updateScreen(false);
 	}
 	else if (KEYCHECK_PRESS(ev->keys, KEY_LEFT))
 	{
@@ -843,7 +842,6 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					moveCursorLeftInString(channelName, &namePos, BUTTONCHECK_DOWN(ev, BUTTON_SK2));
 					updateCursor(true);
-					allowedToSpeakUpdate =false;
 				}
 				break;
 			case CH_DETAILS_MODE:
@@ -908,7 +906,7 @@ static void handleEvent(uiEvent_t *ev)
 				break;
 			case CH_DETAILS_ALL_SKIP:
 				tmpChannel.flag4 &= ~0x10;// clear Channel All Skip Bit (was Lone Worker bit)
-				break;
+				break;				
 			case CH_DETAILS_RXGROUP:
 				if (tmpChannel.chMode == RADIO_MODE_DIGITAL)
 				{
@@ -930,7 +928,7 @@ static void handleEvent(uiEvent_t *ev)
 				break;
 
 		}
-		updateScreen(false, allowedToSpeakUpdate);
+		updateScreen(false);
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN))
 	{
@@ -965,8 +963,7 @@ static void handleEvent(uiEvent_t *ev)
 		{
 			channelName[namePos] = ev->keys.key;
 			updateCursor(true);
-			SpeakChar(ev->keys.key);
-			updateScreen(false, false);
+			updateScreen(false);
 		}
 		if ((ev->keys.event == KEY_MOD_PRESS) && (namePos < 16))
 		{
@@ -976,8 +973,7 @@ static void handleEvent(uiEvent_t *ev)
 				namePos++;
 			}
 			updateCursor(true);
-			SpeakChar(ev->keys.key);
-			updateScreen(false, false);
+			updateScreen(false);
 		}
 	}
 }

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -777,12 +777,16 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					cssIncrementFromEvent(ev, &tmpChannel.rxTone, &RxCSSIndex, &RxCSSType);
 					trxSetRxCSS(tmpChannel.rxTone);
+					SpeakCSSCode(tmpChannel.rxTone, RxCSSType, (tmpChannel.rxTone & CODEPLUG_DCS_INVERTED_MASK));
+					allowedToSpeakUpdate=false;
 				}
 				break;
 			case CH_DETAILS_TXCTCSS:
 				if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 				{
 					cssIncrementFromEvent(ev, &tmpChannel.txTone, &TxCSSIndex, &TxCSSType);
+					SpeakCSSCode(tmpChannel.txTone, TxCSSType, (tmpChannel.txTone & CODEPLUG_DCS_INVERTED_MASK));
+					allowedToSpeakUpdate=false;
 				}
 				break;
 			case CH_DETAILS_BANDWIDTH:
@@ -874,12 +878,16 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					cssDecrementFromEvent(ev, &tmpChannel.rxTone, &RxCSSIndex, &RxCSSType);
 					trxSetRxCSS(tmpChannel.rxTone);
+					SpeakCSSCode(tmpChannel.rxTone, RxCSSType, (tmpChannel.rxTone & CODEPLUG_DCS_INVERTED_MASK));
+					allowedToSpeakUpdate=false;
 				}
 				break;
 			case CH_DETAILS_TXCTCSS:
 				if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 				{
 					cssDecrementFromEvent(ev, &tmpChannel.txTone, &TxCSSIndex, &TxCSSType);
+					SpeakCSSCode(tmpChannel.txTone, TxCSSType, (tmpChannel.txTone & CODEPLUG_DCS_INVERTED_MASK));
+					allowedToSpeakUpdate=false;
 				}
 				break;
 			case CH_DETAILS_BANDWIDTH:

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -24,7 +24,7 @@
 #include <user_interface/uiUtilities.h>
 #include <user_interface/uiLocalisation.h>
 
-static void updateScreen(bool isFirstRun);
+static void updateScreen(bool isFirstRun, bool allowedToSpeakUpdate);
 static void updateCursor(bool moved);
 static void handleEvent(uiEvent_t *ev);
 
@@ -400,7 +400,7 @@ menuStatus_t menuChannelDetails(uiEvent_t *ev, bool isFirstRun)
 			voicePromptsAppendPrompt(PROMPT_SILENCE);
 		}
 
-		updateScreen(true);
+		updateScreen(true, true);
 		updateCursor(true);
 
 		return (MENU_STATUS_LIST_TYPE | MENU_STATUS_SUCCESS);
@@ -429,7 +429,7 @@ static void updateCursor(bool moved)
 	}
 }
 
-static void updateScreen(bool isFirstRun)
+static void updateScreen(bool isFirstRun, bool allowedToSpeakUpdate)
 {
 	int mNum = 0;
 	static const int bufferLen = 17;
@@ -618,7 +618,7 @@ static void updateScreen(bool isFirstRun)
 				strcpy(buf, rightSideVar);
 			}
 
-			if ((i == 0) && (nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1))
+			if ((i == 0) && (allowedToSpeakUpdate &&(nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1)))
 			{
 				if (!isFirstRun)
 				{
@@ -688,19 +688,19 @@ static void handleEvent(uiEvent_t *ev)
 			if (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN))
 			{
 				updateFrequency();
-				updateScreen(false);
+				updateScreen(false, true);
 				return;
 			}
 			if (KEYCHECK_SHORTUP(ev->keys, KEY_RED))
 			{
-				updateScreen(false);
+				updateScreen(false, true);
 				return;
 			}
 			if (KEYCHECK_SHORTUP(ev->keys, KEY_LEFT))
 			{
 				freq_enter_idx--;
 				freq_enter_digits[freq_enter_idx] = '-';
-				updateScreen(false);
+				updateScreen(false, true);
 				return;
 			}
 		}
@@ -718,24 +718,24 @@ static void handleEvent(uiEvent_t *ev)
 					updateFrequency();
 					freq_enter_idx = 0;
 				}
-				updateScreen(false);
+				updateScreen(false, true);
 				return;
 			}
 		}
 	}
 
 	// Not entering a frequency numeric digit
-
+	bool allowedToSpeakUpdate = true;
 	if (KEYCHECK_PRESS(ev->keys, KEY_DOWN))
 	{
 		menuSystemMenuIncrement(&gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
-		updateScreen(false);
+		updateScreen(false, true);
 		menuChannelDetailsExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys, KEY_UP))
 	{
 		menuSystemMenuDecrement(&gMenusCurrentItemIndex, NUM_CH_DETAILS_ITEMS);
-		updateScreen(false);
+		updateScreen(false, true);
 		menuChannelDetailsExitCode |= MENU_STATUS_LIST_TYPE;
 	}
 	else if (KEYCHECK_PRESS(ev->keys, KEY_RIGHT))
@@ -747,6 +747,7 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					moveCursorRightInString(channelName, &namePos, 16, BUTTONCHECK_DOWN(ev, BUTTON_SK2));
 					updateCursor(true);
+					allowedToSpeakUpdate =false;
 				}
 				break;
 			case CH_DETAILS_MODE:
@@ -810,7 +811,7 @@ static void handleEvent(uiEvent_t *ev)
 				break;
 			case CH_DETAILS_ALL_SKIP:
 				tmpChannel.flag4 |= 0x10;// set Channel All Skip bit (was Lone Worker)
-				break;				
+				break;
 			case CH_DETAILS_RXGROUP:
 				if (tmpChannel.chMode == RADIO_MODE_DIGITAL)
 				{
@@ -831,7 +832,7 @@ static void handleEvent(uiEvent_t *ev)
 				tmpChannel.flag4 |= 0x40;
 				break;
 		}
-		updateScreen(false);
+		updateScreen(false, 					allowedToSpeakUpdate);
 	}
 	else if (KEYCHECK_PRESS(ev->keys, KEY_LEFT))
 	{
@@ -842,6 +843,7 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					moveCursorLeftInString(channelName, &namePos, BUTTONCHECK_DOWN(ev, BUTTON_SK2));
 					updateCursor(true);
+					allowedToSpeakUpdate =false;
 				}
 				break;
 			case CH_DETAILS_MODE:
@@ -906,7 +908,7 @@ static void handleEvent(uiEvent_t *ev)
 				break;
 			case CH_DETAILS_ALL_SKIP:
 				tmpChannel.flag4 &= ~0x10;// clear Channel All Skip Bit (was Lone Worker bit)
-				break;				
+				break;
 			case CH_DETAILS_RXGROUP:
 				if (tmpChannel.chMode == RADIO_MODE_DIGITAL)
 				{
@@ -928,7 +930,7 @@ static void handleEvent(uiEvent_t *ev)
 				break;
 
 		}
-		updateScreen(false);
+		updateScreen(false, allowedToSpeakUpdate);
 	}
 	else if (KEYCHECK_SHORTUP(ev->keys, KEY_GREEN))
 	{
@@ -963,7 +965,8 @@ static void handleEvent(uiEvent_t *ev)
 		{
 			channelName[namePos] = ev->keys.key;
 			updateCursor(true);
-			updateScreen(false);
+			SpeakChar(ev->keys.key);
+			updateScreen(false, false);
 		}
 		if ((ev->keys.event == KEY_MOD_PRESS) && (namePos < 16))
 		{
@@ -973,7 +976,8 @@ static void handleEvent(uiEvent_t *ev)
 				namePos++;
 			}
 			updateCursor(true);
-			updateScreen(false);
+			SpeakChar(ev->keys.key);
+			updateScreen(false, false);
 		}
 	}
 }

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -17,7 +17,6 @@
  */
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiLocalisation.h>
-#include <user_interface/uiUtilities.h>
 #include <settings.h>
 #include <ticks.h>
 
@@ -448,7 +447,6 @@ void moveCursorLeftInString(char *str, int *pos, bool delete)
 	if (*pos > 0)
 	{
 		*pos -=1;
-		SpeakChar(str[*pos]); // speak the new char or the char about to be backspaced out.
 
 		if (delete)
 		{
@@ -481,7 +479,6 @@ void moveCursorRightInString(char *str, int *pos, int max, bool insert)
 		if (*pos < max-1)
 		{
 			*pos += 1;
-			SpeakChar(str[*pos]); // speak the new char or the char about to be backspaced out.
 		}
 	}
 }

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -17,7 +17,7 @@
  */
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiLocalisation.h>
-#include <user_interface/UiUtilities.h>
+#include <user_interface/uiUtilities.h>
 #include <settings.h>
 #include <ticks.h>
 

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -447,7 +447,7 @@ void moveCursorLeftInString(char *str, int *pos, bool delete)
 	if (*pos > 0)
 	{
 		*pos -=1;
-
+		SpeakChar(str[*pos]); // speak the new char or the char about to be backspaced out.
 		if (delete)
 		{
 			for (int i = *pos; i <= nLen; i++)
@@ -479,6 +479,7 @@ void moveCursorRightInString(char *str, int *pos, int max, bool insert)
 		if (*pos < max-1)
 		{
 			*pos += 1;
+			SpeakChar(str[*pos]); // speak the new char or the char about to be backspaced out.
 		}
 	}
 }

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -447,7 +447,7 @@ void moveCursorLeftInString(char *str, int *pos, bool delete)
 	if (*pos > 0)
 	{
 		*pos -=1;
-		SpeakChar(str[*pos]); // speak the new char or the char about to be backspaced out.
+
 		if (delete)
 		{
 			for (int i = *pos; i <= nLen; i++)
@@ -479,7 +479,6 @@ void moveCursorRightInString(char *str, int *pos, int max, bool insert)
 		if (*pos < max-1)
 		{
 			*pos += 1;
-			SpeakChar(str[*pos]); // speak the new char or the char about to be backspaced out.
 		}
 	}
 }

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -17,6 +17,7 @@
  */
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiLocalisation.h>
+#include <user_interface/UiUtilities.h>
 #include <settings.h>
 #include <ticks.h>
 

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -17,6 +17,7 @@
  */
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiLocalisation.h>
+#include <user_interface/uiUtilities.h>
 #include <settings.h>
 #include <ticks.h>
 
@@ -447,6 +448,7 @@ void moveCursorLeftInString(char *str, int *pos, bool delete)
 	if (*pos > 0)
 	{
 		*pos -=1;
+		SpeakChar(str[*pos]); // speak the new char or the char about to be backspaced out.
 
 		if (delete)
 		{
@@ -479,6 +481,7 @@ void moveCursorRightInString(char *str, int *pos, int max, bool insert)
 		if (*pos < max-1)
 		{
 			*pos += 1;
+			SpeakChar(str[*pos]); // speak the new char or the char about to be backspaced out.
 		}
 	}
 }

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -17,7 +17,7 @@
  */
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiLocalisation.h>
-#include <user_interface/uiUtilities.h>
+#include <user_interface/UiUtilities.h>
 #include <settings.h>
 #include <ticks.h>
 

--- a/firmware/source/user_interface/menuSystem.c
+++ b/firmware/source/user_interface/menuSystem.c
@@ -17,7 +17,6 @@
  */
 #include <user_interface/menuSystem.h>
 #include <user_interface/uiLocalisation.h>
-#include <user_interface/UiUtilities.h>
 #include <settings.h>
 #include <ticks.h>
 

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1156,7 +1156,7 @@ void menuUtilityRenderQSOData(void)
 			// Group call
 			if (((LinkHead->talkGroupOrPcId & 0xFFFFFF) != trxTalkGroupOrPcId )||
 					((dmrMonitorCapturedTS != -1) && (dmrMonitorCapturedTS != trxGetDMRTimeSlot())) ||
-					(trxGetDMRColourCode() != currentChannelData->rxColor))
+					(trxGetDMRColourCode() != currentChannelData->txColor))
 			{
 #if defined(PLATFORM_RD5R)
 				// draw the text in inverse video

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1887,6 +1887,11 @@ void SpeakChar(char ch)
 
 void SpeakCSSCode(uint16_t code, CSSTypes_t cssType, bool inverted)
 {
+	if (nonVolatileSettings.audioPromptMode < AUDIO_PROMPT_MODE_VOICE_LEVEL_1)
+	{
+		return;
+	}
+
 	static const int bufferLen = 17;
 	char buf[bufferLen];
 	switch (cssType)

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1156,7 +1156,7 @@ void menuUtilityRenderQSOData(void)
 			// Group call
 			if (((LinkHead->talkGroupOrPcId & 0xFFFFFF) != trxTalkGroupOrPcId )||
 					((dmrMonitorCapturedTS != -1) && (dmrMonitorCapturedTS != trxGetDMRTimeSlot())) ||
-					(trxGetDMRColourCode() != currentChannelData->txColor))
+					(trxGetDMRColourCode() != currentChannelData->rxColor))
 			{
 #if defined(PLATFORM_RD5R)
 				// draw the text in inverse video
@@ -1867,4 +1867,20 @@ void acceptPrivateCall(int id)
 
 	setOverrideTGorPC(uiPrivateCallLastID, true);
 	announceItem(PROMPT_SEQUENCE_CONTACT_TG_OR_PC,PROMPT_THRESHOLD_3);
+}
+
+void SpeakChar(char ch)
+{
+	if (nonVolatileSettings.audioPromptMode < AUDIO_PROMPT_MODE_VOICE_LEVEL_1)
+	{
+		return;
+	}
+
+	char buf[2];
+	buf[0]=ch;
+	buf[1]='\0';
+
+	voicePromptsInit();
+	voicePromptsAppendString(buf);
+	voicePromptsPlay();
 }

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1156,7 +1156,7 @@ void menuUtilityRenderQSOData(void)
 			// Group call
 			if (((LinkHead->talkGroupOrPcId & 0xFFFFFF) != trxTalkGroupOrPcId )||
 					((dmrMonitorCapturedTS != -1) && (dmrMonitorCapturedTS != trxGetDMRTimeSlot())) ||
-					(trxGetDMRColourCode() != currentChannelData->rxColor))
+					(trxGetDMRColourCode() != currentChannelData->txColor))
 			{
 #if defined(PLATFORM_RD5R)
 				// draw the text in inverse video
@@ -1867,20 +1867,4 @@ void acceptPrivateCall(int id)
 
 	setOverrideTGorPC(uiPrivateCallLastID, true);
 	announceItem(PROMPT_SEQUENCE_CONTACT_TG_OR_PC,PROMPT_THRESHOLD_3);
-}
-
-void SpeakChar(char ch)
-{
-	if (nonVolatileSettings.audioPromptMode < AUDIO_PROMPT_MODE_VOICE_LEVEL_1)
-	{
-		return;
-	}
-
-	char buf[2];
-	buf[0]=ch;
-	buf[1]='\0';
-
-	voicePromptsInit();
-	voicePromptsAppendString(buf);
-	voicePromptsPlay();
 }

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1884,3 +1884,28 @@ void SpeakChar(char ch)
 	voicePromptsAppendString(buf);
 	voicePromptsPlay();
 }
+
+void SpeakCSSCode(uint16_t code, CSSTypes_t cssType, bool inverted)
+{
+	static const int bufferLen = 17;
+	char buf[bufferLen];
+	switch (cssType)
+	{
+		case	CSS_NONE:
+			snprintf(buf, bufferLen, "%s", currentLanguage->none);
+			break;
+		case	CSS_CTCSS:
+			snprintf(buf, bufferLen, "%d.%dHz", code/10 , code%10);
+			break;
+		case	CSS_DCS:
+		case	CSS_DCS_INVERTED:
+		snprintf(buf, bufferLen, "D%03o%c", code&0777, inverted ? 'I' : 'N');
+		break;
+		default:
+		return;
+	}
+
+	voicePromptsInit();
+	voicePromptsAppendString(buf);
+	voicePromptsPlay();
+}


### PR DESCRIPTION
changes by VK7JS Joseph 9 Sept 2020
1. left and right arrow now read the character moved to when editing a channel name.
2. sk2+left (backspace) now reads the character being deleted.
3. As user presses alphanumeric keys during text entry, the preview character is spoken along with the final character entered.
4. The channel name field is no longer repeated each time a key is pressed during channel name editing.