### PR TITLE
Improved Last Heard responsivity with voice prompts

### DIFF
--- a/firmware/source/user_interface/menuLastHeard.c
+++ b/firmware/source/user_interface/menuLastHeard.c
@@ -205,16 +205,9 @@ static void handleEvent(uiEvent_t *ev)
 
 	if (isDirty)
 	{
-		bool voicePromptsWerePlaying = voicePromptsIsPlaying();
-
-		if ((nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1) && voicePromptsWerePlaying)
-		{
-			voicePromptsTerminate();
-		}
-
 		menuLastHeardUpdateScreen(true, displayLHDetails, false);// This will also setup the voice prompt
 
-		if (voicePromptsWerePlaying)
+		if (nonVolatileSettings.audioPromptMode >= AUDIO_PROMPT_MODE_VOICE_LEVEL_1)
 		{
 			voicePromptsPlay();
 		}
@@ -371,7 +364,6 @@ static void menuLastHeardDisplayTA(uint8_t y, char *text, uint32_t time, uint32_
 
 			voicePromptsAppendString(timeBuffer);
 			voicePromptsAppendPrompt(PROMPT_MINUTES);
-			voicePromptsAppendString("   ");// Add some blank sound at the end of the callsign, to allow time for follow-on scrolling
 		}
 	}
 	else


### PR DESCRIPTION
Fixed the behavior of voicing the Last Heard items, where only follow-on browsing was possible. Once the announcement was terminated, the browsing wasn't voiced until SK1 was pressed to activate the voice again.

Besides, a little of redundant code has been removed.