### PR TITLE
Fix type of soundBeepVolumeDivider

### DIFF
--- a/firmware/include/functions/sound.h
+++ b/firmware/include/functions/sound.h
@@ -41,7 +41,7 @@ extern const int MELODY_LOW_BATTERY[];
 extern volatile int *melody_play;
 extern volatile int melody_idx;
 extern volatile int micAudioSamplesTotal;
-extern int soundBeepVolumeDivider;
+extern uint8_t soundBeepVolumeDivider;
 
 #define WAV_BUFFER_SIZE 0xa0
 #define WAV_BUFFER_COUNT 18

--- a/firmware/source/functions/sound.c
+++ b/firmware/source/functions/sound.c
@@ -100,7 +100,7 @@ static const int freqs[64] = {0,104,110,117,123,131,139,147,156,165,175,185,196,
 
 volatile int *melody_play = NULL;
 volatile int melody_idx = 0;
-int soundBeepVolumeDivider;
+uint8_t soundBeepVolumeDivider;
 static uint8_t audioAmpStatusMask = 0;
 
 uint8_t getAudioAmpStatus(void)


### PR DESCRIPTION
In the `settingsStruct_t`, this is a `uint8_t`, causing the following compilation error when compiling using the Makefile:

```
In file included from ../source/user_interface/menuSoundOptions.c:19:
../include/functions/settings.h:192:36: error: '_Generic' selector of type 'int' is not compatible with any association
  192 | #define settingsSet(S, V) _Generic((S),   \
      |                                    ^
../source/user_interface/menuSoundOptions.c:366:4: note: in expansion of macro 'settingsSet'
  366 |    settingsSet(soundBeepVolumeDivider, nonVolatileSettings.beepVolumeDivider);
      |    ^~~~~~~~~~~
```

This should fix that.