### PR TITLE
Fix compilation for the GD77S.

### DIFF
--- a/firmware/include/functions/voicePrompts.h
+++ b/firmware/include/functions/voicePrompts.h
@@ -34,7 +34,6 @@ enum voicePrompts { PROMPT_SILENCE = 0, PROMPT_POINT, PROMPT_0, PROMPT_1, PROMPT
 };
 
 
-extern bool voicePromptIsActive;
 extern bool voicePromptDataIsLoaded;
 
 void voicePromptsCacheInit(void);
@@ -46,7 +45,7 @@ void voicePromptsAppendString(char *);// Append a text string e.g. "VK3KYY"
 void voicePromptsAppendInteger(int32_t value); // Append a signed integer
 void voicePromptsAppendLanguageString(const char * const *);//Append a text from the current language e.g. &currentLanguage->battery
 void voicePromptsPlay(void);// Starts prompt playback
-bool voicePromptsIsPlaying(void);
+extern bool voicePromptsIsPlaying(void);
 bool voicePromptsHasDataToPlay(void);
 void voicePromptsTerminate(void);
 

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -48,16 +48,23 @@
 #define MAX_TG_OR_PC_VALUE              16777215
 
 #if defined(PLATFORM_GD77S)
-void announceRadioMode(bool voicePromptWasPlaying);
-void announceZoneName(bool voicePromptWasPlaying);
-void announceContactNameTgOrPc(void);
-void announcePowerLevel(void);
-void announceBatteryPercentage(void);
-void announceTS(void);
-void announceCC(void);
-void announceChannelName(bool voicePromptWasPlaying);
-void announceFrequency(void);
-void announceVFOAndFrequency(void);
+#define ANNOUNCE_STATIC
+#else
+#define ANNOUNCE_STATIC static
+#endif
+
+#if defined(PLATFORM_GD77S)
+// Displaying ANNOUNCE_STATIC here is a bit overkill but it makes things clearer.
+ANNOUNCE_STATIC void announceRadioMode(bool voicePromptWasPlaying);
+ANNOUNCE_STATIC void announceZoneName(bool voicePromptWasPlaying);
+ANNOUNCE_STATIC void announceContactNameTgOrPc(void);
+ANNOUNCE_STATIC void announcePowerLevel(void);
+ANNOUNCE_STATIC void announceBatteryPercentage(void);
+ANNOUNCE_STATIC void announceTS(void);
+ANNOUNCE_STATIC void announceCC(void);
+ANNOUNCE_STATIC void announceChannelName(bool voicePromptWasPlaying);
+ANNOUNCE_STATIC void announceFrequency(void);
+ANNOUNCE_STATIC void announceVFOAndFrequency(void);
 #endif
 
 extern struct_codeplugRxGroup_t currentRxGroupData;
@@ -94,7 +101,7 @@ typedef struct
 {
 	uint32_t entries;
 	uint8_t  contactLength;
-	int32_t  slices[ID_SLICES]; // [0] is min availabel ID, [REGION - 1] is max available ID
+	int32_t  slices[ID_SLICES]; // [0] is min availabel ID, [ID_SLICES - 1] is max available ID
 	uint32_t IDsPerSlice;
 
 } dmrIDsCache_t;

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -47,6 +47,18 @@
 #define NUM_PC_OR_TG_DIGITS                    8
 #define MAX_TG_OR_PC_VALUE              16777215
 
+#if defined(PLATFORM_GD77S)
+void announceRadioMode(bool voicePromptWasPlaying);
+void announceZoneName(bool voicePromptWasPlaying);
+void announceContactNameTgOrPc(void);
+void announcePowerLevel(void);
+void announceBatteryPercentage(void);
+void announceTS(void);
+void announceCC(void);
+void announceChannelName(bool voicePromptWasPlaying);
+void announceFrequency(void);
+void announceVFOAndFrequency(void);
+#endif
 
 extern struct_codeplugRxGroup_t currentRxGroupData;
 extern struct_codeplugContact_t currentContactData;

