### PR TITLE
Fix CC filtering

### DIFF
--- a/firmware/source/hardware/HR-C6000.c
+++ b/firmware/source/hardware/HR-C6000.c
@@ -788,7 +788,7 @@ inline static void HRC6000SysInterruptHandler(void)
 	if (!trxTransmissionEnabled) // ignore the LC data when we are transmitting
 	{
 		//if ((!ccHold) && (nonVolatileSettings.dmrDestinationFilter < DMR_CCTS_FILTER_CC))
-		if ((!ccHold) && (nonVolatileSettings.dmrCcTsFilter == DMR_CCTS_FILTER_NONE || nonVolatileSettings.dmrCcTsFilter == DMR_CCTS_FILTER_TS))
+		if ((!ccHold) && (nonVolatileSettings.dmrCcTsFilter == DMR_CCTS_FILTER_CC || nonVolatileSettings.dmrCcTsFilter == DMR_CCTS_FILTER_TS))
 		{
 			if(rxColorCode == lastRxColorCode)
 			{


### PR DESCRIPTION
When Quick menu option Filter CC is OFF, my Bao 1801 radio can't receive correctly answers from Brandmeister robot, but all others ok. I found that problem in this line.