### PR TITLE
Fix type

### DIFF
--- a/firmware/include/functions/sound.h
+++ b/firmware/include/functions/sound.h
@@ -41,7 +41,7 @@ extern const int MELODY_LOW_BATTERY[];
 extern volatile int *melody_play;
 extern volatile int melody_idx;
 extern volatile int micAudioSamplesTotal;
-extern int soundBeepVolumeDivider;
+extern uint8_t soundBeepVolumeDivider;
 
 #define WAV_BUFFER_SIZE 0xa0
 #define WAV_BUFFER_COUNT 18

--- a/firmware/include/functions/sound.h
+++ b/firmware/include/functions/sound.h
@@ -41,7 +41,7 @@ extern const int MELODY_LOW_BATTERY[];
 extern volatile int *melody_play;
 extern volatile int melody_idx;
 extern volatile int micAudioSamplesTotal;
-extern uint8_t soundBeepVolumeDivider;
+extern int32_t soundBeepVolumeDivider;
 
 #define WAV_BUFFER_SIZE 0xa0
 #define WAV_BUFFER_COUNT 18

--- a/firmware/source/functions/sound.c
+++ b/firmware/source/functions/sound.c
@@ -100,7 +100,7 @@ static const int freqs[64] = {0,104,110,117,123,131,139,147,156,165,175,185,196,
 
 volatile int *melody_play = NULL;
 volatile int melody_idx = 0;
-int soundBeepVolumeDivider;
+uint8_t soundBeepVolumeDivider;
 static uint8_t audioAmpStatusMask = 0;
 
 uint8_t getAudioAmpStatus(void)

--- a/firmware/source/functions/sound.c
+++ b/firmware/source/functions/sound.c
@@ -100,7 +100,7 @@ static const int freqs[64] = {0,104,110,117,123,131,139,147,156,165,175,185,196,
 
 volatile int *melody_play = NULL;
 volatile int melody_idx = 0;
-uint8_t soundBeepVolumeDivider;
+int32_t soundBeepVolumeDivider;
 static uint8_t audioAmpStatusMask = 0;
 
 uint8_t getAudioAmpStatus(void)


### PR DESCRIPTION
Following #742 after I got some good advice from @rogerclarkmelbourne 

> This is not a good idea. That variable is used for the high speed processing of the beep samples. It needs to be 32 bit otherwise the processing will slow down, and may impact on the general operation of the radio.
> Cast the variable elsewhere if the storage data type and the internal memory representation are causing your compiler to have problems.

Now uses a 32-bit int. This patch makes the code compile again with the GCC toolchain (and the provided Makefile).