--- a/firmware/source/dmr_codec/codec.c
+++ b/firmware/source/dmr_codec/codec.c
@@ -40,7 +40,7 @@ void codecInit(void)
 {
 	// Need to prevent the DMR side of the code initialising the codec and sound buffers when the voice prompts are playing
 	// This could be done in every location this function is called, but it saves space if the check is done inside the function.
-	if (voicePromptIsActive)
+	if (voicePromptsIsPlaying())
 	{
 		return;
 	}

--- a/firmware/source/functions/trx.c
+++ b/firmware/source/functions/trx.c
@@ -453,7 +453,7 @@ void trxCheckAnalogSquelch(void)
 
 		if ((trxRxNoise < squelch) && (((rxCSSactive) && (trxCheckCSSFlag(currentChannelData->rxTone))) || (!rxCSSactive)))
 		{
-			if (!voicePromptIsActive)
+			if (!voicePromptsIsPlaying())
 			{
 				GPIO_PinWrite(GPIO_RX_audio_mux, Pin_RX_audio_mux, 1);// Set the audio path to AT1846 -> audio amp.
 				enableAudioAmp(AUDIO_AMP_MODE_RF);

--- a/firmware/source/functions/voicePrompts.c
+++ b/firmware/source/functions/voicePrompts.c
@@ -294,7 +294,7 @@ void voicePromptsPlay(void)
 	}
 }
 
-bool voicePromptsIsPlaying(void)
+inline bool voicePromptsIsPlaying(void)
 {
 	return (voicePromptIsActive);// && (getAudioAmpStatus() & AUDIO_AMP_MODE_PROMPT));
 }

--- a/firmware/source/hardware/HR-C6000.c
+++ b/firmware/source/hardware/HR-C6000.c
@@ -1573,7 +1573,7 @@ void tick_HR_C6000(void)
 		else
 		{
 			// voice prompts take priority over incoming DMR audio
-			if (!voicePromptIsActive && hasEncodedAudio)
+			if (!voicePromptsIsPlaying() && hasEncodedAudio)
 			{
 				hasEncodedAudio = false;
 				codecDecode((uint8_t *)DMR_frame_buffer + 0x0C, 3);

--- a/firmware/source/main.c
+++ b/firmware/source/main.c
@@ -743,7 +743,7 @@ void mainTask(void *data)
 			menuSystemCallCurrentMenuTick(&ev);
 
 			// Beep sounds aren't allowed in these modes.
-			if (((nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_SILENT) || voicePromptIsActive) /*|| (nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_VOICE)*/)
+			if (((nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_SILENT) || voicePromptsIsPlaying()) /*|| (nonVolatileSettings.audioPromptMode == AUDIO_PROMPT_MODE_VOICE)*/)
 			{
 				if (melody_play != NULL)
 				{

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -683,7 +683,7 @@ static void handleEvent(uiEvent_t *ev)
 
 	if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK1))
 	{
-		if (!voicePromptIsActive)
+		if (!voicePromptsIsPlaying())
 		{
 			voicePromptsPlay();
 		}

--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -197,8 +197,8 @@ static void handleEvent(uiEvent_t *ev)
 
 	if (isDirty)
 	{
-		bool voicePromptsWerePlaying = voicePromptIsActive;
-		if ((nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1) && voicePromptIsActive)
+		bool voicePromptsWerePlaying = voicePromptsIsPlaying();
+		if ((nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1) && voicePromptsWerePlaying)
 		{
 			voicePromptsTerminate();
 		}
@@ -214,7 +214,7 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK1))
 		{
-			if (!voicePromptIsActive)
+			if (!voicePromptsIsPlaying())
 			{
 				voicePromptsPlay();
 			}
@@ -244,7 +244,7 @@ static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_
 
 	if (itemIsSelected && (nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1))
 	{
-		if (voicePromptIsActive)
+		if (voicePromptsIsPlaying())
 		{
 			voicePromptsTerminate();
 		}

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -702,7 +702,7 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK1))
 		{
-			if (!voicePromptIsActive)
+			if (!voicePromptsIsPlaying())
 			{
 				voicePromptsPlay();
 			}

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -2119,7 +2119,7 @@ static void buildSpeechUiModeForGD77S(GD77S_UIMODES_t uiMode)
 			break;
 
 		case GD77S_UIMODE_ZONE: // Zone
-			announceZoneName();
+			announceZoneName(voicePromptsIsPlaying());
 			break;
 
 

--- a/firmware/source/user_interface/uiTxTgPcContactOwnId.c
+++ b/firmware/source/user_interface/uiTxTgPcContactOwnId.c
@@ -222,7 +222,7 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK1))
 		{
-			if (!voicePromptIsActive)
+			if (!voicePromptsIsPlaying())
 			{
 				voicePromptsInit();
 				switch(gMenusCurrentItemIndex)

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -46,6 +46,11 @@ int numLastHeard=0;
 int menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 int qsodata_timer;
 const uint32_t RSSI_UPDATE_COUNTER_RELOAD = 100;
+
+#if defined(PLATFORM_GD77S)
+#define ANNOUNCE_STATIC
+#else
+#define ANNOUNCE_STATIC static
 static void announceRadioMode(bool voicePromptWasPlaying);
 static void announceZoneName(bool voicePromptWasPlaying);
 static void announceContactNameTgOrPc(void);
@@ -56,6 +61,8 @@ static void announceCC(void);
 static void announceChannelName(bool voicePromptWasPlaying);
 static void announceFrequency(void);
 static void announceVFOAndFrequency(void);
+#endif
+
 
 uint32_t menuUtilityReceivedPcId 	= 0;// No current Private call awaiting acceptance
 uint32_t menuUtilityTgBeforePcMode 	= 0;// No TG saved, prior to a Private call being accepted.
@@ -1604,7 +1611,7 @@ void decreasePowerLevel(void)
 	announceItem(PROMPT_SEQUENCE_POWER, PROMPT_THRESHOLD_3);
 }
 
-static void announceRadioMode(bool voicePromptWasPlaying)
+ANNOUNCE_STATIC void announceRadioMode(bool voicePromptWasPlaying)
 {
 	if (!voicePromptWasPlaying)
 	{
@@ -1613,7 +1620,7 @@ static void announceRadioMode(bool voicePromptWasPlaying)
 	voicePromptsAppendString( (trxGetMode() == RADIO_MODE_DIGITAL) ? "DMR" : "FM");
 }
 
-static void announceZoneName(bool voicePromptWasPlaying)
+ANNOUNCE_STATIC void announceZoneName(bool voicePromptWasPlaying)
 {
 	if (!voicePromptWasPlaying)
 	{
@@ -1622,7 +1629,7 @@ static void announceZoneName(bool voicePromptWasPlaying)
 	voicePromptsAppendString(currentZone.name);
 }
 
-static void announceContactNameTgOrPc(void)
+ANNOUNCE_STATIC void announceContactNameTgOrPc(void)
 {
 	if (nonVolatileSettings.overrideTG == 0)
 	{
@@ -1646,7 +1653,7 @@ static void announceContactNameTgOrPc(void)
 	}
 }
 
-static void announcePowerLevel(void)
+ANNOUNCE_STATIC void announcePowerLevel(void)
 {
 	voicePromptsAppendString((char *)POWER_LEVELS[nonVolatileSettings.txPowerLevel]);
 	switch(nonVolatileSettings.txPowerLevel)
@@ -1673,26 +1680,26 @@ static void announcePowerLevel(void)
 	}
 }
 
-static void announceBatteryPercentage(void)
+ANNOUNCE_STATIC void announceBatteryPercentage(void)
 {
 	voicePromptsAppendLanguageString(&currentLanguage->battery);
 	voicePromptsAppendInteger(getBatteryPercentage());
 	voicePromptsAppendPrompt(PROMPT_PERCENT);
 }
 
-static void announceTS(void)
+ANNOUNCE_STATIC void announceTS(void)
 {
 	voicePromptsAppendPrompt(PROMPT_TIMESLOT);
 	voicePromptsAppendInteger(trxGetDMRTimeSlot() + 1);
 }
 
-static void announceCC(void)
+ANNOUNCE_STATIC void announceCC(void)
 {
 	voicePromptsAppendLanguageString(&currentLanguage->colour_code);
 	voicePromptsAppendInteger(trxGetDMRColourCode());
 }
 
-static void announceChannelName(bool voicePromptWasPlaying)
+ANNOUNCE_STATIC void announceChannelName(bool voicePromptWasPlaying)
 {
 	char voiceBuf[17];
 	codeplugUtilConvertBufToString(channelScreenChannelData.name, voiceBuf, 16);
@@ -1719,7 +1726,7 @@ static void removeUnnecessaryZerosFromVoicePrompts(char *str)
 	}
 }
 
-static void announceFrequency(void)
+ANNOUNCE_STATIC void announceFrequency(void)
 {
 	char buffer[17];
 
@@ -1744,7 +1751,7 @@ static void announceFrequency(void)
 	}
 }
 
-static void announceVFOAndFrequency(void)
+ANNOUNCE_STATIC void announceVFOAndFrequency(void)
 {
 	voicePromptsAppendPrompt(PROMPT_VFO);
 	voicePromptsAppendString((nonVolatileSettings.currentVFONumber == 0) ? "A" : "B");

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -47,23 +47,6 @@ int menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 int qsodata_timer;
 const uint32_t RSSI_UPDATE_COUNTER_RELOAD = 100;
 
-#if defined(PLATFORM_GD77S)
-#define ANNOUNCE_STATIC
-#else
-#define ANNOUNCE_STATIC static
-static void announceRadioMode(bool voicePromptWasPlaying);
-static void announceZoneName(bool voicePromptWasPlaying);
-static void announceContactNameTgOrPc(void);
-static void announcePowerLevel(void);
-static void announceBatteryPercentage(void);
-static void announceTS(void);
-static void announceCC(void);
-static void announceChannelName(bool voicePromptWasPlaying);
-static void announceFrequency(void);
-static void announceVFOAndFrequency(void);
-#endif
-
-
 uint32_t menuUtilityReceivedPcId 	= 0;// No current Private call awaiting acceptance
 uint32_t menuUtilityTgBeforePcMode 	= 0;// No TG saved, prior to a Private call being accepted.
 
@@ -1822,7 +1805,7 @@ void announceItem(voicePromptItem_t item, audioPromptThreshold_t immediateAnnoun
 	{
 		return;
 	}
-	bool voicePromptWasPlaying = voicePromptIsActive;
+	bool voicePromptWasPlaying = voicePromptsIsPlaying();
 
 	voicePromptSequenceState = item;
 

--- a/firmware/source/user_interface/uiVFOMode.c
+++ b/firmware/source/user_interface/uiVFOMode.c
@@ -702,7 +702,7 @@ static void handleEvent(uiEvent_t *ev)
 	{
 		if (BUTTONCHECK_SHORTUP(ev, BUTTON_SK1))
 		{
-			if (!voicePromptIsActive)
+			if (!voicePromptsIsPlaying())
 			{
 				voicePromptsPlay();
 			}


### PR DESCRIPTION
Since announce*() functions are declared static, a special case for the GD77S has be handled.
All these functions loose their static attribute when compiled for GD77S platform.