### PR TITLE
"drivers/fsl_port.h not found" when build without MCUXpresso

### DIFF
--- a/firmware/source/interfaces/spi.c
+++ b/firmware/source/interfaces/spi.c
@@ -17,7 +17,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "drivers/fsl_port.h"
+#include "fsl_port.h"
 #include "interfaces/hr-c6000_spi.h"
 
 const uint32_t SPI_0_BAUDRATE = 3000000U;


### PR DESCRIPTION
Recently modified interfaces/spi.c includes "drivers/fsl_port.h", not "fsl_port.h".
This makes file not found error when building with firmware/Makefile on Arch Linux.

interfaces/i2c.c includes "fsl_port.h" so I think spi.c should not specify drivers/ directory.
