### PR TITLE
GD77S: Report RX and TX CSS codes, if set (OK1TE)

### DIFF
--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -197,7 +197,12 @@ void decreasePowerLevel(void);
 void increasePowerLevel(void);
 
 void announceChar(char ch);
+
+void prepareCSSCodeAnnouncement(uint16_t code, CSSTypes_t cssType, bool inverted);
 void announceCSSCode(uint16_t code, CSSTypes_t cssType, bool inverted);
+#if defined(PLATFORM_GD77S)
+void announceCSSCodes(void);
+#endif
 
 void announceItem(voicePromptItem_t item, audioPromptThreshold_t immediateAnnouceThreshold);
 void playNextSettingSequence(void);

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -201,7 +201,7 @@ void announceChar(char ch);
 void prepareCSSCodeAnnouncement(uint16_t code, CSSTypes_t cssType);
 void announceCSSCode(uint16_t code, CSSTypes_t cssType);
 #if defined(PLATFORM_GD77S)
-void announceCSSCodes(void);
+void announceRxTxCSSCodesIfSet(void);
 #endif
 
 void announceItem(voicePromptItem_t item, audioPromptThreshold_t immediateAnnouceThreshold);

--- a/firmware/include/user_interface/uiUtilities.h
+++ b/firmware/include/user_interface/uiUtilities.h
@@ -198,8 +198,8 @@ void increasePowerLevel(void);
 
 void announceChar(char ch);
 
-void prepareCSSCodeAnnouncement(uint16_t code, CSSTypes_t cssType, bool inverted);
-void announceCSSCode(uint16_t code, CSSTypes_t cssType, bool inverted);
+void prepareCSSCodeAnnouncement(uint16_t code, CSSTypes_t cssType);
+void announceCSSCode(uint16_t code, CSSTypes_t cssType);
 #if defined(PLATFORM_GD77S)
 void announceCSSCodes(void);
 #endif

--- a/firmware/source/user_interface/menuChannelDetails.c
+++ b/firmware/source/user_interface/menuChannelDetails.c
@@ -785,7 +785,7 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					cssIncrementFromEvent(ev, &tmpChannel.rxTone, &RxCSSIndex, &RxCSSType);
 					trxSetRxCSS(tmpChannel.rxTone);
-					announceCSSCode(tmpChannel.rxTone, RxCSSType, (tmpChannel.rxTone & CODEPLUG_DCS_INVERTED_MASK));
+					announceCSSCode(tmpChannel.rxTone, RxCSSType);
 					allowedToSpeakUpdate = false;
 				}
 				break;
@@ -793,7 +793,7 @@ static void handleEvent(uiEvent_t *ev)
 				if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 				{
 					cssIncrementFromEvent(ev, &tmpChannel.txTone, &TxCSSIndex, &TxCSSType);
-					announceCSSCode(tmpChannel.txTone, TxCSSType, (tmpChannel.txTone & CODEPLUG_DCS_INVERTED_MASK));
+					announceCSSCode(tmpChannel.txTone, TxCSSType);
 					allowedToSpeakUpdate = false;
 				}
 				break;
@@ -886,7 +886,7 @@ static void handleEvent(uiEvent_t *ev)
 				{
 					cssDecrementFromEvent(ev, &tmpChannel.rxTone, &RxCSSIndex, &RxCSSType);
 					trxSetRxCSS(tmpChannel.rxTone);
-					announceCSSCode(tmpChannel.rxTone, RxCSSType, (tmpChannel.rxTone & CODEPLUG_DCS_INVERTED_MASK));
+					announceCSSCode(tmpChannel.rxTone, RxCSSType);
 					allowedToSpeakUpdate = false;
 				}
 				break;
@@ -894,7 +894,7 @@ static void handleEvent(uiEvent_t *ev)
 				if (tmpChannel.chMode == RADIO_MODE_ANALOG)
 				{
 					cssDecrementFromEvent(ev, &tmpChannel.txTone, &TxCSSIndex, &TxCSSType);
-					announceCSSCode(tmpChannel.txTone, TxCSSType, (tmpChannel.txTone & CODEPLUG_DCS_INVERTED_MASK));
+					announceCSSCode(tmpChannel.txTone, TxCSSType);
 					allowedToSpeakUpdate = false;
 				}
 				break;

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -2047,12 +2047,15 @@ static void buildSpeechChannelDetailsForGD77S()
 	codeplugUtilConvertBufToString(channelScreenChannelData.name, buf, 16);
 	voicePromptsAppendString(buf);
 
-	announceContactNameTgOrPc();
-
 	if (trxGetMode() == RADIO_MODE_DIGITAL)
 	{
+		announceContactNameTgOrPc();
 		announceTS();
 		announceCC();
+	}
+	else // analog
+	{
+		announceCSSCodes();
 	}
 }
 

--- a/firmware/source/user_interface/uiChannelMode.c
+++ b/firmware/source/user_interface/uiChannelMode.c
@@ -2055,7 +2055,7 @@ static void buildSpeechChannelDetailsForGD77S()
 	}
 	else // analog
 	{
-		announceCSSCodes();
+		announceRxTxCSSCodesIfSet();
 	}
 }
 

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1800,7 +1800,7 @@ void announceCSSCode(uint16_t code, CSSTypes_t cssType, bool inverted)
 	}
 
 	voicePromptsInit();
-	prepareCSSCodeAnnouncement(cssType, code, inverted);
+	prepareCSSCodeAnnouncement(code, cssType, inverted);
 	voicePromptsPlay();
 }
 

--- a/firmware/source/user_interface/uiUtilities.c
+++ b/firmware/source/user_interface/uiUtilities.c
@@ -1806,7 +1806,7 @@ void announceCSSCode(uint16_t code, CSSTypes_t cssType)
 }
 
 #if defined(PLATFORM_GD77S)
-void announceCSSTypeAndCode(uint16_t code)
+void announceCSSTypeAndCodeIfSet(uint16_t code)
 {
 	CSSTypes_t cssType = CSS_NONE;
 	if (codeplugChannelToneIsCTCSS(code))
@@ -1814,7 +1814,7 @@ void announceCSSTypeAndCode(uint16_t code)
 		cssType = CSS_CTCSS;
 		voicePromptsAppendString("CTCSS ");
 	}
-	else if (codeplugChannelToneIsDCS(code))
+	else if (codeplugChannelToneIsDCS(code)) // both normal and inverted
 	{
 		cssType = CSS_DCS;
 		voicePromptsAppendString("DCS ");
@@ -1823,20 +1823,20 @@ void announceCSSTypeAndCode(uint16_t code)
 	prepareCSSCodeAnnouncement(code, cssType);
 }
 
-void announceCSSCodes(void)
+void announceRxTxCSSCodesIfSet(void)
 {
 	uint16_t code = channelScreenChannelData.rxTone;
 	if ((nonVolatileSettings.analogFilterLevel > ANALOG_FILTER_NONE) && (code != CODEPLUG_CSS_NONE))
 	{
 		voicePromptsAppendString(" RX");
-		announceCSSTypeAndCode(code);
+		announceCSSTypeAndCodeIfSet(code);
 	}
 
 	code = channelScreenChannelData.txTone;
 	if (code != CODEPLUG_CSS_NONE)
 	{
 		voicePromptsAppendString(" TX");
-		announceCSSTypeAndCode(code);
+		announceCSSTypeAndCodeIfSet(code);
 	}
 }
 #endif


### PR DESCRIPTION
Improved GD77S channel details summary (long press SK1):
For analog channels announce the CSS settings instead of the assigned digital contact.